### PR TITLE
Update implementation of classification module + check before quantile calculation

### DIFF
--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -145,8 +145,8 @@ class MapieClassifier (BaseEstimator, ClassifierMixin):  # type: ignore
     ) -> None:
         self.estimator = estimator
         self.method = method
-        self.random_state = random_state
         self.cv = cv
+        self.random_state = random_state
         self.n_jobs = n_jobs
         self.verbose = verbose
 
@@ -261,7 +261,10 @@ class MapieClassifier (BaseEstimator, ClassifierMixin):  # type: ignore
         ValueError
             If the cross-validator is not valid.
         """
-        if (cv is None or cv == "prefit"):
+        if cv is None:
+            cv = 0.2
+            return cv
+        if cv == "prefit":
             return cv
         if isinstance(cv, float) and cv > 0.0 and cv < 1.0:
             return cv
@@ -375,14 +378,9 @@ class MapieClassifier (BaseEstimator, ClassifierMixin):  # type: ignore
             X_val, y_val = X, y
         else:
             indices = np.arange(X.shape[0])
-            if isinstance(cv, float):
-                train_index, val_index = train_test_split(
-                    indices, test_size=cv, random_state=self.random_state
-                )
-            else:
-                train_index, val_index = train_test_split(
-                    indices, test_size=0.2, random_state=self.random_state
-                )
+            train_index, val_index = train_test_split(
+                indices, test_size=cv, random_state=self.random_state
+            )
             self.single_estimator_, y_pred, X_val, y_val = (
                 self._fit_and_predict_oof_model(
                     clone(estimator), X, y, train_index,

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -170,7 +170,7 @@ def test_valid_prefit_estimator(estimator: ClassifierMixin) -> None:
         [
             "single_estimator_",
             "n_features_in_",
-            "n_samples_in_val_"
+            "n_samples_val_"
         ]
     )
     assert mapie.n_features_in_ == 10
@@ -259,16 +259,16 @@ def test_valid_verbose(verbose: Any) -> None:
 
 
 @pytest.mark.parametrize(
-    "cv", [-3.14, -2, 0, 1, "cv", DummyClassifier(), [1, 2]]
+    "cv", [-3.14, 1.5, -2, 0, 1, "cv", DummyClassifier(), [1, 2]]
 )
 def test_invalid_cv(cv: Any) -> None:
     """Test that invalid cv raise errors."""
     mapie = MapieClassifier(cv=cv)
-    with pytest.raises(ValueError, match=r".*Invalid cv.*"):
+    with pytest.raises(ValueError, match=r".*Invalid cv argument.*"):
         mapie.fit(X_lr, y_lr)
 
 
-@pytest.mark.parametrize("cv", [None, "prefit"])
+@pytest.mark.parametrize("cv", [None, "prefit", 0.2, 0.3])
 def test_valid_cv(cv: Any) -> None:
     """Test that valid cv raise no errors."""
     if cv == "prefit":
@@ -299,7 +299,7 @@ def test_valid_method(method: str) -> None:
         [
             "single_estimator_",
             "n_features_in_",
-            "n_samples_in_val_",
+            "n_samples_val_",
             "scores_"
         ]
     )

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -38,11 +38,13 @@ class DumbClassifier:
 METHODS = ["score"]
 
 Params = TypedDict(
-    "Params", {"method": str, "cv": Optional[str]}
+    "Params", {
+        "method": str, "cv": Optional[str], "random_state": Optional[int]
+    }
 )
 
 STRATEGIES = {
-    "score": Params(method="score", cv=None)
+    "score": Params(method="score", cv=None, random_state=1)
 }
 
 X_toy = np.arange(9).reshape(-1, 1)
@@ -204,12 +206,8 @@ def test_results_single_and_multi_jobs(strategy: str) -> None:
     Test that MapieRegressor gives equal predictions
     regardless of number of parallel jobs.
     """
-    mapie_single = MapieClassifier(
-        random_state=1, n_jobs=1, **STRATEGIES[strategy]
-    )
-    mapie_multi = MapieClassifier(
-        random_state=1, n_jobs=-1, **STRATEGIES[strategy]
-    )
+    mapie_single = MapieClassifier(n_jobs=1, **STRATEGIES[strategy])
+    mapie_multi = MapieClassifier(n_jobs=-1, **STRATEGIES[strategy])
     mapie_single.fit(X_lr, y_lr)
     mapie_multi.fit(X_lr, y_lr)
     y_pred_single = mapie_single.predict(X_lr)
@@ -224,8 +222,8 @@ def test_results_with_constant_sample_weights(strategy: str) -> None:
     or constant with different values.
     """
     n_samples = 500
-    mapie0 = MapieClassifier(random_state=1, **STRATEGIES[strategy])
-    mapie1 = MapieClassifier(random_state=1, **STRATEGIES[strategy])
+    mapie0 = MapieClassifier(**STRATEGIES[strategy])
+    mapie1 = MapieClassifier(**STRATEGIES[strategy])
     mapie0.fit(X_lr, y_lr, sample_weight=None)
     mapie1.fit(X_lr, y_lr, sample_weight=np.ones(shape=n_samples))
     y_pred0 = mapie0.predict(X_lr)
@@ -243,7 +241,7 @@ def test_invalid_n_jobs(n_jobs: Any) -> None:
 
 @pytest.mark.parametrize("random_state", ["dummy", 1.5, [1, 2]])
 def test_invalid_random_state(random_state: Any) -> None:
-    """Test that invalid n_jobs raise errors."""
+    """Test that invalid random_state raise errors."""
     mapie = MapieClassifier(random_state=random_state)
     with pytest.raises(ValueError, match=r".*Invalid random_state argument.*"):
         mapie.fit(X_lr, y_lr)

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -83,6 +83,7 @@ def test_default_parameters() -> None:
     assert mapie.estimator is None
     assert mapie.method == "score"
     assert mapie.cv is None
+    assert mapie.random_state is None
     assert mapie.verbose == 0
     assert mapie.n_jobs is None
 
@@ -203,8 +204,12 @@ def test_results_single_and_multi_jobs(strategy: str) -> None:
     Test that MapieRegressor gives equal predictions
     regardless of number of parallel jobs.
     """
-    mapie_single = MapieClassifier(n_jobs=1, **STRATEGIES[strategy])
-    mapie_multi = MapieClassifier(n_jobs=-1, **STRATEGIES[strategy])
+    mapie_single = MapieClassifier(
+        random_state=1, n_jobs=1, **STRATEGIES[strategy]
+    )
+    mapie_multi = MapieClassifier(
+        random_state=1, n_jobs=-1, **STRATEGIES[strategy]
+    )
     mapie_single.fit(X_lr, y_lr)
     mapie_multi.fit(X_lr, y_lr)
     y_pred_single = mapie_single.predict(X_lr)
@@ -219,8 +224,8 @@ def test_results_with_constant_sample_weights(strategy: str) -> None:
     or constant with different values.
     """
     n_samples = 500
-    mapie0 = MapieClassifier(**STRATEGIES[strategy])
-    mapie1 = MapieClassifier(**STRATEGIES[strategy])
+    mapie0 = MapieClassifier(random_state=1, **STRATEGIES[strategy])
+    mapie1 = MapieClassifier(random_state=1, **STRATEGIES[strategy])
     mapie0.fit(X_lr, y_lr, sample_weight=None)
     mapie1.fit(X_lr, y_lr, sample_weight=np.ones(shape=n_samples))
     y_pred0 = mapie0.predict(X_lr)
@@ -233,6 +238,14 @@ def test_invalid_n_jobs(n_jobs: Any) -> None:
     """Test that invalid n_jobs raise errors."""
     mapie = MapieClassifier(n_jobs=n_jobs)
     with pytest.raises(ValueError, match=r".*Invalid n_jobs argument.*"):
+        mapie.fit(X_lr, y_lr)
+
+
+@pytest.mark.parametrize("random_state", ["dummy", 1.5, [1, 2]])
+def test_invalid_random_state(random_state: Any) -> None:
+    """Test that invalid n_jobs raise errors."""
+    mapie = MapieClassifier(random_state=random_state)
+    with pytest.raises(ValueError, match=r".*Invalid random_state argument.*"):
         mapie.fit(X_lr, y_lr)
 
 

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -170,7 +170,7 @@ def test_valid_prefit_estimator(estimator: ClassifierMixin) -> None:
         [
             "single_estimator_",
             "n_features_in_",
-            "n_samples_in_train_"
+            "n_samples_in_val_"
         ]
     )
     assert mapie.n_features_in_ == 10
@@ -299,7 +299,7 @@ def test_valid_method(method: str) -> None:
         [
             "single_estimator_",
             "n_features_in_",
-            "n_samples_in_train_",
+            "n_samples_in_val_",
             "scores_"
         ]
     )
@@ -423,7 +423,7 @@ def test_toy_dataset_predictions() -> None:
     """Test prediction sets estimated by MapieClassifier on a toy dataset"""
     clf = GaussianNB().fit(X_toy, y_toy)
     mapie = MapieClassifier(estimator=clf, cv="prefit").fit(X_toy, y_toy)
-    _, y_pi_mapie = mapie.predict(X_toy, alpha=0.1)
+    _, y_pi_mapie = mapie.predict(X_toy, alpha=0.2)
     np.testing.assert_allclose(
         classification_coverage_score(y_toy, y_pi_mapie), 7/9
     )

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -143,7 +143,7 @@ def test_valid_shape_no_n_features_in(
         np.array([0.05, 0.95])
     ]
 )
-def test_valid_calcul_of_quantile(alpha: Any) -> None:
+def test_valid_calculation_of_quantile(alpha: Any) -> None:
     """Test that valid alphas raise no errors."""
     n = 30
     check_alpha_and_n_samples(alpha, n)
@@ -153,13 +153,13 @@ def test_valid_calcul_of_quantile(alpha: Any) -> None:
     "alpha",
     [
         np.linspace(0.05, 0.07),
-        [0.05, 0.07],
-        (0.05, 0.07),
-        np.array([0.05, 0.07])
+        [0.05, 0.07, 0.9],
+        (0.05, 0.07, 0.9),
+        np.array([0.05, 0.07, 0.9])
     ]
 )
-def test_invalid_calcul_of_quantile(alpha: Any) -> None:
-    """Test that alpha with 1/alpha < number of samples  raise errors."""
+def test_invalid_calculation_of_quantile(alpha: Any) -> None:
+    """Test that alpha with 1/alpha > number of samples  raise errors."""
     n = 10
     with pytest.raises(
         ValueError, match=r".*Number of samples of the score is too low*"

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -9,7 +9,7 @@ from sklearn.datasets import make_regression, make_classification
 
 from mapie.utils import check_null_weight, fit_estimator
 from mapie.utils import check_alpha, check_n_features_in
-
+from mapie.utils import check_calcul_of_quantile
 
 X_toy = np.array([0, 1, 2, 3, 4, 5]).reshape(-1, 1)
 y_toy = np.array([5, 7, 9, 11, 13, 15])
@@ -132,3 +132,36 @@ def test_valid_shape_no_n_features_in(
         X=X_reg, cv="prefit", estimator=estimator
     )
     assert n_features_in == 10
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        np.linspace(0.05, 0.95, 5),
+        [0.05, 0.95],
+        (0.05, 0.95),
+        np.array([0.05, 0.95])
+    ]
+)
+def test_valid_calcul_of_quantile(alpha: Any) -> None:
+    """Test that valid alphas raise no errors."""
+    n = 30
+    check_calcul_of_quantile(alpha, n)
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [
+        np.linspace(0.05, 0.07),
+        [0.05, 0.07],
+        (0.05, 0.07),
+        np.array([0.05, 0.07])
+    ]
+)
+def test_invalid_calcul_of_quantile(alpha: Any) -> None:
+    """Test that alpha with 1/alpha < number of samples  raise errors."""
+    n = 10
+    with pytest.raises(
+        ValueError, match=r".*Number of samples of the score too low*"
+    ):
+        check_calcul_of_quantile(alpha, n)

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -9,7 +9,7 @@ from sklearn.datasets import make_regression, make_classification
 
 from mapie.utils import check_null_weight, fit_estimator
 from mapie.utils import check_alpha, check_n_features_in
-from mapie.utils import check_calcul_of_quantile
+from mapie.utils import check_alpha_and_n_samples
 
 X_toy = np.array([0, 1, 2, 3, 4, 5]).reshape(-1, 1)
 y_toy = np.array([5, 7, 9, 11, 13, 15])
@@ -146,7 +146,7 @@ def test_valid_shape_no_n_features_in(
 def test_valid_calcul_of_quantile(alpha: Any) -> None:
     """Test that valid alphas raise no errors."""
     n = 30
-    check_calcul_of_quantile(alpha, n)
+    check_alpha_and_n_samples(alpha, n)
 
 
 @pytest.mark.parametrize(
@@ -162,6 +162,6 @@ def test_invalid_calcul_of_quantile(alpha: Any) -> None:
     """Test that alpha with 1/alpha < number of samples  raise errors."""
     n = 10
     with pytest.raises(
-        ValueError, match=r".*Number of samples of the score too low*"
+        ValueError, match=r".*Number of samples of the score is too low*"
     ):
-        check_calcul_of_quantile(alpha, n)
+        check_alpha_and_n_samples(alpha, n)

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -166,7 +166,7 @@ def check_alpha(
 
 def check_n_features_in(
     X: ArrayLike,
-    cv: Optional[str] = None,
+    cv: Union[float, str, None] = None,
     estimator: Optional[Union[RegressorMixin, ClassifierMixin]] = None
 ) -> int:
     """
@@ -204,13 +204,14 @@ def check_n_features_in(
     return n_features_in
 
 
-def check_calcul_of_quantile(alphas: np.ndarray, n: int) -> None:
+def check_alpha_and_n_samples(alphas: Iterable[float], n: int) -> None:
     """
-    Check if the quantile is calculable
+    Check if the quantile can be computed based
+    on the number of samples and the alpha value.
 
     Parameters
     ----------
-    alphas : Optional[np.ndarray]
+    alphas : Iterable[float]
         np.ndarray of floats .
     n : int
         number of samples.
@@ -219,11 +220,11 @@ def check_calcul_of_quantile(alphas: np.ndarray, n: int) -> None:
     ------
     ValueError
         If the number of samples of the score too low,
-        1 / alpha must be less than the number of samples.
+        1 / alpha must be lower than the number of samples.
     """
     for alpha in alphas:
         if n < 1/alpha:
             raise ValueError(
-                    "Number of samples of the score too low,"
-                    " 1 / alpha must be less than the number of samples."
+                    "Number of samples of the score is too low,"
+                    " 1 / alpha must be lower than the number of samples."
                 )

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -166,7 +166,7 @@ def check_alpha(
 
 def check_n_features_in(
     X: ArrayLike,
-    cv: Union[float, str, None] = None,
+    cv: Optional[Union[float, str]] = None,
     estimator: Optional[Union[RegressorMixin, ClassifierMixin]] = None
 ) -> int:
     """
@@ -212,18 +212,18 @@ def check_alpha_and_n_samples(alphas: Iterable[float], n: int) -> None:
     Parameters
     ----------
     alphas : Iterable[float]
-        np.ndarray of floats .
+        np.ndarray of floats.
     n : int
         number of samples.
 
     Raises
     ------
     ValueError
-        If the number of samples of the score too low,
+        If the number of samples of the score is too low,
         1 / alpha must be lower than the number of samples.
     """
     for alpha in alphas:
-        if n < 1/alpha:
+        if n < 1/alpha or n < 1/(1-alpha):
             raise ValueError(
                     "Number of samples of the score is too low,"
                     " 1 / alpha must be lower than the number of samples."

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -202,3 +202,28 @@ def check_n_features_in(
                 "X.shape and estimator.n_features_in_."
             )
     return n_features_in
+
+
+def check_calcul_of_quantile(alphas: np.ndarray, n: int) -> None:
+    """
+    Check if the quantile is calculable
+
+    Parameters
+    ----------
+    alphas : Optional[np.ndarray]
+        np.ndarray of floats .
+    n : int
+        number of samples.
+
+    Raises
+    ------
+    ValueError
+        If the number of samples of the score too low,
+        1 / alpha must be less than the number of samples.
+    """
+    for alpha in alphas:
+        if n < 1/alpha:
+            raise ValueError(
+                    "Number of samples of the score too low,"
+                    " 1 / alpha must be less than the number of samples."
+                )

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -212,7 +212,7 @@ def check_alpha_and_n_samples(alphas: Iterable[float], n: int) -> None:
     Parameters
     ----------
     alphas : Iterable[float]
-        np.ndarray of floats.
+        Iterable of floats.
     n : int
         number of samples.
 
@@ -220,11 +220,12 @@ def check_alpha_and_n_samples(alphas: Iterable[float], n: int) -> None:
     ------
     ValueError
         If the number of samples of the score is too low,
-        1 / alpha must be lower than the number of samples.
+        1/alpha (or 1/(1-alpha)) must be lower than the number of samples.
     """
     for alpha in alphas:
         if n < 1/alpha or n < 1/(1-alpha):
             raise ValueError(
                     "Number of samples of the score is too low,"
-                    " 1 / alpha must be lower than the number of samples."
+                    " 1/alpha (or 1/(1-alpha)) must be lower"
+                    "than the number of samples."
                 )


### PR DESCRIPTION
# Description

Grouping of score calculations in the fit
Changing attribute name of n_samples_in_train_ by n_samples_in_val_
Adding check if 1/alpha < number of samples of scores before quantile calculation

Fixes #(issue)


Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tests added in test_utils.py

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `flake8 . --exclude=doc`
- [x] Typing passes successfully : `mypy mapie examples --strict`
- [x] Unit tests pass successfully : `pytest -vs --doctest-modules mapie`
- [x] Coverage is 100% : `pytest -vs --doctest-modules --cov-branch --cov=mapie --pyargs mapie`
- [x] Documentation builds successfully : `cd doc; make clean; make html`