### PR TITLE
Replace LabelBinarizer by label_binarize

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ and two standard deviations from the mean.
 
 .. code:: python
 
-    from mapie.estimators import MapieRegressor
+    from mapie.regression import MapieRegressor
     alpha = [0.05, 0.32]
     mapie = MapieRegressor(regressor)
     mapie.fit(X, y)

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -355,7 +355,6 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
             ValueError
             If the sum of the scores is not equal to one.
         """
-        print((1-np.sum(y_pred_proba, axis=1)).max())
         np.testing.assert_allclose(
             np.sum(y_pred_proba, axis=1),
             1,

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -9,7 +9,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.utils import check_X_y, check_array, check_random_state
 from sklearn.utils.multiclass import type_of_target
 from sklearn.utils.validation import check_is_fitted
-from sklearn.preprocessing import LabelBinarizer
+from sklearn.preprocessing import label_binarize
 
 from ._typing import ArrayLike
 from ._machine_precision import EPSILON
@@ -235,10 +235,14 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
                     "Default LogisticRegression's input can't be an image."
                     "Please provide a proper model."
                 )
+        if isinstance(estimator, Pipeline):
+            est = estimator[-1]
+        else:
+            est = estimator
         if (
-            not hasattr(estimator, "fit")
-            and not hasattr(estimator, "predict")
-            and not hasattr(estimator, "predict_proba")
+            not hasattr(est, "fit")
+            and not hasattr(est, "predict")
+            and not hasattr(est, "predict_proba")
         ):
             raise ValueError(
                 "Invalid estimator. "
@@ -246,10 +250,13 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
                 "predict, and predict_proba methods."
             )
         if self.cv == "prefit":
-            if isinstance(self.estimator, Pipeline):
-                check_is_fitted(self.estimator[-1])
-            else:
-                check_is_fitted(self.estimator)
+            check_is_fitted(est)
+            if not hasattr(est, "classes_"):
+                raise AttributeError(
+                    "Invalid classifier. "
+                    "Fitted classifier does not contain "
+                    "'classes_' attribute."
+                )
         return estimator
 
     def _check_cv(
@@ -551,15 +558,17 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
                 1 - y_pred_proba, y.reshape(-1, 1), axis=1
             )
         elif self.method == "cumulated_score":
-            encoder = LabelBinarizer().fit(y)
-            y_true = encoder.transform(y)
+            # encoder = LabelBinarizer().fit(y)
+            # y_true = encoder.transform(y)
+            y_true = label_binarize(y=y, classes=estimator.classes_)
             index_sorted = np.fliplr(np.argsort(y_pred_proba, axis=1))
             y_pred_proba_sorted = np.take_along_axis(
                 y_pred_proba, index_sorted, axis=1
             )
             y_true_sorted = np.take_along_axis(y_true, index_sorted, axis=1)
             y_pred_proba_sorted_cumsum = np.cumsum(y_pred_proba_sorted, axis=1)
-            cutoff = encoder.inverse_transform(y_true_sorted)
+            # cutoff = encoder.inverse_transform(y_true_sorted)
+            cutoff = np.argmax(y_true_sorted, axis=1)
             self.conformity_scores_ = np.take_along_axis(
                 y_pred_proba_sorted_cumsum, cutoff.reshape(-1, 1), axis=1
             )

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -558,8 +558,6 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
                 1 - y_pred_proba, y.reshape(-1, 1), axis=1
             )
         elif self.method == "cumulated_score":
-            # encoder = LabelBinarizer().fit(y)
-            # y_true = encoder.transform(y)
             y_true = label_binarize(y=y, classes=estimator.classes_)
             index_sorted = np.fliplr(np.argsort(y_pred_proba, axis=1))
             y_pred_proba_sorted = np.take_along_axis(
@@ -567,7 +565,6 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
             )
             y_true_sorted = np.take_along_axis(y_true, index_sorted, axis=1)
             y_pred_proba_sorted_cumsum = np.cumsum(y_pred_proba_sorted, axis=1)
-            # cutoff = encoder.inverse_transform(y_true_sorted)
             cutoff = np.argmax(y_true_sorted, axis=1)
             self.conformity_scores_ = np.take_along_axis(
                 y_pred_proba_sorted_cumsum, cutoff.reshape(-1, 1), axis=1

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -355,10 +355,12 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
             ValueError
             If the sum of the scores is not equal to one.
         """
+        print((1-np.sum(y_pred_proba, axis=1)).max())
         np.testing.assert_allclose(
             np.sum(y_pred_proba, axis=1),
             1,
-            err_msg="The sum of the scores is not equal to one."
+            err_msg="The sum of the scores is not equal to one.",
+            rtol=1e-5
         )
         return y_pred_proba
 

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -822,7 +822,6 @@ def test_sum_proba_to_one_fit(y_pred_proba: ArrayLike) -> None:
     Test if when the output probabilities of the model do not
     sum to one, return an error in the fit method.
     """
-    print(y_pred_proba)
     wrong_model = WrongOutputModel(y_pred_proba)
     wrong_model.fit(X_toy, y_toy)
     mapie = MapieClassifier(wrong_model)

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -250,6 +250,7 @@ class CumulatedScoreClassifier:
         self.y_pred_sets = np.array(
             [[True, True, False], [False, True, True], [True, True, False]]
         )
+        self.classes_ = self.y_calib
 
     def fit(self, X: np.ndarray, y: np.ndarray) -> CumulatedScoreClassifier:
         self.fitted_ = True
@@ -280,6 +281,7 @@ class ImageClassifier:
         self.y_pred_sets = np.array(
             [[True, True, False], [False, True, True], [True, True, False]]
         )
+        self.classes_ = self.y_calib
 
     def fit(self, X: np.ndarray, y: np.ndarray) -> ImageClassifier:
         self.fitted_ = True
@@ -304,6 +306,7 @@ class WrongOutputModel():
     def __init__(self, proba_out: ArrayLike):
         self.trained_ = True
         self.proba_out = proba_out
+        self.classes_ = proba_out.shape[1]
 
     def fit(self, *args: Any) -> None:
         pass
@@ -819,6 +822,7 @@ def test_sum_proba_to_one_fit(y_pred_proba: ArrayLike) -> None:
     Test if when the output probabilities of the model do not
     sum to one, return an error in the fit method.
     """
+    print(y_pred_proba)
     wrong_model = WrongOutputModel(y_pred_proba)
     wrong_model.fit(X_toy, y_toy)
     mapie = MapieClassifier(wrong_model)
@@ -847,3 +851,24 @@ def test_sum_proba_to_one_predict(
         AssertionError, match=r".*The sum of the.*"
     ):
         mapie.predict(X_toy, alpha=alpha)
+
+
+@pytest.mark.parametrize(
+    "estimator", [LogisticRegression(), make_pipeline(LogisticRegression())]
+)
+def test_classifier_without_classes_attribute(
+    estimator: ClassifierMixin
+) -> None:
+    """
+    Test that prefitted classifier without 'classes_ 'attribute raises error.
+    """
+    estimator.fit(X_toy, y_toy)
+    if isinstance(estimator, Pipeline):
+        delattr(estimator[-1], "classes_")
+    else:
+        delattr(estimator, "classes_")
+    mapie = MapieClassifier(estimator=estimator, cv="prefit")
+    with pytest.raises(
+        AttributeError, match=r".*does not contain 'classes_'.*"
+    ):
+        mapie.fit(X_toy, y_toy)


### PR DESCRIPTION
# Description

Replace `LabelBinarizer` by `label_binarize` in the "cumulated_score" method to explicitely include the classes predicted by the base classifier. 

For MapieClassifier, when cv is set to "prefit", the calibration set does not necessarily contain all the classes of the original dataset. Therefore, the base classifier could have been trained on a training set containing a larger number of classes. This discrepancy triggers a bug for the cumulated_score in the fit method.

Fixes #116 
Fixes #108 

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All existing unit tests + New test checking that the base prefitted classifier has the `classes_` attribute.

# Checklist:

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`