### PR TITLE
Fix typing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.3.3 (2022-XX-XX)
+------------------
+* Relax and fix typing
+
 0.3.2 (2022-03-11)
 ------------------
 * Refactorize unit tests

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: tests doc build
+
 lint:	
 	flake8 . --exclude=doc
 
 type-check:
-	mypy mapie examples --strict --allow-untyped-calls
+	mypy mapie examples
 
 tests:
 	pytest -vs --doctest-modules mapie

--- a/environment.dev.yml
+++ b/environment.dev.yml
@@ -5,6 +5,8 @@ channels:
 dependencies:
     - bump2version=1.0.1
     - flake8=4.0.1
+    - ipykernel=6.9.0
+    - jupyter=1.0.0
     - mypy=0.910
     - numpydoc=1.1.0
     - pandas=1.3.5

--- a/environment.dev.yml
+++ b/environment.dev.yml
@@ -7,7 +7,7 @@ dependencies:
     - flake8=4.0.1
     - ipykernel=6.9.0
     - jupyter=1.0.0
-    - mypy=0.910
+    - mypy=0.941
     - numpydoc=1.1.0
     - pandas=1.3.5
     - pytest=6.2.5

--- a/examples/classification/1-quickstart/plot_comp_methods_on_2d_dataset.py
+++ b/examples/classification/1-quickstart/plot_comp_methods_on_2d_dataset.py
@@ -57,7 +57,7 @@ from mapie.metrics import (
     classification_coverage_score,
     classification_mean_width_score
 )
-from mapie._typing import ArrayLike, NDArray
+from mapie._typing import NDArray
 
 
 centers = [(0, 3.5), (-2, 0), (2, 0)]

--- a/examples/classification/1-quickstart/plot_comp_methods_on_2d_dataset.py
+++ b/examples/classification/1-quickstart/plot_comp_methods_on_2d_dataset.py
@@ -57,7 +57,7 @@ from mapie.metrics import (
     classification_coverage_score,
     classification_mean_width_score
 )
-from mapie._typing import ArrayLike
+from mapie._typing import ArrayLike, NDArray
 
 
 centers = [(0, 3.5), (-2, 0), (2, 0)]
@@ -144,8 +144,8 @@ for method in methods:
 
 def plot_scores(
     alphas: List[float],
-    scores: ArrayLike,
-    quantiles: ArrayLike,
+    scores: NDArray,
+    quantiles: NDArray,
     method: str,
     ax: plt.Axes,
 ) -> None:
@@ -183,7 +183,7 @@ plt.show()
 
 
 def plot_results(
-    alphas: List[float], y_pred_mapie: ArrayLike, y_ps_mapie: ArrayLike
+    alphas: List[float], y_pred_mapie: NDArray, y_ps_mapie: NDArray
 ) -> None:
     tab10 = plt.cm.get_cmap("Purples", 4)
     colors = {

--- a/examples/classification/2-advanced-analysis/plot_crossconformal.py
+++ b/examples/classification/2-advanced-analysis/plot_crossconformal.py
@@ -26,7 +26,7 @@ the ``cv="prefit"`` option of
 """
 
 
-from typing import Dict, Any, Optional, Union
+from typing import Dict, Any, Optional, Union, List
 from typing_extensions import TypedDict
 import numpy as np
 import pandas as pd
@@ -35,9 +35,10 @@ from sklearn.naive_bayes import GaussianNB
 from sklearn.model_selection import KFold
 from mapie.classification import MapieClassifier
 from mapie.metrics import (
-    classification_coverage_score, classification_mean_width_score
+    classification_coverage_score,
+    classification_mean_width_score
 )
-from mapie._typing import ArrayLike
+from mapie._typing import NDArray
 
 
 ##############################################################################
@@ -156,9 +157,9 @@ plt.show()
 
 def plot_results(
     mapies: Dict[int, Any],
-    X_test: ArrayLike,
-    X_test2: ArrayLike,
-    y_test2: ArrayLike,
+    X_test: NDArray,
+    X_test2: NDArray,
+    y_test2: NDArray,
     alpha: float,
     method: str
 ) -> None:
@@ -223,9 +224,9 @@ plot_results(
 
 
 def plot_coverage_width(
-    alpha: float,
-    coverages: ArrayLike,
-    widths: ArrayLike,
+    alpha: NDArray,
+    coverages: List[NDArray],
+    widths: List[NDArray],
     method: str,
     comp: str = "split"
 ) -> None:
@@ -355,12 +356,12 @@ STRATEGIES = {
     )
 }
 
-y_preds, y_ps = {}, {}
+y_ps = {}
 for strategy, params in STRATEGIES.items():
     args_init, args_predict = STRATEGIES[strategy]
     mapie_clf = MapieClassifier(**args_init)
     mapie_clf.fit(X_train, y_train)
-    y_preds[strategy], y_ps[strategy] = mapie_clf.predict(
+    _, y_ps[strategy] = mapie_clf.predict(
         X_test_distrib,
         alpha=alpha,
         **args_predict

--- a/examples/classification/2-advanced-analysis/plot_digits_classification.py
+++ b/examples/classification/2-advanced-analysis/plot_digits_classification.py
@@ -22,7 +22,7 @@ from mapie.metrics import (
     classification_coverage_score,
     classification_mean_width_score
 )
-from mapie._typing import ArrayLike
+from mapie._typing import NDArray
 
 
 ##############################################################################
@@ -99,7 +99,7 @@ for ax, image, label in zip_imgs:
 #   in the calibration and test subsets.
 
 def get_datasets(dataset: Any) -> Tuple[
-    ArrayLike, ArrayLike, ArrayLike, ArrayLike, ArrayLike, ArrayLike
+    NDArray, NDArray, NDArray, NDArray, NDArray, NDArray
 ]:
     n_samples = len(digits.images)
     data = dataset.images.reshape((n_samples, -1))

--- a/examples/regression/1-quickstart/plot_homoscedastic_1d_data.py
+++ b/examples/regression/1-quickstart/plot_homoscedastic_1d_data.py
@@ -18,17 +18,17 @@ from sklearn.preprocessing import PolynomialFeatures
 from matplotlib import pyplot as plt
 
 from mapie.regression import MapieRegressor
-from mapie._typing import ArrayLike
+from mapie._typing import NDArray
 
 
-def f(x: ArrayLike) -> ArrayLike:
+def f(x: NDArray) -> NDArray:
     """Polynomial function used to generate one-dimensional data"""
     return np.array(5 * x + 5 * x ** 4 - 9 * x ** 2)
 
 
 def get_homoscedastic_data(
     n_train: int = 200, n_true: int = 200, sigma: float = 0.1
-) -> Tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike, float]:
+) -> Tuple[NDArray, NDArray, NDArray, NDArray, float]:
     """
     Generate one-dimensional data from a given function,
     number of training and test samples and a given standard
@@ -46,7 +46,7 @@ def get_homoscedastic_data(
 
     Returns
     -------
-    Tuple[Any, Any, ArrayLike, Any, float]
+    Tuple[NDArray, NDArray, NDArray, NDArray, float]
         Generated training and test data.
         [0]: X_train
         [1]: y_train
@@ -65,14 +65,14 @@ def get_homoscedastic_data(
 
 
 def plot_1d_data(
-    X_train: ArrayLike,
-    y_train: ArrayLike,
-    X_test: ArrayLike,
-    y_test: ArrayLike,
+    X_train: NDArray,
+    y_train: NDArray,
+    X_test: NDArray,
+    y_test: NDArray,
     y_test_sigma: float,
-    y_pred: ArrayLike,
-    y_pred_low: ArrayLike,
-    y_pred_up: ArrayLike,
+    y_pred: NDArray,
+    y_pred_low: NDArray,
+    y_pred_up: NDArray,
     ax: plt.Axes,
     title: str,
 ) -> None:
@@ -82,21 +82,21 @@ def plot_1d_data(
 
     Parameters
     ----------
-    X_train : ArrayLike
+    X_train : NDArray
         Training data.
-    y_train : ArrayLike
+    y_train : NDArray
         Training labels.
-    X_test : ArrayLike
+    X_test : NDArray
         Test data.
-    y_test : ArrayLike
+    y_test : NDArray
         True function values on test data.
     y_test_sigma : float
         True standard deviation.
-    y_pred : ArrayLike
+    y_pred : NDArray
         Predictions on test data.
-    y_pred_low : ArrayLike
+    y_pred_low : NDArray
         Predicted lower bounds on test data.
-    y_pred_up : ArrayLike
+    y_pred_up : NDArray
         Predicted upper bounds on test data.
     ax : plt.Axes
         Axis to plot.

--- a/examples/regression/1-quickstart/plot_prefit_nn.py
+++ b/examples/regression/1-quickstart/plot_prefit_nn.py
@@ -19,10 +19,10 @@ from matplotlib import pyplot as plt
 
 from mapie.regression import MapieRegressor
 from mapie.metrics import regression_coverage_score
-from mapie._typing import ArrayLike
+from mapie._typing import NDArray
 
 
-def f(x: ArrayLike) -> ArrayLike:
+def f(x: NDArray) -> NDArray:
     """Polynomial function used to generate one-dimensional data."""
     return np.array(5 * x + 5 * x ** 4 - 9 * x ** 2)
 

--- a/examples/regression/2-advanced-analysis/plot_both_uncertainties.py
+++ b/examples/regression/2-advanced-analysis/plot_both_uncertainties.py
@@ -16,20 +16,20 @@ from sklearn.preprocessing import PolynomialFeatures
 import matplotlib.pyplot as plt
 
 from mapie.regression import MapieRegressor
-from mapie._typing import ArrayLike
+from mapie._typing import ArrayLike, NDArray
 
 F = TypeVar("F", bound=Callable[..., Any])
 
 
 # Functions for generating our dataset
-def x_sinx(x: ArrayLike) -> Any:
+def x_sinx(x: NDArray) -> NDArray:
     """One-dimensional x*sin(x) function."""
     return x * np.sin(x)
 
 
 def get_1d_data_with_normal_distrib(
     funct: F, mu: float, sigma: float, n_samples: int, noise: float
-) -> Tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
+) -> Tuple[NDArray, NDArray, NDArray, NDArray, NDArray]:
     """
     Generate noisy 1D data with normal distribution from given function
     and noise standard deviation.
@@ -49,7 +49,7 @@ def get_1d_data_with_normal_distrib(
 
     Returns
     -------
-    Tuple[Any, Any, ArrayLike, Any, float]
+    Tuple[NDArray, AnNDArrayy, NDArray, NDArray, NDArray]
         Generated training and test data.
         [0]: X_train
         [1]: y_train
@@ -104,14 +104,14 @@ for strategy, params in STRATEGIES.items():
 
 # Visualization
 def plot_1d_data(
-    X_train: ArrayLike,
-    y_train: ArrayLike,
-    X_test: ArrayLike,
-    y_test: ArrayLike,
+    X_train: NDArray,
+    y_train: NDArray,
+    X_test: NDArray,
+    y_test: NDArray,
     y_sigma: float,
-    y_pred: ArrayLike,
-    y_pred_low: ArrayLike,
-    y_pred_up: ArrayLike,
+    y_pred: NDArray,
+    y_pred_low: NDArray,
+    y_pred_up: NDArray,
     ax: plt.Axes,
     title: str,
 ) -> None:

--- a/examples/regression/2-advanced-analysis/plot_both_uncertainties.py
+++ b/examples/regression/2-advanced-analysis/plot_both_uncertainties.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import PolynomialFeatures
 import matplotlib.pyplot as plt
 
 from mapie.regression import MapieRegressor
-from mapie._typing import ArrayLike, NDArray
+from mapie._typing import NDArray
 
 F = TypeVar("F", bound=Callable[..., Any])
 

--- a/examples/regression/3-scientific-articles/plot_barber2020_simulations.py
+++ b/examples/regression/3-scientific-articles/plot_barber2020_simulations.py
@@ -28,7 +28,7 @@ Aaditya Ramdas, and Ryan J. Tibshirani.
 "Predictive inference with the jackknife+."
 Ann. Statist., 49(1):486–507, February 2021.
 """
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 import numpy as np
 from sklearn.linear_model import LinearRegression
@@ -39,15 +39,15 @@ from mapie.metrics import (
     regression_mean_width_score
 )
 from mapie.regression import MapieRegressor
-from mapie._typing import ArrayLike
+from mapie._typing import NDArray
 
 
 def PIs_vs_dimensions(
     strategies: Dict[str, Any],
     alpha: float,
     n_trial: int,
-    dimensions: List[int],
-) -> Dict[str, Dict[int, Dict[str, ArrayLike]]]:
+    dimensions: NDArray,
+) -> Dict[str, Dict[int, Dict[str, NDArray]]]:
     """
     Compute the prediction intervals for a linear regression problem.
     Function adapted from Foygel-Barber et al. (2020).
@@ -82,14 +82,14 @@ def PIs_vs_dimensions(
 
     Returns
     -------
-    Dict[str, Dict[int, Dict[str, ArrayLike]]]
+    Dict[str, Dict[int, Dict[str, NDArray]]]
         Prediction interval widths and coverages for each strategy, trial,
         and dimension value.
     """
     n_train = 100
     n_test = 100
     SNR = 10
-    results: Dict[str, Dict[int, Dict[str, ArrayLike]]] = {
+    results: Dict[str, Dict[int, Dict[str, NDArray]]] = {
         strategy: {
             dimension: {
                 "coverage": np.empty(n_trial),
@@ -132,7 +132,7 @@ def PIs_vs_dimensions(
 
 
 def plot_simulation_results(
-    results: Dict[str, Dict[int, Dict[str, ArrayLike]]], title: str
+    results: Dict[str, Dict[int, Dict[str, NDArray]]], title: str
 ) -> None:
     """
     Show the prediction interval coverages and widths as a function
@@ -141,7 +141,7 @@ def plot_simulation_results(
 
     Parameters
     ----------
-    results : Dict[str, Dict[int, Dict[str, ArrayLike]]]
+    results : Dict[str, Dict[int, Dict[str, NDArray]]]
         Prediction interval widths and coverages for each strategy, trial,
         and dimension value.
     title : str

--- a/examples/regression/3-scientific-articles/plot_kim2020_simulations.py
+++ b/examples/regression/3-scientific-articles/plot_kim2020_simulations.py
@@ -216,7 +216,7 @@ def get_coverage_width(PIs: pd.DataFrame, y: NDArray) -> Tuple[float, float]:
 
 
 def B_random_from_B_fixed(
-    B: int, 
+    B: int,
     train_size: int,
     m: int,
     itrial: int = 0,

--- a/examples/regression/3-scientific-articles/plot_kim2020_simulations.py
+++ b/examples/regression/3-scientific-articles/plot_kim2020_simulations.py
@@ -43,7 +43,7 @@ from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.linear_model import Ridge
 from sklearn.model_selection import train_test_split
 
-from mapie._typing import ArrayLike
+from mapie._typing import ArrayLike, NDArray
 from mapie.metrics import (
     regression_mean_width_score,
     regression_coverage_score,
@@ -52,7 +52,7 @@ from mapie.regression import MapieRegressor
 from mapie.subsample import Subsample
 
 
-def get_X_y() -> Tuple[ArrayLike, ArrayLike]:
+def get_X_y() -> Tuple[NDArray, NDArray]:
     """
     Downloads the ``blog`` dataset from a zip file on the UCI Machine Learning
     website, and returns X and y, which are respectively the explicative
@@ -60,7 +60,7 @@ def get_X_y() -> Tuple[ArrayLike, ArrayLike]:
 
     Returns
     -------
-    Tuple[ArrayLike, ArrayLike] of shapes
+    Tuple[NDArray, NDArray] of shapes
     (n_samples, n_features) and (n_samples,)
         Explicative data and labels
     """
@@ -95,16 +95,16 @@ class Ridge2(RegressorMixin, BaseEstimator):  # type:ignore
         self.ridge_mult = ridge_mult
         self.__name__ = "Ridge2"
 
-    def fit(self, X: ArrayLike, y: Optional[ArrayLike] = None) -> Ridge2:
+    def fit(self, X: NDArray, y: Optional[NDArray] = None) -> Ridge2:
         """
         Fit Ridge2.
 
         Parameters
         ----------
-        X : ArrayLike of shape (n_samples, n_features)
+        X : NDArray of shape (n_samples, n_features)
             Training data.
 
-        y : ArrayLike of shape (n_samples,)
+        y : NDArray of shape (n_samples,)
             Training labels.
 
         Returns
@@ -116,7 +116,7 @@ class Ridge2(RegressorMixin, BaseEstimator):  # type:ignore
         self.ridge2 = Ridge(alpha=alpha).fit(X=X, y=y)
         return self
 
-    def predict(self, X: ArrayLike) -> ArrayLike:
+    def predict(self, X: ArrayLike) -> NDArray:
         """
         Predict target on new samples.
 
@@ -127,7 +127,7 @@ class Ridge2(RegressorMixin, BaseEstimator):  # type:ignore
 
         Returns
         -------
-        np.ndarray of shape (n_samples, )
+        NDArray of shape (n_samples, )
             Predictions on test data
         """
         return self.ridge2.predict(X)
@@ -135,9 +135,9 @@ class Ridge2(RegressorMixin, BaseEstimator):  # type:ignore
 
 def compute_PIs(
     estimator: BaseEstimator,
-    X_train: ArrayLike,
-    y_train: ArrayLike,
-    X_test: ArrayLike,
+    X_train: NDArray,
+    y_train: NDArray,
+    X_test: NDArray,
     method: str,
     cv: Any,
     alpha: float,
@@ -152,11 +152,11 @@ def compute_PIs(
     ----------
     estimator : BaseEstimator
         Base model to fit.
-    X_train : np.ndarray
+    X_train : NDArray
         Features of training set.
-    y_train : np.ndarray
+    y_train : NDArray
         Target of training set.
-    X_test : np.ndarray
+    X_test : NDArray
         Features of testing set.
     method : str
         Method for estimating prediction intervals.
@@ -187,7 +187,7 @@ def compute_PIs(
     return pd.DataFrame(PI, columns=["lower", "upper"])
 
 
-def get_coverage_width(PIs: pd.DataFrame, y: ArrayLike) -> Tuple[float, float]:
+def get_coverage_width(PIs: pd.DataFrame, y: NDArray) -> Tuple[float, float]:
     """
     Computes the mean coverage and width of the predictions intervals of a
     DataFrame given by the ``compute_PIs`` function
@@ -198,7 +198,7 @@ def get_coverage_width(PIs: pd.DataFrame, y: ArrayLike) -> Tuple[float, float]:
         DataFrame returned by `compute_PIs``, with lower and upper bounds of
         the PIs.
 
-    y : ArrayLike
+    y : NDArray
         Targets supposedly covered by the PIs.
 
     Returns
@@ -216,7 +216,11 @@ def get_coverage_width(PIs: pd.DataFrame, y: ArrayLike) -> Tuple[float, float]:
 
 
 def B_random_from_B_fixed(
-    B: int, train_size: int, m: int, itrial: int = 0, random_state: int = 98765
+    B: int, 
+    train_size: int,
+    m: int,
+    itrial: int = 0,
+    random_state: int = 98765
 ) -> int:
     """
     Generates a random number from a binomial distribution.

--- a/examples/regression/3-scientific-articles/plot_kim2020_simulations.py
+++ b/examples/regression/3-scientific-articles/plot_kim2020_simulations.py
@@ -78,7 +78,7 @@ def get_X_y() -> Tuple[NDArray, NDArray]:
     return (X, y)
 
 
-class Ridge2(RegressorMixin, BaseEstimator):  # type:ignore
+class Ridge2(RegressorMixin, BaseEstimator):
     """
     Little variation of Ridge proposed in [1].
     Rectify alpha on the training set svd max value.

--- a/mapie/_typing.py
+++ b/mapie/_typing.py
@@ -1,3 +1,12 @@
-from numpy.typing import ArrayLike, NDArray
+from typing import Union, List
+
+import numpy as np
+
+
+try:
+    from numpy.typing import ArrayLike, NDArray
+except (AttributeError, ModuleNotFoundError):
+    ArrayLike = Union[np.ndarray, List[List[float]]]  # type: ignore
+    NDArray = np.ndarray  # type: ignore
 
 __all__ = ["ArrayLike", "NDArray"]

--- a/mapie/_typing.py
+++ b/mapie/_typing.py
@@ -1,9 +1,3 @@
-import numpy as np
-from typing import Union, List
+from numpy.typing import ArrayLike, NDArray
 
-try:
-    from np.typing import ArrayLike
-except (AttributeError, ModuleNotFoundError):
-    ArrayLike = Union[np.ndarray, List[List[float]]]
-
-__all__ = ["ArrayLike"]
+__all__ = ["ArrayLike", "NDArray"]

--- a/mapie/_typing.py
+++ b/mapie/_typing.py
@@ -1,4 +1,4 @@
-from typing import Union, List
+from typing import Union, List, Any
 
 import numpy as np
 
@@ -6,7 +6,7 @@ import numpy as np
 try:
     from numpy.typing import ArrayLike, NDArray
 except (AttributeError, ModuleNotFoundError):
-    ArrayLike = Union[np.ndarray, List[List[float]]]  # type: ignore
+    ArrayLike = Union[np.ndarray, List[Any]]  # type: ignore
     NDArray = np.ndarray  # type: ignore
 
 __all__ = ["ArrayLike", "NDArray"]

--- a/mapie/aggregation_functions.py
+++ b/mapie/aggregation_functions.py
@@ -2,14 +2,14 @@ from typing import Callable, Optional
 
 import numpy as np
 
-from ._typing import ArrayLike
+from ._typing import NDArray
 
 
 def phi1D(
-    x: ArrayLike,
-    B: ArrayLike,
-    fun: Callable[[ArrayLike], ArrayLike],
-) -> ArrayLike:
+    x: NDArray,
+    B: NDArray,
+    fun: Callable[[NDArray], NDArray],
+) -> NDArray:
     """
     The function phi1D is called by phi2D.
     It aims at applying a function ``fun`` after multiplying each row
@@ -17,16 +17,16 @@ def phi1D(
 
     Parameters
     ----------
-    x : ArrayLike of shape (n, )
+    x : NDArray of shape (n, )
         1D vector.
-    B : ArrayLike of shape (k, n)
+    B : NDArray of shape (k, n)
         2D vector whose number of columns is the number of rows of x.
     fun : function
-        Vectorized function applying to Arraylike.
+        Vectorized function applying to NDArray.
 
     Returns
     -------
-    ArrayLike
+    NDArray
         The function fun is applied to the product of ``x`` and ``B``.
         Typically, ``fun`` is a numpy function, ignoring nan,
         with argument ``axis=1``.
@@ -46,25 +46,25 @@ def phi1D(
 
 
 def phi2D(
-    A: ArrayLike,
-    B: ArrayLike,
-    fun: Callable[[ArrayLike], ArrayLike],
-) -> ArrayLike:
+    A: NDArray,
+    B: NDArray,
+    fun: Callable[[NDArray], NDArray],
+) -> NDArray:
     """
     The function phi2D is a loop applying phi1D on each row of A.
 
     Parameters
     ----------
-    A : ArrayLike of shape (n_rowsA, n_columns)
-    B : ArrayLike of shape (n_rowsB, n_columns)
+    A : NDArray of shape (n_rowsA, n_columns)
+    B : NDArray of shape (n_rowsB, n_columns)
         A and B must have the same number of columns.
 
     fun : function
-        Vectorized function applying to Arraylike, and that should ignore nan.
+        Vectorized function applying to NDArray, and that should ignore nan.
 
     Returns
     -------
-    ArrayLike of shape (n_rowsA, n_rowsB)
+    NDArray of shape (n_rowsA, n_rowsB)
         Applies phi1D(x, B, fun) to each row x of A.
 
     Examples
@@ -81,19 +81,19 @@ def phi2D(
     return np.apply_along_axis(phi1D, axis=1, arr=A, B=B, fun=fun)
 
 
-def aggregate_all(agg_function: Optional[str], X: ArrayLike) -> ArrayLike:
+def aggregate_all(agg_function: Optional[str], X: NDArray) -> NDArray:
     """
     Applies np.nanmean(, axis=1) or np.nanmedian(, axis=1) according
     to the string ``agg_function``.
 
     Parameters
     -----------
-    X : ArrayLike of shape (n, p)
+    X : NDArray of shape (n, p)
         Array of floats and nans
 
     Returns
     --------
-    ArrayLike of shape (n, 1):
+    NDArray of shape (n, 1):
         Array of the means or medians of each row of X
 
     Raises

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -77,8 +77,8 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
           ``sklearn.model_selection.LeaveOneOut()``.
         - CV splitter: any ``sklearn.model_selection.BaseCrossValidator``
           Main variants are:
-            - ``sklearn.model_selection.LeaveOneOut`` (jackknife),
-            - ``sklearn.model_selection.KFold`` (cross-validation)
+          - ``sklearn.model_selection.LeaveOneOut`` (jackknife),
+          - ``sklearn.model_selection.KFold`` (cross-validation)
         - ``"prefit"``, assumes that ``estimator`` has been fitted already.
           All data provided in the ``fit`` method is then used
           to calibrate the predictions through the score computation.

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Optional, Union, Tuple, Iterable, List
+from typing import Optional, Union, Tuple, Iterable, List, cast
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -17,7 +17,7 @@ from sklearn.utils.validation import (
     _check_y,
 )
 
-from ._typing import ArrayLike
+from ._typing import ArrayLike, NDArray
 from ._machine_precision import EPSILON
 from .utils import (
     check_cv,
@@ -332,8 +332,8 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
     def _check_proba_normalized(
         self,
         y_pred_proba: ArrayLike,
-        axis: Optional[int] = 1
-    ) -> Optional[ArrayLike]:
+        axis: int = 1
+    ) -> ArrayLike:
         """
         Check if, for all the observations, the sum of
         the probabilities is equal to one.
@@ -347,7 +347,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Returns
         -------
-        Optional[ArrayLike] of shape (n_samples, n_classes)
+        ArrayLike of shape (n_samples, n_classes)
             Softmax output of a model if the scores all sum
             to one.
 
@@ -366,8 +366,8 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
     def _get_last_index_included(
         self,
-        y_pred_proba_cumsum: ArrayLike,
-        threshold: ArrayLike,
+        y_pred_proba_cumsum: NDArray,
+        threshold: NDArray,
         include_last_label: Optional[Union[bool, str]]
     ) -> ArrayLike:
         """
@@ -377,10 +377,10 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Parameters
         ----------
-        y_pred_proba_cumsum : ArrayLike of shape (n_samples, n_classes)
+        y_pred_proba_cumsum : NDArray of shape (n_samples, n_classes)
             Cumsumed probabilities in the original order.
 
-        threshold : ArrayLike of shape (n_alpha,) or shape (n_samples_train,)
+        threshold : NDArray of shape (n_alpha,) or shape (n_samples_train,)
             Threshold to compare with y_proba_last_cumsum, can be either:
 
             - the quantiles associated with alpha values when
@@ -395,7 +395,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Returns
         -------
-        Optional[ArrayLike] of shape (n_samples, n_classes)
+        ArrayLike of shape (n_samples, n_classes)
             Index of the last included sorted probability.
         """
         if (
@@ -434,12 +434,12 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
     def _add_random_tie_breaking(
         self,
-        prediction_sets: ArrayLike,
-        y_pred_index_last: ArrayLike,
-        y_pred_proba_cumsum: ArrayLike,
-        y_pred_proba_last: ArrayLike,
-        threshold: ArrayLike
-    ) -> ArrayLike:
+        prediction_sets: NDArray,
+        y_pred_index_last: NDArray,
+        y_pred_proba_cumsum: NDArray,
+        y_pred_proba_last: NDArray,
+        threshold: NDArray
+    ) -> NDArray:
         """
         Randomly remove last label from prediction set based on the
         comparison between a random number and the difference between
@@ -447,20 +447,20 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Parameters
         ----------
-        prediction_sets : ArrayLike of shape
+        prediction_sets : NDArray of shape
             (n_samples, n_classes, n_threshold)
             Prediction set for each observation and each alpha.
 
-        y_pred_index_last : ArrayLike of shape (n_samples, threshold)
+        y_pred_index_last : NDArray of shape (n_samples, threshold)
             Index of the last included label.
 
-        y_pred_proba_cumsum : ArrayLike of shape (n_samples, n_classes)
+        y_pred_proba_cumsum : NDArray of shape (n_samples, n_classes)
             Cumsumed probability of the model in the original order.
 
-        y_pred_proba_last : ArrayLike of shape (n_samples, 1, threshold)
+        y_pred_proba_last : NDArray of shape (n_samples, 1, threshold)
             Last included probability.
 
-        threshold : ArrayLike of shape (n_alpha,) or shape (n_samples_train,)
+        threshold : NDArray of shape (n_alpha,) or shape (n_samples_train,)
             Threshold to compare with y_proba_last_cumsum, can be either:
 
             - the quantiles associated with alpha values when
@@ -471,7 +471,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Returns
         -------
-        ArrayLike of shape (n_samples, n_classes, n_alpha)
+        NDArray of shape (n_samples, n_classes, n_alpha)
             Updated version of prediction_sets with randomly removed
             labels.
         """
@@ -503,9 +503,9 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
     def _fix_number_of_classes(
         self,
-        n_classes_training: ArrayLike,
-        y_proba: ArrayLike
-    ) -> ArrayLike:
+        n_classes_training: NDArray,
+        y_proba: NDArray
+    ) -> NDArray:
         """
         Fix shape of y_proba of validation set if number of classes
         of the training set used for cross-validation is different than
@@ -513,14 +513,14 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Parameters
         ----------
-        n_classes_training : ArrayLike
+        n_classes_training : NDArray
             Classes of the training set.
-        y_proba : ArrayLike
+        y_proba : NDArray
             Probabilities of the validation set.
 
         Returns
         -------
-        ArrayLike
+        NDArray
             Probabilities with the right number of classes.
         """
         y_pred_full = np.zeros(
@@ -623,13 +623,12 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         if sample_weight is None:
             estimator = fit_estimator(estimator, X_train, y_train)
         else:
+            sample_weight_train = _safe_indexing(sample_weight, train_index)
             estimator = fit_estimator(
-                estimator, X_train, y_train, sample_weight[train_index]
+                estimator, X_train, y_train, sample_weight_train
             )
         if _num_samples(X_val) > 0:
-            y_pred_proba = self._predict_oof_model(
-                estimator, X_val,
-            )
+            y_pred_proba = self._predict_oof_model(estimator, X_val)
         else:
             y_pred_proba = np.array([])
         val_id = np.full_like(y_val, k, dtype=int)
@@ -684,7 +683,8 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         X, y = indexable(X, y)
         y = _check_y(y)
         assert type_of_target(y) == "multiclass"
-        self.n_classes_ = len(set(y))
+        n_samples = _num_samples(y)
+        self.n_classes_ = len(np.unique(y))
         self.n_features_in_ = check_n_features_in(X, cv, estimator)
         sample_weight, X, y = check_null_weight(sample_weight, X, y)
 
@@ -700,10 +700,11 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
             y_pred_proba = self._check_proba_normalized(y_pred_proba)
 
         else:
+            cv = cast(BaseCrossValidator, cv)
             self.single_estimator_ = fit_estimator(
                 clone(estimator), X, y, sample_weight
             )
-            y_pred_proba = np.empty((len(y), len(np.unique(y))), dtype=float)
+            y_pred_proba = np.empty((n_samples, self.n_classes_), dtype=float)
             outputs = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                 delayed(self._fit_and_predict_oof_model)(
                     clone(estimator),
@@ -716,12 +717,15 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
                 )
                 for k, (train_index, val_index) in enumerate(cv.split(X))
             )
-            self.estimators_, predictions, val_ids, val_indices = map(
-                list, zip(*outputs)
-            )
-            predictions, val_ids, val_indices = map(
-                np.concatenate, (predictions, val_ids, val_indices)
-            )
+            (
+                self.estimators_,
+                predictions_list,
+                val_ids_list,
+                val_indices_list
+            ) = map(list, zip(*outputs))
+            predictions: NDArray = np.concatenate(predictions_list)
+            val_ids: NDArray = np.concatenate(val_ids_list)
+            val_indices: NDArray = np.concatenate(val_indices_list)
             self.k_[val_indices] = val_ids
             y_pred_proba[val_indices] = predictions
 
@@ -842,7 +846,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         # Checks
         cv = check_cv(self.cv)
         include_last_label = self._check_include_last_label(include_last_label)
-        alpha_ = check_alpha(alpha)
+        alpha = cast(Optional[NDArray], check_alpha(alpha))
         check_is_fitted(self, self.fit_attributes)
         if self.image_input:
             check_input_is_image(X)
@@ -850,170 +854,172 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         # Estimate prediction sets
         y_pred = self.single_estimator_.predict(X)
         n = self.n_samples_
-        if alpha_ is None:
+
+        if alpha is None:
             return np.array(y_pred)
 
+        # Estimate of probabilities from estimator(s)
+        # In all cases : len(y_pred_proba.shape) == 3
+        # with  (n_test, n_classes, n_alpha or n_train_samples)
+        alpha = cast(NDArray, alpha)
+        check_alpha_and_n_samples(alpha, self.conformity_scores_.shape[0])
+        if cv == "prefit":
+            y_pred_proba = self.single_estimator_.predict_proba(X)
+            y_pred_proba = np.repeat(
+                y_pred_proba[:, :, np.newaxis], len(alpha_), axis=2
+            )
         else:
-            # Estimate of probabilities from estimator(s)
-            # In all cases : len(y_pred_proba.shape) == 3
-            # with  (n_test, n_classes, n_alpha or n_train_samples)
-            if cv == "prefit":
-                y_pred_proba = self.single_estimator_.predict_proba(X)
+            y_pred_proba_k = np.asarray(
+                Parallel(
+                    n_jobs=self.n_jobs, verbose=self.verbose
+                )(
+                    delayed(self._predict_oof_model)(estimator, X)
+                    for estimator in self.estimators_
+                )
+            )
+            if agg_scores == "crossval":
+                y_pred_proba = np.moveaxis(y_pred_proba_k[self.k_], 0, 2)
+            elif agg_scores == "mean":
+                y_pred_proba = np.mean(y_pred_proba_k, axis=0)
                 y_pred_proba = np.repeat(
                     y_pred_proba[:, :, np.newaxis], len(alpha_), axis=2
                 )
             else:
-                y_pred_proba_k = np.asarray(
-                    Parallel(
-                        n_jobs=self.n_jobs, verbose=self.verbose
-                    )(
-                        delayed(self._predict_oof_model)(estimator, X)
-                        for estimator in self.estimators_
-                    )
-                )
-                if agg_scores == "crossval":
-                    y_pred_proba = np.moveaxis(y_pred_proba_k[self.k_], 0, 2)
-                elif agg_scores == "mean":
-                    y_pred_proba = np.mean(y_pred_proba_k, axis=0)
-                    y_pred_proba = np.repeat(
-                        y_pred_proba[:, :, np.newaxis], len(alpha_), axis=2
-                    )
-                else:
-                    raise ValueError("Invalid 'agg_scores' argument.")
-            # Check that sum of probas is equal to 1
-            y_pred_proba = self._check_proba_normalized(y_pred_proba, axis=1)
+                raise ValueError("Invalid 'agg_scores' argument.")
+        # Check that sum of probas is equal to 1
+        y_pred_proba = self._check_proba_normalized(y_pred_proba, axis=1)
 
-            # Choice of the quantile
-            check_alpha_and_n_samples(alpha_, n)
-            if self.method == "naive":
-                self.quantiles_ = 1 - alpha_
+        # Choice of the quantile
+        check_alpha_and_n_samples(alpha_, n)
+        if self.method == "naive":
+            self.quantiles_ = 1 - alpha_
+        else:
+            if (cv == "prefit") or (agg_scores in ["mean"]):
+                self.quantiles_ = np.stack([
+                    np.quantile(
+                        self.conformity_scores_,
+                        ((n + 1) * (1 - _alpha)) / n,
+                        interpolation="higher"
+                    ) for _alpha in alpha_
+                ])
             else:
-                if (cv == "prefit") or (agg_scores in ["mean"]):
-                    self.quantiles_ = np.stack([
-                        np.quantile(
-                            self.conformity_scores_,
-                            ((n + 1) * (1 - _alpha)) / n,
-                            interpolation="higher"
-                        ) for _alpha in alpha_
-                    ])
-                else:
-                    self.quantiles_ = (n + 1) * (1 - alpha_)
+                self.quantiles_ = (n + 1) * (1 - alpha_)
 
-            # Build prediction sets
-            if self.method == "score":
-                if (cv == "prefit") or (agg_scores == "mean"):
-                    prediction_sets = y_pred_proba > (
-                        1 - (self.quantiles_ + EPSILON)
+        # Build prediction sets
+        if self.method == "score":
+            if (cv == "prefit") or (agg_scores == "mean"):
+                prediction_sets = y_pred_proba > (
+                    1 - (self.quantiles_ + EPSILON)
+                )
+            else:
+                y_pred_included = (
+                    1 - y_pred_proba < (
+                        self.conformity_scores_.ravel() + EPSILON
                     )
-                else:
-                    y_pred_included = (
-                        1 - y_pred_proba < (
-                            self.conformity_scores_.ravel() + EPSILON
-                        )
-                    ).sum(axis=2)
-                    prediction_sets = np.stack(
-                        [
-                            y_pred_included > _alpha * (n - 1) - EPSILON
-                            for _alpha in alpha_
-                        ], axis=2
-                    )
-
-            elif self.method in ["cumulated_score", "naive"]:
-                # specify which thresholds will be used
-                if (cv == "prefit") or (agg_scores in ["mean"]):
-                    thresholds = self.quantiles_
-                else:
-                    thresholds = self.conformity_scores_.ravel()
-                # sort labels by decreasing probability
-                index_sorted = np.flip(
-                    np.argsort(y_pred_proba, axis=1), axis=1
-                )
-                # sort probabilities by decreasing order
-                y_pred_proba_sorted = np.take_along_axis(
-                    y_pred_proba, index_sorted, axis=1
-                )
-                # get sorted cumulated score
-                y_pred_proba_sorted_cumsum = np.cumsum(
-                    y_pred_proba_sorted, axis=1
-                )
-                # get cumulated score at their original position
-                y_pred_proba_cumsum = np.take_along_axis(
-                    y_pred_proba_sorted_cumsum,
-                    np.argsort(index_sorted, axis=1),
-                    axis=1
-                )
-                # get index of the last included label
-                y_pred_index_last = self._get_last_index_included(
-                    y_pred_proba_cumsum,
-                    thresholds,
-                    include_last_label
-                )
-                # get the probability of the last included label
-                y_pred_proba_last = np.take_along_axis(
-                    y_pred_proba,
-                    y_pred_index_last,
-                    axis=1
-                )
-                # get the prediction set by taking all probabilities
-                # above the last one
-                if (cv == "prefit") or (agg_scores in ["mean"]):
-                    y_pred_included = (
-                        (y_pred_proba > y_pred_proba_last - EPSILON)
-                    )
-                else:
-                    y_pred_included = (
-                        # ~(y_pred_proba >= y_pred_proba_last - EPSILON)
-                        (y_pred_proba < y_pred_proba_last + EPSILON)
-                    )
-                # remove last label randomly
-                if include_last_label == "randomized":
-                    y_pred_included = self._add_random_tie_breaking(
-                        y_pred_included,
-                        y_pred_index_last,
-                        y_pred_proba_cumsum,
-                        y_pred_proba_last,
-                        thresholds,
-                    )
-                if (cv == "prefit") or (agg_scores in ["mean"]):
-                    prediction_sets = y_pred_included
-                else:
-                    # compute the number of times the inequality is verified
-                    prediction_sets_summed = y_pred_included.sum(axis=2)
-                    # compare the summed prediction sets with (n+1)*(1-alpha)
-                    prediction_sets = np.stack(
-                        [
-                            prediction_sets_summed < quantile + EPSILON
-                            for quantile in self.quantiles_
-                        ], axis=2
-                    )
-            elif self.method == "top_k":
-                y_pred_proba = y_pred_proba[:, :, 0]
-                index_sorted = np.fliplr(np.argsort(y_pred_proba, axis=1))
-                y_pred_index_last = np.stack(
-                    [
-                        index_sorted[:, quantile]
-                        for quantile in self.quantiles_
-                    ], axis=1
-                )
-                y_pred_proba_last = np.stack(
-                    [
-                        np.take_along_axis(
-                            y_pred_proba,
-                            y_pred_index_last[:, iq].reshape(-1, 1),
-                            axis=1
-                        )
-                        for iq, _ in enumerate(self.quantiles_)
-                    ], axis=2
-                )
+                ).sum(axis=2)
                 prediction_sets = np.stack(
                     [
-                        y_pred_proba >= y_pred_proba_last[:, :, iq] - EPSILON
-                        for iq, _ in enumerate(self.quantiles_)
+                        y_pred_included > _alpha * (n - 1) - EPSILON
+                        for _alpha in alpha_
                     ], axis=2
                 )
+
+        elif self.method in ["cumulated_score", "naive"]:
+            # specify which thresholds will be used
+            if (cv == "prefit") or (agg_scores in ["mean"]):
+                thresholds = self.quantiles_
             else:
-                raise ValueError(
-                    "Invalid method. "
-                    "Allowed values are 'score' or 'cumulated_score'."
+                thresholds = self.conformity_scores_.ravel()
+            # sort labels by decreasing probability
+            index_sorted = np.flip(
+                np.argsort(y_pred_proba, axis=1), axis=1
+            )
+            # sort probabilities by decreasing order
+            y_pred_proba_sorted = np.take_along_axis(
+                y_pred_proba, index_sorted, axis=1
+            )
+            # get sorted cumulated score
+            y_pred_proba_sorted_cumsum = np.cumsum(
+                y_pred_proba_sorted, axis=1
+            )
+            # get cumulated score at their original position
+            y_pred_proba_cumsum = np.take_along_axis(
+                y_pred_proba_sorted_cumsum,
+                np.argsort(index_sorted, axis=1),
+                axis=1
+            )
+            # get index of the last included label
+            y_pred_index_last = self._get_last_index_included(
+                y_pred_proba_cumsum,
+                thresholds,
+                include_last_label
+            )
+            # get the probability of the last included label
+            y_pred_proba_last = np.take_along_axis(
+                y_pred_proba,
+                y_pred_index_last,
+                axis=1
+            )
+            # get the prediction set by taking all probabilities
+            # above the last one
+            if (cv == "prefit") or (agg_scores in ["mean"]):
+                y_pred_included = (
+                    (y_pred_proba > y_pred_proba_last - EPSILON)
                 )
-            return y_pred, prediction_sets
+            else:
+                y_pred_included = (
+                    # ~(y_pred_proba >= y_pred_proba_last - EPSILON)
+                    (y_pred_proba < y_pred_proba_last + EPSILON)
+                )
+            # remove last label randomly
+            if include_last_label == "randomized":
+                y_pred_included = self._add_random_tie_breaking(
+                    y_pred_included,
+                    y_pred_index_last,
+                    y_pred_proba_cumsum,
+                    y_pred_proba_last,
+                    thresholds,
+                )
+            if (cv == "prefit") or (agg_scores in ["mean"]):
+                prediction_sets = y_pred_included
+            else:
+                # compute the number of times the inequality is verified
+                prediction_sets_summed = y_pred_included.sum(axis=2)
+                # compare the summed prediction sets with (n+1)*(1-alpha)
+                prediction_sets = np.stack(
+                    [
+                        prediction_sets_summed < quantile + EPSILON
+                        for quantile in self.quantiles_
+                    ], axis=2
+                )
+        elif self.method == "top_k":
+            y_pred_proba = y_pred_proba[:, :, 0]
+            index_sorted = np.fliplr(np.argsort(y_pred_proba, axis=1))
+            y_pred_index_last = np.stack(
+                [
+                    index_sorted[:, quantile]
+                    for quantile in self.quantiles_
+                ], axis=1
+            )
+            y_pred_proba_last = np.stack(
+                [
+                    np.take_along_axis(
+                        y_pred_proba,
+                        y_pred_index_last[:, iq].reshape(-1, 1),
+                        axis=1
+                    )
+                    for iq, _ in enumerate(self.quantiles_)
+                ], axis=2
+            )
+            prediction_sets = np.stack(
+                [
+                    y_pred_proba >= y_pred_proba_last[:, :, iq] - EPSILON
+                    for iq, _ in enumerate(self.quantiles_)
+                ], axis=2
+            )
+        else:
+            raise ValueError(
+                "Invalid method. "
+                "Allowed values are 'score' or 'cumulated_score'."
+            )
+        return y_pred, prediction_sets

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -682,10 +682,10 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         X, y = indexable(X, y)
         y = _check_y(y)
         assert type_of_target(y) == "multiclass"
+        sample_weight, X, y = check_null_weight(sample_weight, X, y)
         n_samples = _num_samples(y)
         self.n_classes_ = len(np.unique(y))
         self.n_features_in_ = check_n_features_in(X, cv, estimator)
-        sample_weight, X, y = check_null_weight(sample_weight, X, y)
 
         # Initialization
         self.estimators_: List[ClassifierMixin] = []

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -127,9 +127,6 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
     n_features_in_: int
         Number of features passed to the fit method.
 
-    n_samples_: Union[int, List[int]]
-        Number of samples passed to the fit method.
-
     conformity_scores_ : ArrayLike of shape (n_samples_train)
         The conformity scores used to calibrate the prediction sets.
 
@@ -177,8 +174,8 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
     fit_attributes = [
         "single_estimator_",
         "estimators_",
+        "k_",
         "n_features_in_",
-        "n_samples_",
         "conformity_scores_"
     ]
 
@@ -856,7 +853,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
 
         # Estimate prediction sets
         y_pred = self.single_estimator_.predict(X)
-        n = self.n_samples_
+        n = len(self.conformity_scores_)
 
         if alpha is None:
             return np.array(y_pred)
@@ -865,7 +862,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         # In all cases : len(y_pred_proba.shape) == 3
         # with  (n_test, n_classes, n_alpha or n_train_samples)
         alpha = cast(NDArray, alpha)
-        check_alpha_and_n_samples(alpha, self.conformity_scores_.shape[0])
+        check_alpha_and_n_samples(alpha, n)
         if cv == "prefit":
             y_pred_proba = self.single_estimator_.predict_proba(X)
             y_pred_proba = np.repeat(

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -32,7 +32,7 @@ from .utils import (
 )
 
 
-class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
+class MapieClassifier(BaseEstimator, ClassifierMixin):
     """
     Prediction sets for classification.
 

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -606,13 +606,13 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         -------
         Tuple[ClassifierMixin, NDArray, NDArray, ArrayLike]
 
-        - [0]: Fitted estimator
-        - [1]: Estimator predictions on the validation fold,
-          of shape (n_samples_val,)
-        - [2]: Identification number of the validation fold,
-          of shape (n_samples_val,)
-        - [3]: Validation data indices,
-          of shape (n_samples_val,).
+        - [0]: ClassifierMixin, fitted estimator
+        - [1]: NDArray of shape (n_samples_val,),
+          Estimator predictions on the validation fold,
+        - [2]: NDArray of shape (n_samples_val,)
+          Identification number of the validation fold,
+        - [3]: ArrayLike of shape (n_samples_val,)
+          Validation data indices
         """
         X_train = _safe_indexing(X, train_index)
         y_train = _safe_indexing(y, train_index)
@@ -780,7 +780,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
         alpha: Optional[Union[float, Iterable[float]]] = None,
         include_last_label: Optional[Union[bool, str]] = True,
         agg_scores: Optional[str] = "mean"
-    ) -> Union[ArrayLike, Tuple[ArrayLike, ArrayLike]]:
+    ) -> Union[NDArray, Tuple[NDArray, NDArray]]:
         """
         Prediction prediction sets on new samples based on target confidence
         interval.
@@ -833,11 +833,11 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):  # type: ignore
 
         Returns
         -------
-        Union[ArrayLike, Tuple[ArrayLike, ArrayLike]]
+        Union[NDArray, Tuple[NDArray, NDArray]]
 
-        - ArrayLike of shape (n_samples,) if alpha is None.
+        - NDArray of shape (n_samples,) if alpha is None.
 
-        - Tuple[ArrayLike, ArrayLike] of shapes
+        - Tuple[NDArray, NDArray] of shapes
         (n_samples,) and (n_samples, n_classes, n_alpha) if alpha is not None.
         """
         if self.method == "top_k":

--- a/mapie/metrics.py
+++ b/mapie/metrics.py
@@ -1,6 +1,9 @@
+from typing import cast
+
 import numpy as np
 from sklearn.utils.validation import column_or_1d, check_array
-from ._typing import ArrayLike
+
+from ._typing import ArrayLike, NDArray
 
 
 def regression_coverage_score(
@@ -38,15 +41,18 @@ def regression_coverage_score(
     >>> print(regression_coverage_score(y_true, y_pred_low, y_pred_up))
     0.8
     """
-    y_true = column_or_1d(y_true)
-    y_pred_low = column_or_1d(y_pred_low)
-    y_pred_up = column_or_1d(y_pred_up)
-    coverage = ((y_pred_low <= y_true) & (y_pred_up >= y_true)).mean()
+    y_true = cast(NDArray, column_or_1d(y_true))
+    y_pred_low = cast(NDArray, column_or_1d(y_pred_low))
+    y_pred_up = cast(NDArray, column_or_1d(y_pred_up))
+    coverage = np.mean(
+        ((y_pred_low <= y_true) & (y_pred_up >= y_true))
+    )
     return float(coverage)
 
 
 def classification_coverage_score(
-    y_true: ArrayLike, y_pred_set: ArrayLike
+    y_true: ArrayLike,
+    y_pred_set: ArrayLike
 ) -> float:
     """
     Effective coverage score obtained by the prediction sets.
@@ -81,8 +87,13 @@ def classification_coverage_score(
     >>> print(classification_coverage_score(y_true, y_pred_set))
     0.8
     """
-    y_true = column_or_1d(y_true)
-    y_pred_set = check_array(y_pred_set, force_all_finite=True, dtype=["bool"])
+    y_true = cast(NDArray, column_or_1d(y_true))
+    y_pred_set = cast(
+        NDArray,
+        check_array(
+            y_pred_set, force_all_finite=True, dtype=["bool"]
+        )
+    )
     coverage = np.take_along_axis(
         y_pred_set, y_true.reshape(-1, 1), axis=1
     ).mean()
@@ -91,7 +102,7 @@ def classification_coverage_score(
 
 def regression_mean_width_score(
     y_pred_low: ArrayLike,
-    y_pred_up: ArrayLike,
+    y_pred_up: ArrayLike
 ) -> float:
     """
     Effective mean width score obtained by the prediction intervals.
@@ -117,15 +128,13 @@ def regression_mean_width_score(
     >>> print(regression_mean_width_score(y_pred_low, y_pred_up))
     2.3
     """
-    y_pred_low = column_or_1d(y_pred_low)
-    y_pred_up = column_or_1d(y_pred_up)
+    y_pred_low = cast(NDArray, column_or_1d(y_pred_low))
+    y_pred_up = cast(NDArray, column_or_1d(y_pred_up))
     mean_width = np.abs(y_pred_up - y_pred_low).mean()
     return float(mean_width)
 
 
-def classification_mean_width_score(
-    y_pred_set: ArrayLike
-) -> float:
+def classification_mean_width_score(y_pred_set: ArrayLike) -> float:
     """
     Mean width of prediction set output by
     :class:`mapie.classification.MapieClassifier`.
@@ -154,6 +163,11 @@ def classification_mean_width_score(
     >>> print(classification_mean_width_score(y_pred_set))
     2.0
     """
-    y_pred_set = check_array(y_pred_set, force_all_finite=True, dtype=["bool"])
+    y_pred_set = cast(
+        NDArray,
+        check_array(
+            y_pred_set, force_all_finite=True, dtype=["bool"]
+        )
+    )
     mean_width = y_pred_set.sum(axis=1).mean()
     return float(mean_width)

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -345,7 +345,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         train_index: ArrayLike,
         val_index: ArrayLike,
         sample_weight: Optional[ArrayLike] = None,
-    ) -> Tuple[RegressorMixin, ArrayLike, ArrayLike]:
+    ) -> Tuple[RegressorMixin, NDArray, ArrayLike]:
         """
         Fit a single out-of-fold model on a given training set and
         perform predictions on a test set.
@@ -373,14 +373,13 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
 
         Returns
         -------
-        Tuple[RegressorMixin, ArrayLike, ArrayLike]
+        Tuple[RegressorMixin, NDArray, ArrayLike]
 
         - [0]: Fitted estimator
         - [1]: Estimator predictions on the validation fold,
           of shape (n_samples_val,)
         - [3]: Validation data indices,
           of shape (n_samples_val,).
-
         """
         X_train = _safe_indexing(X, train_index)
         y_train = _safe_indexing(y, train_index)

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -537,13 +537,13 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                 ]
 
                 for i, val_ind in enumerate(val_indices):
-                    pred_matrix[val_ind, i] = np.array(predictions[i]).ravel()
+                    pred_matrix[val_ind, i] = np.array(predictions[i])
                     self.k_[val_ind, i] = 1
                 check_nan_in_aposteriori_prediction(pred_matrix)
 
                 y_pred = aggregate_all(agg_function, pred_matrix)
 
-        self.residuals_ = np.abs(np.ravel(y) - y_pred)
+        self.residuals_ = np.abs(y - y_pred)
         return self
 
     def predict(

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -33,7 +33,7 @@ from .utils import (
 )
 
 
-class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
+class MapieRegressor(BaseEstimator, RegressorMixin):
     """
     Prediction interval with out-of-fold residuals.
 
@@ -499,13 +499,13 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         else:
             cv = cast(BaseCrossValidator, cv)
             self.k_ = np.full(
-                shape=(n_samples, cv.get_n_splits(X, y)),  # type: ignore
+                shape=(n_samples, cv.get_n_splits(X, y)),
                 fill_value=np.nan,
                 dtype=float,
             )
 
             pred_matrix = np.full(
-                shape=(n_samples, cv.get_n_splits(X, y)),  # type: ignore
+                shape=(n_samples, cv.get_n_splits(X, y)),
                 fill_value=np.nan,
                 dtype=float,
             )

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -481,9 +481,9 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         agg_function = self._check_agg_function(self.agg_function)
         X, y = indexable(X, y)
         y = _check_y(y)
-        n_samples = _num_samples(y)
         self.n_features_in_ = check_n_features_in(X, cv, estimator)
         sample_weight, X, y = check_null_weight(sample_weight, X, y)
+        n_samples = _num_samples(y)
 
         # Initialization
         self.estimators_: List[RegressorMixin] = []

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -483,6 +483,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         y = _check_y(y)
         self.n_features_in_ = check_n_features_in(X, cv, estimator)
         sample_weight, X, y = check_null_weight(sample_weight, X, y)
+        y = cast(NDArray, y)
         n_samples = _num_samples(y)
 
         # Initialization

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -375,11 +375,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         -------
         Tuple[RegressorMixin, NDArray, ArrayLike]
 
-        - [0]: Fitted estimator
-        - [1]: Estimator predictions on the validation fold,
-          of shape (n_samples_val,)
-        - [3]: Validation data indices,
-          of shape (n_samples_val,).
+        - [0]: RegressorMixin, fitted estimator
+        - [1]: NDArrayof shape (n_samples_val,),
+          estimator predictions on the validation fold.
+        - [3]: NDArray of shape (n_samples_val,),
+          validation data indices.
         """
         X_train = _safe_indexing(X, train_index)
         y_train = _safe_indexing(y, train_index)
@@ -551,7 +551,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
         X: ArrayLike,
         ensemble: bool = False,
         alpha: Optional[Union[float, Iterable[float]]] = None,
-    ) -> Union[ArrayLike, Tuple[ArrayLike, ArrayLike]]:
+    ) -> Union[NDArray, Tuple[NDArray, NDArray]]:
         """
         Predict target on new samples with confidence intervals.
         Residuals from the training set and predictions from the model clones
@@ -591,11 +591,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):  # type: ignore
 
         Returns
         -------
-        Union[ArrayLike, Tuple[ArrayLike, ArrayLike]]
+        Union[NDArray, Tuple[NDArray, NDArray]]
 
-        - ArrayLike of shape (n_samples,) if alpha is None.
+        - NDArray of shape (n_samples,) if alpha is None.
 
-        - Tuple[ArrayLike, ArrayLike] of shapes
+        - Tuple[NDArray, NDArray] of shapes
         (n_samples,) and (n_samples, 2, n_alpha) if alpha is not None.
 
             - [:, 0, :]: Lower bound of the prediction interval.

--- a/mapie/subsample.py
+++ b/mapie/subsample.py
@@ -6,6 +6,7 @@ import numpy as np
 from numpy.random import RandomState
 from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils import check_random_state, resample
+from sklearn.utils.validation import _num_samples
 
 from ._typing import ArrayLike
 
@@ -54,7 +55,8 @@ class Subsample(BaseCrossValidator):  # type: ignore
         self.random_state = random_state
 
     def split(
-        self, X: ArrayLike
+        self,
+        X: ArrayLike
     ) -> Generator[Tuple[Any, ArrayLike], None, None]:
         """
         Generate indices to split data into training and test sets.
@@ -71,7 +73,7 @@ class Subsample(BaseCrossValidator):  # type: ignore
         test : ArrayLike of shape (n_indices_test,)
             The testing set indices for that split.
         """
-        indices = np.arange(len(X))
+        indices = np.arange(_num_samples(X))
         n_samples = (
             self.n_samples if self.n_samples is not None else len(indices)
         )

--- a/mapie/subsample.py
+++ b/mapie/subsample.py
@@ -8,7 +8,7 @@ from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils import check_random_state, resample
 from sklearn.utils.validation import _num_samples
 
-from ._typing import ArrayLike
+from ._typing import ArrayLike, NDArray
 
 
 class Subsample(BaseCrossValidator):  # type: ignore
@@ -57,7 +57,7 @@ class Subsample(BaseCrossValidator):  # type: ignore
     def split(
         self,
         X: ArrayLike
-    ) -> Generator[Tuple[Any, ArrayLike], None, None]:
+    ) -> Generator[Tuple[NDArray, NDArray], None, None]:
         """
         Generate indices to split data into training and test sets.
 
@@ -68,9 +68,9 @@ class Subsample(BaseCrossValidator):  # type: ignore
 
         Yields
         ------
-        train : ArrayLike of shape (n_indices_training,)
+        train : NDArray of shape (n_indices_training,)
             The training set indices for that split.
-        test : ArrayLike of shape (n_indices_test,)
+        test : NDArray of shape (n_indices_test,)
             The testing set indices for that split.
         """
         indices = np.arange(_num_samples(X))

--- a/mapie/subsample.py
+++ b/mapie/subsample.py
@@ -11,7 +11,7 @@ from sklearn.utils.validation import _num_samples
 from ._typing import ArrayLike, NDArray
 
 
-class Subsample(BaseCrossValidator):  # type: ignore
+class Subsample(BaseCrossValidator):
     """
     Generate a sampling method, that resamples the training set with
     possible bootstraps. It can replace KFold or  LeaveOneOut as cv argument

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple, Union, Iterable, Dict
 from typing_extensions import TypedDict
 
-import pandas as pd
 import pytest
+import pandas as pd
 import numpy as np
 from sklearn.base import ClassifierMixin
 from sklearn.datasets import make_classification
@@ -19,7 +19,7 @@ from sklearn.utils.validation import check_is_fitted
 
 from mapie.classification import MapieClassifier
 from mapie.metrics import classification_coverage_score
-from mapie._typing import ArrayLike
+from mapie._typing import ArrayLike, NDArray
 
 
 METHODS = ["score", "cumulated_score"]
@@ -450,10 +450,10 @@ class CumulatedScoreClassifier:
         self.fitted_ = True
         return self
 
-    def predict(self, X: ArrayLike) -> ArrayLike:
+    def predict(self, X: ArrayLike) -> NDArray:
         return np.array([1, 2, 1])
 
-    def predict_proba(self, X: ArrayLike) -> ArrayLike:
+    def predict_proba(self, X: ArrayLike) -> NDArray:
         if np.max(X) <= 2:
             return np.array(
                 [[0.4, 0.5, 0.1], [0.2, 0.6, 0.2], [0.6, 0.3, 0.1]]
@@ -465,6 +465,7 @@ class CumulatedScoreClassifier:
 
 
 class ImageClassifier:
+
     def __init__(self, X_calib: ArrayLike, X_test: ArrayLike) -> None:
         self.X_calib = X_calib
         self.y_calib = np.array([0, 1, 2])
@@ -481,10 +482,10 @@ class ImageClassifier:
         self.fitted_ = True
         return self
 
-    def predict(self, X: ArrayLike) -> ArrayLike:
+    def predict(self, X: ArrayLike) -> NDArray:
         return np.array([1, 2, 1])
 
-    def predict_proba(self, X: ArrayLike) -> ArrayLike:
+    def predict_proba(self, X: ArrayLike) -> NDArray:
         if np.max(X) == 0:
             return np.array(
                 [[0.4, 0.5, 0.1], [0.2, 0.6, 0.2], [0.6, 0.3, 0.1]]
@@ -497,7 +498,7 @@ class ImageClassifier:
 
 class WrongOutputModel:
 
-    def __init__(self, proba_out: ArrayLike):
+    def __init__(self, proba_out: NDArray):
         self.trained_ = True
         self.proba_out = proba_out
         self.classes_ = np.arange(len(np.unique(proba_out[0])))
@@ -505,10 +506,10 @@ class WrongOutputModel:
     def fit(self, *args: Any) -> None:
         """Dummy fit."""
 
-    def predict_proba(self, *args: Any) -> ArrayLike:
+    def predict_proba(self, *args: Any) -> NDArray:
         return self.proba_out
 
-    def predict(self, *args: Any) -> ArrayLike:
+    def predict(self, *args: Any) -> NDArray:
         pred = (
             self.proba_out == self.proba_out.max(axis=1)[:, None]
         ).astype(int)
@@ -610,7 +611,7 @@ def test_invalid_include_last_label(include_last_label: Any) -> None:
 @pytest.mark.parametrize("dataset", [(X, y), (X_toy, y_toy)])
 @pytest.mark.parametrize("alpha", [0.2, [0.2, 0.3], (0.2, 0.3)])
 def test_predict_output_shape(
-    strategy: str, alpha: Any, dataset: Tuple[ArrayLike, ArrayLike]
+    strategy: str, alpha: Any, dataset: Tuple[NDArray, NDArray]
 ) -> None:
     """Test predict output shape."""
     args_init, args_predict = STRATEGIES[strategy]
@@ -839,7 +840,7 @@ def test_image_cumulated_scores(X: Dict[str, ArrayLike]) -> None:
 
 
 @pytest.mark.parametrize("y_pred_proba", Y_PRED_PROBA_WRONG)
-def test_sum_proba_to_one_fit(y_pred_proba: ArrayLike) -> None:
+def test_sum_proba_to_one_fit(y_pred_proba: NDArray) -> None:
     """
     Test if when the output probabilities of the model do not
     sum to one, return an error in the fit method.
@@ -855,7 +856,7 @@ def test_sum_proba_to_one_fit(y_pred_proba: ArrayLike) -> None:
 @pytest.mark.parametrize("y_pred_proba", Y_PRED_PROBA_WRONG)
 @pytest.mark.parametrize("alpha", [0.2, [0.2, 0.3], (0.2, 0.3)])
 def test_sum_proba_to_one_predict(
-    y_pred_proba: ArrayLike,
+    y_pred_proba: NDArray,
     alpha: Union[float, Iterable[float]]
 ) -> None:
     """

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -177,7 +177,7 @@ def test_none_alpha_results(pack: Tuple[BaseEstimator, BaseEstimator]) -> None:
     np.testing.assert_allclose(y_pred_expected, y_pred)
 
 
-@parametrize_with_checks([MapieRegressor()])  # type: ignore
+@parametrize_with_checks([MapieRegressor()])
 def test_sklearn_compatible_estimator(
     estimator: BaseEstimator, check: Any
 ) -> None:

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -440,7 +440,6 @@ def test_pred_loof_isnan() -> None:
         y=y_toy,
         train_index=[0, 1, 2, 3, 4],
         val_index=[],
-        k=0,
     )
     assert len(y_pred) == 0
 

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -17,7 +17,7 @@ from sklearn.preprocessing import OneHotEncoder
 from sklearn.compose import ColumnTransformer
 from typing_extensions import TypedDict
 
-from mapie._typing import ArrayLike
+from mapie._typing import ArrayLike, NDArray
 from mapie.aggregation_functions import aggregate_all
 from mapie.metrics import regression_coverage_score
 from mapie.regression import MapieRegressor
@@ -178,7 +178,7 @@ def test_too_large_cv(cv: Any) -> None:
 @pytest.mark.parametrize("dataset", [(X, y), (X_toy, y_toy)])
 @pytest.mark.parametrize("alpha", [0.2, [0.2, 0.4], (0.2, 0.4)])
 def test_predict_output_shape(
-    strategy: str, alpha: Any, dataset: Tuple[ArrayLike, ArrayLike]
+    strategy: str, alpha: Any, dataset: Tuple[NDArray, NDArray]
 ) -> None:
     """Test predict output shape."""
     mapie_reg = MapieRegressor(**STRATEGIES[strategy])
@@ -333,7 +333,7 @@ def test_linear_regression_results(strategy: str) -> None:
 def test_results_prefit_ignore_method() -> None:
     """Test that method is ignored when ``cv="prefit"``."""
     estimator = LinearRegression().fit(X, y)
-    all_y_pis: List[ArrayLike] = []
+    all_y_pis: List[NDArray] = []
     for method in METHODS:
         mapie_reg = MapieRegressor(
             estimator=estimator, cv="prefit", method=method

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -72,19 +72,6 @@ def test_check_null_weight_with_zeros() -> None:
     )
 
 
-def test_check_null_weight_with_more_zeros() -> None:
-    """
-    Test that the function reduces the shape if there are
-    more zeros than expected in sample weights.
-    """
-    sample_weight = np.ones(shape=len(y_toy) * 2)
-    sample_weight[len(y_toy):] = 0.0
-    sw_out, X_out, y_out = check_null_weight(sample_weight, X_toy, y_toy)
-    np.testing.assert_almost_equal(np.array(sw_out), np.ones(shape=len(y_toy)))
-    np.testing.assert_almost_equal(X_out, X_toy)
-    np.testing.assert_almost_equal(y_out, y_toy)
-
-
 @pytest.mark.parametrize("estimator", [LinearRegression(), DumbEstimator()])
 @pytest.mark.parametrize("sample_weight", [None, np.ones_like(y_toy)])
 def test_fit_estimator(

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -43,17 +43,17 @@ def test_check_null_weight_with_none() -> None:
     """Test that the function has no effect if sample weight is None."""
     sw_out, X_out, y_out = check_null_weight(None, X_toy, y_toy)
     assert sw_out is None
-    np.testing.assert_almost_equal(X_out, X_toy)
-    np.testing.assert_almost_equal(y_out, y_toy)
+    np.testing.assert_almost_equal(np.array(X_out), X_toy)
+    np.testing.assert_almost_equal(np.array(y_out), y_toy)
 
 
 def test_check_null_weight_with_nonzeros() -> None:
     """Test that the function has no effect if sample weight is never zero."""
     sample_weight = np.ones_like(y_toy)
     sw_out, X_out, y_out = check_null_weight(sample_weight, X_toy, y_toy)
-    np.testing.assert_almost_equal(sw_out, sample_weight)
-    np.testing.assert_almost_equal(X_out, X_toy)
-    np.testing.assert_almost_equal(y_out, y_toy)
+    np.testing.assert_almost_equal(np.array(sw_out), sample_weight)
+    np.testing.assert_almost_equal(np.array(X_out), X_toy)
+    np.testing.assert_almost_equal(np.array(y_out), y_toy)
 
 
 def test_check_null_weight_with_zeros() -> None:
@@ -61,9 +61,9 @@ def test_check_null_weight_with_zeros() -> None:
     sample_weight = np.ones_like(y_toy)
     sample_weight[:1] = 0.0
     sw_out, X_out, y_out = check_null_weight(sample_weight, X_toy, y_toy)
-    np.testing.assert_almost_equal(sw_out, np.array([1, 1, 1, 1, 1]))
-    np.testing.assert_almost_equal(X_out, np.array([[1], [2], [3], [4], [5]]))
-    np.testing.assert_almost_equal(y_out, np.array([7, 9, 11, 13, 15]))
+    np.testing.assert_almost_equal(np.array(sw_out), np.array([1, 1, 1, 1, 1]))
+    np.testing.assert_almost_equal(np.array(X_out), np.array([[1], [2], [3], [4], [5]]))
+    np.testing.assert_almost_equal(np.array(y_out), np.array([7, 9, 11, 13, 15]))
 
 
 @pytest.mark.parametrize("estimator", [LinearRegression(), DumbEstimator()])

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -89,7 +89,7 @@ def test_fit_estimator_sample_weight() -> None:
         np.testing.assert_almost_equal(y_pred_1, y_pred_2)
 
 
-@pytest.mark.parametrize("alpha", [-1, 0, 1, 2, 2.5, "a", [[0.5]], ["a", "b"]])
+@pytest.mark.parametrize("alpha", [-1, 0, 1, 2, 2.5, "a", ["a", "b"]])
 def test_invalid_alpha(alpha: Any) -> None:
     """Test that invalid alphas raise errors."""
     with pytest.raises(ValueError, match=r".*Invalid alpha.*"):
@@ -99,6 +99,7 @@ def test_invalid_alpha(alpha: Any) -> None:
 @pytest.mark.parametrize(
     "alpha",
     [
+        0.95,
         np.linspace(0.05, 0.95, 5),
         [0.05, 0.95],
         (0.05, 0.95),

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -89,7 +89,7 @@ def test_fit_estimator_sample_weight() -> None:
         np.testing.assert_almost_equal(y_pred_1, y_pred_2)
 
 
-@pytest.mark.parametrize("alpha", [-1, 0, 1, 2, 2.5, "a", ["a", "b"]])
+@pytest.mark.parametrize("alpha", [-1, 0, 1, 2, 2.5, [0.4, 0.6], "a", ["a", "b"]])
 def test_invalid_alpha(alpha: Any) -> None:
     """Test that invalid alphas raise errors."""
     with pytest.raises(ValueError, match=r".*Invalid alpha.*"):
@@ -100,7 +100,6 @@ def test_invalid_alpha(alpha: Any) -> None:
     "alpha",
     [
         0.95,
-        np.linspace(0.05, 0.95, 5),
         [0.05, 0.95],
         (0.05, 0.95),
         np.array([0.05, 0.95]),

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -62,8 +62,27 @@ def test_check_null_weight_with_zeros() -> None:
     sample_weight[:1] = 0.0
     sw_out, X_out, y_out = check_null_weight(sample_weight, X_toy, y_toy)
     np.testing.assert_almost_equal(np.array(sw_out), np.array([1, 1, 1, 1, 1]))
-    np.testing.assert_almost_equal(np.array(X_out), np.array([[1], [2], [3], [4], [5]]))
-    np.testing.assert_almost_equal(np.array(y_out), np.array([7, 9, 11, 13, 15]))
+    np.testing.assert_almost_equal(
+        np.array(X_out),
+        np.array([[1], [2], [3], [4], [5]])
+    )
+    np.testing.assert_almost_equal(
+        np.array(y_out),
+        np.array([7, 9, 11, 13, 15])
+    )
+
+
+def test_check_null_weight_with_more_zeros() -> None:
+    """
+    Test that the function reduces the shape if there are
+    more zeros than expected in sample weights.
+    """
+    sample_weight = np.ones(shape=len(y_toy) * 2)
+    sample_weight[len(y_toy):] = 0.0
+    sw_out, X_out, y_out = check_null_weight(sample_weight, X_toy, y_toy)
+    np.testing.assert_almost_equal(np.array(sw_out), np.ones(shape=len(y_toy)))
+    np.testing.assert_almost_equal(X_out, X_toy)
+    np.testing.assert_almost_equal(y_out, y_toy)
 
 
 @pytest.mark.parametrize("estimator", [LinearRegression(), DumbEstimator()])
@@ -89,7 +108,7 @@ def test_fit_estimator_sample_weight() -> None:
         np.testing.assert_almost_equal(y_pred_1, y_pred_2)
 
 
-@pytest.mark.parametrize("alpha", [-1, 0, 1, 2, 2.5, [0.4, 0.6], "a", ["a", "b"]])
+@pytest.mark.parametrize("alpha", [-1, 0, 1, 2, 2.5, "a", ["a", "b"]])
 def test_invalid_alpha(alpha: Any) -> None:
     """Test that invalid alphas raise errors."""
     with pytest.raises(ValueError, match=r".*Invalid alpha.*"):

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -19,7 +19,7 @@ def check_null_weight(
     sample_weight: Optional[ArrayLike],
     X: ArrayLike,
     y: ArrayLike
-) -> Tuple[Optional[NDArray], ArrayLike, ArrayLike]:
+) -> Tuple[Optional[ArrayLike], ArrayLike, ArrayLike]:
     """
     Check sample weights and remove samples with null sample weights.
 
@@ -34,7 +34,7 @@ def check_null_weight(
 
     Returns
     -------
-    sample_weight : Optional[NDArray] of shape (n_samples,)
+    sample_weight : Optional[ArrayLike] of shape (n_samples,)
         Non-null sample weights.
 
     X : ArrayLike of shape (n_samples, n_features)

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1,4 +1,3 @@
-from random import sample
 import warnings
 from inspect import signature
 from typing import Any, Iterable, Optional, Tuple, Union, cast
@@ -19,7 +18,7 @@ def check_null_weight(
     sample_weight: Optional[ArrayLike],
     X: ArrayLike,
     y: ArrayLike
-) -> Tuple[Optional[ArrayLike], ArrayLike, ArrayLike]:
+) -> Tuple[Optional[NDArray], ArrayLike, ArrayLike]:
     """
     Check sample weights and remove samples with null sample weights.
 
@@ -34,7 +33,7 @@ def check_null_weight(
 
     Returns
     -------
-    sample_weight : Optional[ArrayLike] of shape (n_samples,)
+    sample_weight : Optional[NDArray] of shape (n_samples,)
         Non-null sample weights.
 
     X : ArrayLike of shape (n_samples, n_features)
@@ -64,11 +63,11 @@ def check_null_weight(
     """
     if sample_weight is not None:
         sample_weight = _check_sample_weight(sample_weight, X)
-        sample_weight = sample_weight[:len(y)]
         non_null_weight = sample_weight != 0
         X = _safe_indexing(X, non_null_weight)
         y = _safe_indexing(y, non_null_weight)
-        sample_weight = sample_weight[non_null_weight]
+        sample_weight = _safe_indexing(sample_weight, non_null_weight)
+    sample_weight = cast(Optional[NDArray], sample_weight)
     return sample_weight, X, y
 
 

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -7,10 +7,10 @@ import numpy as np
 from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.model_selection import BaseCrossValidator, KFold, LeaveOneOut
 from sklearn.utils.validation import (
-    check_array,
+    _check_sample_weight,
     _num_features
 )
-from sklearn.utils import _safe_indexing, column_or_1d
+from sklearn.utils import _safe_indexing
 
 from ._typing import ArrayLike, NDArray
 
@@ -52,7 +52,7 @@ def check_null_weight(
     >>> sample_weight = np.array([0, 1, 1, 1, 1, 1])
     >>> sample_weight, X, y = check_null_weight(sample_weight, X, y)
     >>> print(sample_weight)
-    [1 1 1 1 1]
+    [1. 1. 1. 1. 1.]
     >>> print(X)
     [[1]
      [2]
@@ -63,7 +63,7 @@ def check_null_weight(
     [ 7  9 11 13 15]
     """
     if sample_weight is not None:
-        sample_weight = column_or_1d(sample_weight)
+        sample_weight = _check_sample_weight(sample_weight, X)
         sample_weight = sample_weight[:len(y)]
         non_null_weight = sample_weight != 0
         X = _safe_indexing(X, non_null_weight)

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1,3 +1,4 @@
+from random import sample
 import warnings
 from inspect import signature
 from typing import Any, Iterable, Optional, Tuple, Union, cast
@@ -6,11 +7,10 @@ import numpy as np
 from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.model_selection import BaseCrossValidator, KFold, LeaveOneOut
 from sklearn.utils.validation import (
-    _check_sample_weight,
-    _num_features,
-    column_or_1d
+    check_array,
+    _num_features
 )
-from sklearn.utils import _safe_indexing
+from sklearn.utils import _safe_indexing, column_or_1d
 
 from ._typing import ArrayLike, NDArray
 
@@ -52,7 +52,7 @@ def check_null_weight(
     >>> sample_weight = np.array([0, 1, 1, 1, 1, 1])
     >>> sample_weight, X, y = check_null_weight(sample_weight, X, y)
     >>> print(sample_weight)
-    [1. 1. 1. 1. 1.]
+    [1 1 1 1 1]
     >>> print(X)
     [[1]
      [2]
@@ -63,7 +63,8 @@ def check_null_weight(
     [ 7  9 11 13 15]
     """
     if sample_weight is not None:
-        sample_weight = cast(NDArray, _check_sample_weight(sample_weight, X))
+        sample_weight = column_or_1d(sample_weight)
+        sample_weight = sample_weight[:len(y)]
         non_null_weight = sample_weight != 0
         X = _safe_indexing(X, non_null_weight)
         y = _safe_indexing(y, non_null_weight)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 bump2version==1.0.1
 flake8==4.0.1
-mypy==0.920
+mypy==0.941
 numpydoc==1.1.0
 pandas==1.3.5
 pytest==6.2.5

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ gmartinon@quantmetry.com
 """
 PYTHON_REQUIRES = ">=3.7"
 PACKAGES = find_packages()
-INSTALL_REQUIRES = ["scikit-learn", "numpy>=1.22"]
+INSTALL_REQUIRES = ["scikit-learn"]
 EXTRAS_REQUIRE = {
     "tests": [
         "flake8",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ gmartinon@quantmetry.com
 """
 PYTHON_REQUIRES = ">=3.7"
 PACKAGES = find_packages()
-INSTALL_REQUIRES = ["scikit-learn"]
+INSTALL_REQUIRES = ["scikit-learn", "numpy>=1.22"]
 EXTRAS_REQUIRE = {
     "tests": [
         "flake8",


### PR DESCRIPTION
# Description

Fix typing. Basically, there is now a distinction between `ArrayLike` and `NDArray`, the latter type being compatible with standard numpy methodes such as `.shape`. `ArrayLike` however, is meant to be generic (for example, nested python lists). The `_typing.py` bug is fixed.

Fixes #143 

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All standard tests (see below).

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`