### PR TITLE
157 bug in cifar10 notebook

### DIFF
--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -354,7 +354,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
             err_msg="The sum of the scores is not equal to one.",
             rtol=1e-5
         )
-        return y_pred_proba
+        return y_pred_proba.astype(np.float64)
 
     def _get_last_index_included(
         self,
@@ -554,6 +554,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 estimator.classes_,
                 y_pred_proba
             )
+        y_pred_proba = self._check_proba_normalized(y_pred_proba)
         return y_pred_proba
 
     def _fit_and_predict_oof_model(
@@ -620,6 +621,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
             )
         if _num_samples(X_val) > 0:
             y_pred_proba = self._predict_oof_model(estimator, X_val)
+            y_pred_proba = self._check_proba_normalized(y_pred_proba)
         else:
             y_pred_proba = np.array([])
         val_id = np.full_like(y_val, k, dtype=int)


### PR DESCRIPTION
# Description
Force the predict_proba type to float64 for both prefit and CrossVal methods to enable a good comparison with the quantile

Fixes #157 

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

3 new tests : one for the specific function which force float64 arrays, and two tests of mapie classifier with an example which didn't work will before the change with both prefit and CorssVal methods
