### PR TITLE
solve for machine precision issue

### DIFF
--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -483,7 +483,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         random_state = check_random_state(self.random_state)
         us = random_state.uniform(size=(prediction_sets.shape[0], 1))
         # remove last label from comparison between uniform number and V
-        vs_less_than_us = vs < us
+        vs_less_than_us = np.less_equal(vs - us, EPSILON)
         np.put_along_axis(
             prediction_sets,
             y_pred_index_last,

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -530,9 +530,6 @@ class Float32OuputModel:
     def predict(self, X: NDArray, *args: Any) -> NDArray:
         return np.repeat(1, len(X))
 
-    def _get_param_names(self):
-        return ["prefit"]
-
     def get_params(self, *args: Any, **kwargs: Any):
         return {"prefit": False}
 

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -229,13 +229,13 @@ COVERAGES = {
     "score_cv_crossval": 1,
     "cumulated_score_include": 1,
     "cumulated_score_not_include": 5 / 9,
-    "cumulated_score_randomized": 5 / 9,
+    "cumulated_score_randomized": 6 / 9,
     "cumulated_score_include_cv_mean": 1,
     "cumulated_score_not_include_cv_mean": 5 / 9,
     "cumulated_score_randomized_cv_mean": 5 / 9,
     "cumulated_score_include_cv_crossval": 2 / 9,
     "cumulated_score_not_include_cv_crossval": 0,
-    "cumulated_score_randomized_cv_crossval": 6 / 9,
+    "cumulated_score_randomized_cv_crossval": 4 / 9,
     "naive": 5 / 9,
     "top_k": 1
 }
@@ -307,7 +307,7 @@ y_toy_mapie = {
         [False, True, False],
         [False, True, False],
         [False, True, False],
-        [False, False, True],
+        [False, True, True],
         [False, False, True],
     ],
     "cumulated_score_include_cv_mean": [
@@ -369,11 +369,11 @@ y_toy_mapie = {
         [True, False, False],
         [False, False, False],
         [True, False, False],
-        [True, True, False],
+        [False, True, False],
         [False, True, False],
         [False, True, False],
         [False, True, True],
-        [False, True, True],
+        [False, False, True],
         [False, True, False],
     ],
     "naive": [


### PR DESCRIPTION
# Description
Due to a machine precision problem, the tests would not all pass as we would be using a "<" sign as oppose to `np.less_equal` with the epsilon parameter. This is related to issue #169.

Fixes #(issue)
Changed the method to check if the value were greater or equal than by using the `np.less_equal` with an epsilon parameter as oppose to the "<" sign.

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Check that all tests are passed

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`