### PR TITLE
TypedDict to Dict

### DIFF
--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -125,7 +125,7 @@ class MapieQuantileRegressor(MapieRegressor):
         },
         "LGBMRegressor": {
             "loss_name": "objective",
-            "alpha_name": "alpha"
+            "alpha_name": "reg_alpha"
         },
     }
 

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -125,7 +125,7 @@ class MapieQuantileRegressor(MapieRegressor):
         },
         "LGBMRegressor": {
             "loss_name": "objective",
-            "alpha_name": "reg_alpha"
+            "alpha_name": "alpha"
         },
     }
 

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -11,7 +11,6 @@ from sklearn.utils.validation import (
     _num_samples,
     _check_y,
 )
-from typing_extensions import TypedDict
 
 from ._typing import ArrayLike, NDArray
 from .utils import (
@@ -111,30 +110,23 @@ class MapieQuantileRegressor(MapieRegressor):
         "n_calib_samples",
     ]
 
-    Params = TypedDict(
-        "Params",
-        {
-            "loss_name": str,
-            "alpha_name": str
-        },
-    )
     quantile_estimator_params = {
-        "GradientBoostingRegressor": Params(
-            loss_name="loss",
-            alpha_name="alpha"
-        ),
-        "QuantileRegressor": Params(
-            loss_name="quantile",
-            alpha_name="quantile"
-        ),
-        "HistGradientBoostingRegressor": Params(
-            loss_name="loss",
-            alpha_name="alpha"
-        ),
-        "LGBMRegressor": Params(
-            loss_name="objective",
-            alpha_name="alpha"
-        )
+        "GradientBoostingRegressor": {
+            "loss_name": "loss",
+            "alpha_name": "alpha"
+        },
+        "QuantileRegressor": {
+            "loss_name": "quantile",
+            "alpha_name": "quantile"
+        },
+        "HistGradientBoostingRegressor": {
+            "loss_name": "loss",
+            "alpha_name": "alpha"
+        },
+        "LGBMRegressor": {
+            "loss_name": "objective",
+            "alpha_name": "alpha"
+        },
     }
 
     def __init__(

--- a/mapie/tests/test_quantile_regression.py
+++ b/mapie/tests/test_quantile_regression.py
@@ -159,13 +159,6 @@ def test_no_predict_fit_estimator() -> None:
 
 def test_no_para_loss_estimator() -> None:
     """Test to check when it does not have a valid loss_name."""
-    Params = TypedDict(
-        "Params",
-        {
-            "loss_name": str,
-            "alpha_name": str
-        },
-    )
     with pytest.raises(
         ValueError,
         match=r".*The matching parameter `loss_name`*",
@@ -173,10 +166,10 @@ def test_no_para_loss_estimator() -> None:
         mapie_reg = MapieQuantileRegressor()
         mapie_reg.quantile_estimator_params[
             "NoLossPamameterEstimator"
-        ] = Params(
-            loss_name="noloss",
-            alpha_name="alpha"
-        )
+        ] = {
+            "loss_name": "noloss",
+            "alpha_name": "alpha"
+        }
         mapie_reg.estimator = NoLossPamameterEstimator(
             alpha=0.2
             )
@@ -185,13 +178,6 @@ def test_no_para_loss_estimator() -> None:
 
 def test_no_para_alpha_estimator() -> None:
     """Test to check when it does not have a valid alpha parameter name"""
-    Params = TypedDict(
-        "Params",
-        {
-            "loss_name": str,
-            "alpha_name": str
-        },
-    )
     with pytest.raises(
         ValueError,
         match=r".*The matching parameter `alpha_name`*",
@@ -199,10 +185,10 @@ def test_no_para_alpha_estimator() -> None:
         mapie_reg = MapieQuantileRegressor()
         mapie_reg.quantile_estimator_params[
             "NoAlphaPamameterEstimator"
-        ] = Params(
-            loss_name="loss",
-            alpha_name="notalpha"
-        )
+        ] = {
+            "loss_name": "loss",
+            "alpha_name": "noalpha"
+        }
         mapie_reg.estimator = NoAlphaPamameterEstimator(
             alpha=0.2,
             loss="quantile"


### PR DESCRIPTION
# Description
We had the issue that a `TypedDict` was used in `MapieQuantileRegressor` which therefore lead to the use of `typing_extensions` which is a package that was not automatically downloaded through [setup.py](https://github.com/scikit-learn-contrib/MAPIE/blob/master/setup.py). This is related to Issue #177.

Fixes #(issue)
Make all the `TypedDict` to `Dict` thereby allowing to delete the `typing_extensions` import.

Please remove options that are irrelevant.
- Bug fix (non-breaking change which fixes an issue)


# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`