### PR TITLE
Fix linting problem in `setup.py`

### DIFF
--- a/mapie/__init__.py
+++ b/mapie/__init__.py
@@ -4,4 +4,11 @@ from . import metrics
 
 from ._version import __version__
 
-__all__ = ["regression", "classification", "metrics", "__version__"]
+__all__ = [
+    "regression",
+    "classification",
+    "quantile_regression",
+    "time_series_regression",
+    "metrics",
+    "__version__"
+]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ from setuptools import find_packages, setup
 DISTNAME = "MAPIE"
 VERSION = "0.4.1"
 DESCRIPTION = (
-    "A scikit-learn-compatible module for estimating prediction intervals."
+    "A scikit-learn-compatible module "
+    "for estimating prediction intervals."
 )
 with codecs.open("README.rst", encoding="utf-8-sig") as f:
     LONG_DESCRIPTION = f.read()
@@ -19,7 +20,12 @@ PROJECT_URLS = {
 }
 LICENSE = "new BSD"
 MAINTAINER = "V. Taquet, V. Blot, T. Morzadec, G. Martinon"
-MAINTAINER_EMAIL = "vtaquet@quantmetry.com, vblot@quantmetry.com, tmorzadec@quantmetry.com, gmartinon@quantmetry.com"
+MAINTAINER_EMAIL = (
+    "vtaquet@quantmetry.com, "
+    "vblot@quantmetry.com, "
+    "tmorzadec@quantmetry.com, "
+    "gmartinon@quantmetry.com"
+)
 PYTHON_REQUIRES = ">=3.7"
 PACKAGES = find_packages()
 INSTALL_REQUIRES = ["scikit-learn", "numpy>=1.21", "packaging"]


### PR DESCRIPTION
# Description

Fix the linting problem in `setup.py` when the `MAINTAINER_EMAIL` has been merged in one line

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist

- [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully : `make lint`
- [ ] Typing passes successfully : `make type-check`
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`