### PR TITLE
Update theoretical_description_classification.rst

### DIFF
--- a/doc/theoretical_description_classification.rst
+++ b/doc/theoretical_description_classification.rst
@@ -67,7 +67,7 @@ The conformity scores are computed by summing the ranked scores of each label, f
 label of the observation :
 
 .. math:: 
-   s_i(X_i, Y_i) = \sum^k_{j=1} \hat{\mu}(X_i)_{\pi_j} \quad \text{where} \quad Y_i = \pi_j 
+   s_i(X_i, Y_i) = \sum^k_{j=1} \hat{\mu}(X_i)_{\pi_j} \quad \text{where} \quad Y_i = \pi_k 
 
 
 The quantile :math:`\hat{q}` is then computed the same way as the LABEL method.


### PR DESCRIPTION
# Description
This PR fixes an error in the documentation. Assuming the scores are ranked from highest to lowest until the conformity score of the true label is found, then the true label Yᵢ should be equal to  πₖ (the last label to be included), not πⱼ. j is a running index, so  Yᵢ  cannot be equal to πⱼ for all j from 1 to k.

## Type of change

- This change requires a documentation update

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Documentation builds successfully : `make doc`