### PR TITLE
Added binary classification support to MAPIE using the mondrian conformal predictor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ doc/datasets/generated/
 doc/generated/
 
 # Distribution / packaging
-
+mapieenv
 .Python
 env/
 build/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,4 +24,5 @@ Contributors
 * Louis Lacombe <llacombe@quantmetry.com>
 * Arnaud Capitaine <arnaud.gc.capitaine@gmail.com>
 * Tarik Tazi <ttazi@quantmetry.com>
+* Matthias Adamsen <matthiasadamsen@gmail.com>
 To be continued ...

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: tests doc build
 
 lint:	
-	flake8 . --exclude=doc
+	flake8 . --exclude=doc mapieenv
 
 type-check:
 	mypy mapie

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: tests doc build
 
 lint:	
-	flake8 . --exclude=doc mapieenv
+	flake8 . --exclude=doc,mapieenv
 
 type-check:
 	mypy mapie

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1263,6 +1263,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                         alpha_np
                     )
                 elif self.method == "mondrian":
+
                     self.quantiles_ = compute_quantiles(
                         self.conformity_scores_,
                         alpha_np,
@@ -1281,6 +1282,10 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         # Build prediction sets
         if self.method == "score":
             if (cv == "prefit") or (agg_scores == "mean"):
+                print("y proba shape")
+                print(y_pred_proba.shape)
+                print("quantiles shape")
+                print(self.quantiles_.shape)
                 prediction_sets = np.greater_equal(
                     y_pred_proba - (1 - self.quantiles_), -EPSILON
                 )
@@ -1368,11 +1373,12 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 -EPSILON
             )
         elif self.method == "mondrian": #TODO:
-            print(y_pred_proba)
-            print(y_pred_proba.shape)
-            prediction_sets = np.greater_equal(
+            self.quantiles_ = np.transpose(self.quantiles_,[1,0])
+
+            prediction_sets = (np.greater_equal(
                 y_pred_proba,self.quantiles_
-            )
+            ))
+            
             
             
         else:
@@ -1380,4 +1386,5 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 "Invalid method. "
                 "Allowed values are 'score' or 'cumulated_score'."
             )
+        print(prediction_sets)
         return y_pred, prediction_sets

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1003,7 +1003,11 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
 
         X, y = indexable(X, y)
         y = _check_y(y)
-        assert type_of_target(y) == "multiclass"
+        if type_of_target(y) != "multiclass" and self.method != "mondrian":
+            raise ValueError(
+                "Invalid method. "
+                "Binary classification problems require the mondrian method. "
+            )
         sample_weight, X, y = check_null_weight(sample_weight, X, y)
         y = cast(NDArray, y)
         n_samples = _num_samples(y)
@@ -1352,6 +1356,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 - y_pred_proba_last,
                 -EPSILON
             )
+        elif self.
         else:
             raise ValueError(
                 "Invalid method. "

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -167,7 +167,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
      [False False  True]]
     """
 
-    valid_methods_ = ["naive", "score", "cumulated_score", "top_k", "raps"]
+    valid_methods_ = ["naive", "score", "cumulated_score", "top_k", "raps","mondrian"]
     fit_attributes = [
         "single_estimator_",
         "estimators_",
@@ -1081,6 +1081,9 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
             self.conformity_scores_ = np.take_along_axis(
                 1 - y_pred_proba, y.reshape(-1, 1), axis=1
             )
+        elif self.method == "mondrian":
+            self.conformity_scores_ = 1-y_pred_proba
+
         elif self.method in ["cumulated_score", "raps"]:
             self.conformity_scores_, self.cutoff = (
                 self._get_true_label_cumsum_proba(
@@ -1227,7 +1230,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         check_alpha_and_n_samples(alpha_np, n)
 
         if self.method == "naive":
-            self.quantiles_ = 1 - alpha_np
+            self.quantiles_ = 1 - alpha_np 
         else:
             if (cv == "prefit") or (agg_scores in ["mean"]):
                 if self.method == "raps":
@@ -1356,7 +1359,12 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 - y_pred_proba_last,
                 -EPSILON
             )
-        elif self.
+        elif self.method == "mondrian": #TODO:
+            prediction_sets = np.greater_equal(
+                y_pred_proba,self.quantiles_
+            )
+            
+            
         else:
             raise ValueError(
                 "Invalid method. "

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1263,10 +1263,12 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                         alpha_np
                     )
                 else:
+                    print("1")
                     self.quantiles_ = compute_quantiles(
                         self.conformity_scores_,
                         alpha_np
                     )
+                    print("2")
             else:
                 self.quantiles_ = (n + 1) * (1 - alpha_np)
 

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -167,7 +167,13 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
      [False False  True]]
     """
 
-    valid_methods_ = ["naive", "score", "cumulated_score", "top_k", "raps","mondrian"]
+    valid_methods_ = ["naive",
+                      "score",
+                      "cumulated_score",
+                      "top_k",
+                      "raps",
+                      "mondrian"
+                      ]
     fit_attributes = [
         "single_estimator_",
         "estimators_",
@@ -1230,7 +1236,7 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         check_alpha_and_n_samples(alpha_np, n)
 
         if self.method == "naive":
-            self.quantiles_ = 1 - alpha_np 
+            self.quantiles_ = 1 - alpha_np
         else:
             if (cv == "prefit") or (agg_scores in ["mean"]):
                 if self.method == "raps":
@@ -1267,15 +1273,15 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                     self.quantiles_ = compute_quantiles(
                         self.conformity_scores_,
                         alpha_np,
-                        mondrian = True
+                        mondrian=True
                     )
                 else:
-                    
+
                     self.quantiles_ = compute_quantiles(
                         self.conformity_scores_,
                         alpha_np
                     )
-                    
+
             else:
                 self.quantiles_ = (n + 1) * (1 - alpha_np)
 
@@ -1368,15 +1374,14 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 - y_pred_proba_last,
                 -EPSILON
             )
-        elif self.method == "mondrian": #TODO:
-            self.quantiles_ = np.transpose(self.quantiles_,[1,0])
+        elif self.method == "mondrian":
+            self.quantiles_ = np.transpose(self.quantiles_, [1, 0])
 
             prediction_sets = np.greater_equal(
-            y_pred_proba - (1 - self.quantiles_), -EPSILON
+                y_pred_proba - (1 - self.quantiles_),
+                -EPSILON
             )
-            
-            
-            
+
         else:
             raise ValueError(
                 "Invalid method. "

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1262,13 +1262,19 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                         self.conformity_scores_regularized,
                         alpha_np
                     )
+                elif self.method == "mondrian":
+                    self.quantiles_ = compute_quantiles(
+                        self.conformity_scores_,
+                        alpha_np,
+                        mondrian = True
+                    )
                 else:
-                    print("1")
+                    
                     self.quantiles_ = compute_quantiles(
                         self.conformity_scores_,
                         alpha_np
                     )
-                    print("2")
+                    
             else:
                 self.quantiles_ = (n + 1) * (1 - alpha_np)
 
@@ -1362,6 +1368,8 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 -EPSILON
             )
         elif self.method == "mondrian": #TODO:
+            print(y_pred_proba)
+            print(y_pred_proba.shape)
             prediction_sets = np.greater_equal(
                 y_pred_proba,self.quantiles_
             )

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1282,10 +1282,6 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         # Build prediction sets
         if self.method == "score":
             if (cv == "prefit") or (agg_scores == "mean"):
-                print("y proba shape")
-                print(y_pred_proba.shape)
-                print("quantiles shape")
-                print(self.quantiles_.shape)
                 prediction_sets = np.greater_equal(
                     y_pred_proba - (1 - self.quantiles_), -EPSILON
                 )
@@ -1375,9 +1371,9 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
         elif self.method == "mondrian": #TODO:
             self.quantiles_ = np.transpose(self.quantiles_,[1,0])
 
-            prediction_sets = (np.greater_equal(
-                y_pred_proba,self.quantiles_
-            ))
+            prediction_sets = np.greater_equal(
+            y_pred_proba - (1 - self.quantiles_), -EPSILON
+            )
             
             
             
@@ -1386,5 +1382,4 @@ class MapieClassifier(BaseEstimator, ClassifierMixin):
                 "Invalid method. "
                 "Allowed values are 'score' or 'cumulated_score'."
             )
-        print(prediction_sets)
         return y_pred, prediction_sets

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -22,7 +22,7 @@ from mapie.classification import MapieClassifier
 from mapie.metrics import classification_coverage_score
 from mapie.utils import check_alpha
 
-METHODS = ["score", "cumulated_score", "raps"]
+METHODS = ["score", "cumulated_score", "raps","mondrian"]
 WRONG_METHODS = ["scores", "cumulated", "test", "", 1, 2.5, (1, 2)]
 WRONG_INCLUDE_LABELS = ["randomised", "True", "False", "other", 1, 2.5, (1, 2)]
 Y_PRED_PROBA_WRONG = [
@@ -257,6 +257,17 @@ STRATEGIES = {
             method="raps",
             cv="prefit",
             random_state=42
+        ),
+        ParamsPredict(
+            include_last_label="randomized",
+            agg_scores="mean"
+        )
+    ),
+    "mondrian": (
+        Params(
+            method="mondrian",
+            cv="prefit",
+            random_state=None
         ),
         ParamsPredict(
             include_last_label="randomized",

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -292,7 +292,8 @@ COVERAGES = {
     "naive": 5 / 9,
     "top_k": 1,
     "raps": 1,
-    "raps_randomized": 8/9
+    "raps_randomized": 8/9,
+    "mondrian": 1
 }
 
 X_toy = np.arange(9).reshape(-1, 1)
@@ -472,6 +473,17 @@ y_toy_mapie = {
         [False, True, False],
         [False, True, False],
         [False, True, False],
+        [False, True, True],
+        [False, False, True],
+    ],
+    "mondrian": [
+        [True, False, False],
+        [True, False, False],
+        [True, True, False],
+        [True, True, True],
+        [True, True, True],
+        [True, True, True],
+        [False, True, True],
         [False, True, True],
         [False, False, True],
     ],
@@ -875,7 +887,8 @@ def test_toy_dataset_predictions(strategy: str) -> None:
         alpha=0.5,
         include_last_label=args_predict["include_last_label"],
         agg_scores=args_predict["agg_scores"]
-    )
+    ) 
+
     np.testing.assert_allclose(y_ps[:, :, 0], y_toy_mapie[strategy])
     np.testing.assert_allclose(
         classification_coverage_score(y_toy, y_ps[:, :, 0]),

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -22,7 +22,7 @@ from mapie.classification import MapieClassifier
 from mapie.metrics import classification_coverage_score
 from mapie.utils import check_alpha
 
-METHODS = ["score", "cumulated_score", "raps","mondrian"]
+METHODS = ["score", "cumulated_score", "raps", "mondrian"]
 WRONG_METHODS = ["scores", "cumulated", "test", "", 1, 2.5, (1, 2)]
 WRONG_INCLUDE_LABELS = ["randomised", "True", "False", "other", 1, 2.5, (1, 2)]
 Y_PRED_PROBA_WRONG = [
@@ -887,7 +887,7 @@ def test_toy_dataset_predictions(strategy: str) -> None:
         alpha=0.5,
         include_last_label=args_predict["include_last_label"],
         agg_scores=args_predict["agg_scores"]
-    ) 
+    )
 
     np.testing.assert_allclose(y_ps[:, :, 0], y_toy_mapie[strategy])
     np.testing.assert_allclose(

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -616,7 +616,7 @@ def check_alpha_and_last_axis(vector: NDArray, alpha_np: NDArray):
         return vector, alpha_np
 
 
-def compute_quantiles(vector: NDArray, alpha: NDArray) -> NDArray:
+def compute_quantiles(vector: NDArray, alpha: NDArray,mondrian = False) -> NDArray:
     """Compute the desired quantiles of a vector.
 
     Parameters
@@ -634,15 +634,23 @@ def compute_quantiles(vector: NDArray, alpha: NDArray) -> NDArray:
         Quantiles of the vector.
     """
     n = len(vector)
-    if len(vector.shape) <= 2:
+    if len(vector.shape) <= 2 and not mondrian:
+        quantiles_ = np.stack([
+                    np_quantile(
+                        vector,
+                        ((n + 1) * (1 - _alpha)) / n,
+                        method="higher"
+                    ) for _alpha in alpha
+        ])
+    elif len(vector.shape) <= 2 and mondrian:
         quantiles_ = np.stack([
                     np_quantile(
                         vector,
                         ((n + 1) * (1 - _alpha)) / n,
                         method="higher",
+                        axis=1
                     ) for _alpha in alpha
         ])
-
     else:
         check_alpha_and_last_axis(vector, alpha)
         quantiles_ = np.stack(

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -616,7 +616,9 @@ def check_alpha_and_last_axis(vector: NDArray, alpha_np: NDArray):
         return vector, alpha_np
 
 
-def compute_quantiles(vector: NDArray, alpha: NDArray,mondrian = False) -> NDArray:
+def compute_quantiles(vector: NDArray,
+                      alpha: NDArray,
+                      mondrian=False) -> NDArray:
     """Compute the desired quantiles of a vector.
 
     Parameters

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -648,7 +648,7 @@ def compute_quantiles(vector: NDArray, alpha: NDArray,mondrian = False) -> NDArr
                         vector,
                         ((n + 1) * (1 - _alpha)) / n,
                         method="higher",
-                        axis=1
+                        axis=0
                     ) for _alpha in alpha
         ])
     else:


### PR DESCRIPTION
# Description

Mapie was unable to perform confidence estimation on binary classification problems. To address this issue, I have implemented the mondrian conformal as a method of the MapieClassifier. This method is described in detail on page 5 of [this ](https://arxiv.org/ftp/arxiv/papers/1908/1908.03569.pdf) paper, but in essence it uses the quantiles of each class to determine inclusion in the prediction set, as opposed to one quantile found from both classes. This method is not constrained to binary classification, and should work for imbalanced multiclass problems as well.

Closes #216 

## Type of change

Please remove options that are irrelevant.


- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the make test command, and all tests passed

I also tested the changes on a workflow where mapie was included, and altering the method to mondrian gave similar results.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`

I do unfortunately not have much experience writing tests, and do not know the best way to do this, so if anyone can assist on that front with help or advice I would be grateful.