### PR TITLE
Fixes failed estimator checks for MapieTimeSeriesRegressor

### DIFF
--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -7,6 +7,7 @@ import pytest
 from sklearn.datasets import make_regression
 from sklearn.linear_model import LinearRegression
 from sklearn.model_selection import KFold, LeaveOneOut, train_test_split
+from sklearn.utils.estimator_checks import check_estimator
 from typing_extensions import TypedDict
 
 from mapie._typing import NDArray
@@ -79,6 +80,10 @@ COVERAGES = {
     "prefit": 0.98,
 
 }
+
+
+def test_sklearn_checks() -> None:
+    check_estimator(MapieTimeSeriesRegressor())
 
 
 @pytest.mark.parametrize("agg_function", ["dummy", 0, 1, 2.5, [1, 2]])

--- a/mapie/time_series_regression.py
+++ b/mapie/time_series_regression.py
@@ -269,12 +269,12 @@ class MapieTimeSeriesRegressor(MapieRegressor):
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)
 
         return y_pred, np.stack([y_pred_low, y_pred_up], axis=1)
-    
+
     def _more_tags(self):
         return {
-            "_xfail_checks": 
+            "_xfail_checks":
             {
-                "check_estimators_partial_fit_n_features": 
+                "check_estimators_partial_fit_n_features":
                 "partial_fit() can only be called on fitted models"
             }
         }

--- a/mapie/time_series_regression.py
+++ b/mapie/time_series_regression.py
@@ -32,6 +32,10 @@ class MapieTimeSeriesRegressor(MapieRegressor):
     https://arxiv.org/abs/2010.09107
     """
 
+    cv_need_agg_function = ["Subsample", "BlockBootstrap"]
+    valid_methods_ = ["enbpi"]
+    plus_like_method = ["plus", "enbpi"]
+
     def __init__(
         self,
         estimator: Optional[RegressorMixin] = None,
@@ -42,9 +46,6 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         verbose: int = 0,
     ) -> None:
         super().__init__(estimator, method, cv, n_jobs, agg_function, verbose)
-        self.cv_need_agg_function.append("BlockBootstrap")
-        self.valid_methods_ = ["enbpi"]
-        self.plus_like_method.append("enbpi")
 
     def _relative_conformity_scores(
         self,
@@ -182,6 +183,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         ValueError
             If the length of y is greater than the length of the training set.
         """
+        check_is_fitted(self, self.fit_attributes)
         X = cast(NDArray, X)
         y = cast(NDArray, y)
         n = len(self.conformity_scores_)
@@ -267,3 +269,12 @@ class MapieTimeSeriesRegressor(MapieRegressor):
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)
 
         return y_pred, np.stack([y_pred_low, y_pred_up], axis=1)
+    
+    def _more_tags(self):
+        return {
+            "_xfail_checks": 
+            {
+                "check_estimators_partial_fit_n_features": 
+                "partial_fit() can only be called on fitted models"
+            }
+        }


### PR DESCRIPTION
# Description

Fixes [Issue #273](https://github.com/scikit-learn-contrib/MAPIE/issues/273)

- Definition of non-parameter attributes in `MapieTimeSeriesRegressor` is moved to the class body according to `scikit-learn` convention
- `partial_fit` sklearn estimator check is marked as expected fail for now. While this is a temporary solution, I would rather rename the conformity score update on the long term.
- Add test that runs sklearn `check_estimator` for `MapieTimeSeriesRegressor`.

## Type of change

Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`