### PR TITLE
ENH: Fix inconsistency in setup.py

### DIFF
--- a/requirements.doc.txt
+++ b/requirements.doc.txt
@@ -1,8 +1,8 @@
-lightgbm=3.2.1
-matplotlib=3.5.1
-numpydoc=1.1.0
-pandas=1.3.5
-sphinx=4.3.2
-sphinx-gallery=0.10.1
-sphinx_rtd_theme=1.0.0
-typing_extensions=4.0.1
+lightgbm==3.2.1
+matplotlib==3.5.1
+numpydoc==1.1.0
+pandas==1.3.5
+sphinx==4.3.2
+sphinx-gallery==0.10.1
+sphinx_rtd_theme==1.0.0
+typing_extensions==4.0.1

--- a/requirements.doc.txt
+++ b/requirements.doc.txt
@@ -1,0 +1,8 @@
+lightgbm=3.2.1
+matplotlib=3.5.1
+numpydoc=1.1.0
+pandas=1.3.5
+sphinx=4.3.2
+sphinx-gallery=0.10.1
+sphinx_rtd_theme=1.0.0
+typing_extensions=4.0.1

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,0 +1,7 @@
+codecov
+flake8
+mypy
+pandas
+pytest
+pytest-cov
+typed-ast

--- a/setup.py
+++ b/setup.py
@@ -29,25 +29,6 @@ MAINTAINER_EMAIL = (
 PYTHON_REQUIRES = ">=3.7"
 PACKAGES = find_packages()
 INSTALL_REQUIRES = ["scikit-learn", "numpy>=1.21", "packaging"]
-EXTRAS_REQUIRE = {
-    "tests": [
-        "flake8",
-        "mypy",
-        "pandas",
-        "pytest",
-        "pytest-cov",
-        "typed-ast"
-    ],
-    "docs": [
-        "matplotlib",
-        "numpydoc",
-        "pandas",
-        "sphinx",
-        "sphinx-gallery",
-        "sphinx_rtd_theme",
-        "typing_extensions"
-    ]
-}
 CLASSIFIERS = [
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
@@ -79,7 +60,6 @@ setup(
     packages=PACKAGES,
     python_requires=PYTHON_REQUIRES,
     install_requires=INSTALL_REQUIRES,
-    extras_require=EXTRAS_REQUIRE,
     classifiers=CLASSIFIERS,
     zip_safe=False  # the package can run out of an .egg file
 )


### PR DESCRIPTION
# Description  

The file setup.py contains 'tests' and 'doc' extras which are not designed for the final user. It would be better if these libraries were the subject of separates requirements.***.txt, similarly to what is done for requirements.dev.txt.  

Fixes #272  

## Type of change  

Bug fix (non-breaking change which fixes an issue)  

# How Has This Been Tested?  

There should be no impact on the behavior of the code since this modification only affects the working environment in test and doc configuration.   

Following the checklist will be sufficient.  

# Checklist  

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst) 
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files 
- [ ] Linting passes successfully : `make lint` 
- [ ] Typing passes successfully : `make type-check` 
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage (to be fixed in another PR) : `make coverage`
- [ ] Documentation builds successfully : `make doc`