### PR TITLE
UPD: docstring of regression classes

### DIFF
--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -25,7 +25,7 @@ class MapieQuantileRegressor(MapieRegressor):
     """
     This class implements the conformalized quantile regression strategy
     as proposed by Romano et al. (2019) to make conformal predictions.
-    The only valid ``method`` is ``"quantile"`` and the only valid default
+    The only valid ``method`` is ``"quantile"`` and the only valid
     ``cv`` is ``"split"``.
 
     Parameters
@@ -73,11 +73,11 @@ class MapieQuantileRegressor(MapieRegressor):
         - [2]: Estimator with quantile value of 0.5
 
     conformity_scores_: NDArray of shape (n_samples_train, 3)
-        Conformity scores between ``y_calib`` and ``y_pred``:
+        Conformity scores between ``y_calib`` and ``y_pred``.
             - [:, 0]: for ``y_calib`` coming from prediction estimator
-            with quantile of alpha/2
+                with quantile of alpha/2
             - [:, 1]: for ``y_calib`` coming from prediction estimator
-            with quantile of 1 - alpha/2
+                with quantile of 1 - alpha/2
             - [:, 2]: maximum of those first two scores
 
     n_calib_samples: int
@@ -519,14 +519,13 @@ class MapieQuantileRegressor(MapieRegressor):
         shuffle: bool, default=True
             For the ``sklearn.model_selection.train_test_split`` documentation.
             Whether or not to shuffle the data before splitting.
-            If shuffle=False
-            then stratify must be None.
+            If ``shuffle=False`` then stratify must be None.
 
             By default ``True``.
 
         stratify: array-like, default=None
             For the ``sklearn.model_selection.train_test_split`` documentation.
-            If not `None``, data is split in a stratified fashion, using this
+            If not ``None``, data is split in a stratified fashion, using this
             as the class labels.
             Read more in the :ref:`User Guide <stratification>`.
 
@@ -667,7 +666,7 @@ class MapieQuantileRegressor(MapieRegressor):
         - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
 
         - Tuple[NDArray, NDArray] of shapes (n_samples,) and
-          (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
+            (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
 
             - [:, 0, :]: Lower bound of the prediction interval.
             - [:, 1, :]: Upper bound of the prediction interval.

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -74,6 +74,7 @@ class MapieQuantileRegressor(MapieRegressor):
 
     conformity_scores_: NDArray of shape (n_samples_train, 3)
         Conformity scores between ``y_calib`` and ``y_pred``.
+
         - [:, 0]: for ``y_calib`` coming from prediction estimator
           with quantile of alpha/2
         - [:, 1]: for ``y_calib`` coming from prediction estimator

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -25,53 +25,59 @@ class MapieQuantileRegressor(MapieRegressor):
     """
     This class implements the conformalized quantile regression strategy
     as proposed by Romano et al. (2019) to make conformal predictions.
-    The only valid ``method`` is "quantile" and the only valid default
-    ``cv`` is "split".
+    The only valid ``method`` is ``"quantile"`` and the only valid default
+    ``cv`` is ``"split"``.
 
     Parameters
     ----------
     estimator : Optional[RegressorMixin]
         Any regressor with scikit-learn API
-        (i.e. with fit and predict methods), by default ``None``.
+        (i.e. with ``fit`` and ``predict`` methods).
         If ``None``, estimator defaults to a ``QuantileRegressor`` instance.
+
+        By default ``"None"``.
 
     method: str
         Method to choose for prediction, in this case, the only valid method
-        is the "quantile" method.
+        is the ``"quantile"`` method.
+
+        By default ``"quantile"``.
 
     cv: Optional[str]
-        By default the value is set to None. In theory a split method is
-        implemented as it is needed to provided both a training and calibration
-        set.
+        The cross-validation strategy for computing conformity scores.
+        In theory a split method is implemented as it is needed to provided
+        both a training and calibration set.
+
+        By default ``None``.
 
     alpha: float
-        Between 0 and 1.0, represents the risk level of the confidence
-        interval.
+        Between ``0.0`` and ``1.0``, represents the risk level of the
+        confidence interval.
         Lower ``alpha`` produce larger (more conservative) prediction
         intervals.
         ``alpha`` is the complement of the target coverage level.
 
-        By default 0.1.
+        By default ``0.1``.
 
     Attributes
     ----------
-    valid_methods: List[str]
+    valid_methods_: List[str]
         List of all valid methods.
 
     single_estimator_: RegressorMixin
         Estimator fitted on the whole training set.
 
-    estimators_ : List[RegressorMixin]
+    estimators_: List[RegressorMixin]
         - [0]: Estimator with quantile value of alpha/2
         - [1]: Estimator with quantile value of 1 - alpha/2
         - [2]: Estimator with quantile value of 0.5
 
-    conformity_scores_ : NDArray of shape (n_samples_train, 3)
+    conformity_scores_: NDArray of shape (n_samples_train, 3)
         Conformity scores between ``y_calib`` and ``y_pred``:
-            - [:, 0]: for y_calib coming from prediction estimator with
-            quantile of alpha/2
-            - [:, 1]: for y_calib coming from prediction estimator with
-            quantile of 1 - alpha/2
+            - [:, 0]: for ``y_calib`` coming from prediction estimator
+            with quantile of alpha/2
+            - [:, 1]: for ``y_calib`` coming from prediction estimator
+            with quantile of 1 - alpha/2
             - [:, 2]: maximum of those first two scores
 
     n_calib_samples: int
@@ -165,11 +171,12 @@ class MapieQuantileRegressor(MapieRegressor):
         Parameters
         ----------
         alpha : float
-            Can only be a float value between 0 and 1.0.
+            Can only be a float value between ``0.0`` and ``1.0``.
             Represent the risk level of the confidence interval.
             Lower alpha produce larger (more conservative) prediction
             intervals. Alpha is the complement of the target coverage level.
-            By default 0.1
+
+            By default ``0.1``.
 
         Returns
         -------
@@ -184,8 +191,9 @@ class MapieQuantileRegressor(MapieRegressor):
         ------
         ValueError
             If alpha is not a float.
+
         ValueError
-            If the value of alpha is not between 0 and 1.0.
+            If the value of ``alpha`` is not between ``0.0`` and ``1.0``.
         """
         if self.cv == "prefit":
             warnings.warn(
@@ -196,7 +204,7 @@ class MapieQuantileRegressor(MapieRegressor):
         if isinstance(alpha, float):
             if np.any(np.logical_or(alpha <= 0, alpha >= 1.0)):
                 raise ValueError(
-                    "Invalid alpha. Allowed values are between 0 and 1.0."
+                    "Invalid alpha. Allowed values are between 0.0 and 1.0."
                 )
             else:
                 alpha_np = np.array([alpha / 2, 1 - alpha / 2, 0.5])
@@ -214,9 +222,9 @@ class MapieQuantileRegressor(MapieRegressor):
         Perform several checks on the estimator to check if it has
         all the required specifications to be used with this methodology.
         The estimators that can be used in MapieQuantileRegressor need to
-        have a ``fit`` and ``predict``attribute, but also need to allow
+        have a ``fit`` and ``predict`` attribute, but also need to allow
         a quantile loss and therefore also setting a quantile value.
-        Note that there is a TypedDict to check which methods allow for
+        Note that there is a ``TypedDict`` to check which methods allow for
         quantile regression.
 
         Parameters
@@ -233,18 +241,22 @@ class MapieQuantileRegressor(MapieRegressor):
         Raises
         ------
         ValueError
-            If the estimator fit or predict methods.
+            If the estimator implements ``fit`` or ``predict`` methods.
+
         ValueError
             We check if it's a known estimator that does quantile regression
             according to the dictionnary set quantile_estimator_params.
             This dictionnary will need to be updated with the latest new
             available estimators.
+
         ValueError
-            The estimator does not have the "loss_name" in its parameters and
-            therefore can not be used as an estimator.
+            The estimator does not have the ``"loss_name"`` in its parameters
+            and therefore can not be used as an estimator.
+
         ValueError
-            There is no quantile "loss_name" and therefore this estimator
+            There is no quantile ``"loss_name"`` and therefore this estimator
             can not be used as a ``MapieQuantileRegressor``.
+
         ValueError
             The parameter to set the alpha value does not exist in this
             estimator and therefore we cannot use it.
@@ -294,7 +306,7 @@ class MapieQuantileRegressor(MapieRegressor):
                         "The base model does not seem to be accepted"
                         + " by MapieQuantileRegressor. \n"
                         "Give a base model among: \n"
-                        "``quantile_estimator_params.keys()``"
+                        f"{self.quantile_estimator_params.keys()} "
                         "Or, add your base model to"
                         + " ``quantile_estimator_params``."
                     )
@@ -304,7 +316,7 @@ class MapieQuantileRegressor(MapieRegressor):
         cv: Optional[str] = None
     ) -> str:
         """
-        Check if cv argument is None, "split" or "prefit".
+        Check if cv argument is ``None``, ``"split"`` or ``"prefit"``.
 
         Parameters
         ----------
@@ -314,13 +326,13 @@ class MapieQuantileRegressor(MapieRegressor):
         Returns
         -------
         str
-            cv itself or a default "split".
+            cv itself or a default ``"split"``.
 
         Raises
         ------
         ValueError
-            Raises an error if the cv is anything else but the method "split"
-            or "prefit.
+            Raises an error if the cv is anything else but the method
+            ``"split"`` or ``"prefit"``.
             Only the split method has been implemented.
         """
         if cv is None:
@@ -348,7 +360,7 @@ class MapieQuantileRegressor(MapieRegressor):
     ]:
         """
         Check if a calibration set has already been defined, if not, then
-        we define one using the `train_test_split` method.
+        we define one using the ``train_test_split`` method.
 
         Parameters
         ----------
@@ -367,7 +379,6 @@ class MapieQuantileRegressor(MapieRegressor):
                 y_calib
             - [4]: ArrayLike of shape (n_samples_,)
                 sample_weight_train
-
         """
         if X_calib is None or y_calib is None:
             if sample_weight is None:
@@ -417,25 +428,15 @@ class MapieQuantileRegressor(MapieRegressor):
         estimator : List[Union[RegressorMixin, Pipeline]]
             List of three prefitted estimators that should have
             pre-defined quantile levels of alpha/2, 1 - alpha/2 and 0.5.
-        X : ArrayLike of shape (n_samples, n_features)
-            Training data.
-        y : ArrayLike of shape (n_samples,)
-            Training labels.
-        X_calib : Optional[ArrayLike] of shape (n_calib_samples, n_features)
-            Calibration data.
-        y_calib : Optional[ArrayLike] of shape (n_calib_samples,)
-            Calibration labels.
 
         Raises
         ------
         ValueError
             If a non-iterable variable is provided for estimator.
+
         ValueError
             If less or more than three models are defined.
-        Warning
-            If X and y are defined, then warning that they are not used.
-        ValueError
-            If the calibration set is not defined.
+
         Warning
             If the alpha is defined, warns the user that it must be set
             accordingly with the prefit estimators.
@@ -450,10 +451,10 @@ class MapieQuantileRegressor(MapieRegressor):
                 check_is_fitted(est)
         else:
             raise ValueError(
-                    "You need to have provided 3 different estimators, they"
-                    " need to be preset with alpha values in the following"
-                    " order [alpha/2, 1 - alpha/2, 0.5]."
-                    )
+                "You need to have provided 3 different estimators, they"
+                " need to be preset with alpha values in the following"
+                " order [alpha/2, 1 - alpha/2, 0.5]."
+            )
 
     def fit(
         self,
@@ -463,7 +464,7 @@ class MapieQuantileRegressor(MapieRegressor):
         X_calib: Optional[ArrayLike] = None,
         y_calib: Optional[ArrayLike] = None,
         calib_size: Optional[float] = 0.3,
-        random_state: Optional[Union[int, np.random.RandomState, None]] = None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
         shuffle: Optional[bool] = True,
         stratify: Optional[ArrayLike] = None,
     ) -> MapieQuantileRegressor:
@@ -477,43 +478,59 @@ class MapieQuantileRegressor(MapieRegressor):
 
         Parameters
         ----------
-        X : ArrayLike of shape (n_samples, n_features)
+        X: ArrayLike of shape (n_samples, n_features)
             Training data.
-        y : ArrayLike of shape (n_samples,)
+
+        y: ArrayLike of shape (n_samples,)
             Training labels.
-        sample_weight : Optional[ArrayLike] of shape (n_samples,)
+
+        sample_weight: Optional[ArrayLike] of shape (n_samples,)
             Sample weights for fitting the out-of-fold models.
-            If None, then samples are equally weighted.
+            If ``None``, then samples are equally weighted.
             If some weights are null,
             their corresponding observations are removed
             before the fitting process and hence have no residuals.
             If weights are non-uniform, residuals are still uniformly weighted.
             Note that the sample weight defined are only for the training, not
             for the calibration procedure.
+
             By default ``None``.
-        X_calib : Optional[ArrayLike] of shape (n_calib_samples, n_features)
+
+        X_calib: Optional[ArrayLike] of shape (n_calib_samples, n_features)
             Calibration data.
-        y_calib : Optional[ArrayLike] of shape (n_calib_samples,)
+
+        y_calib: Optional[ArrayLike] of shape (n_calib_samples,)
             Calibration labels.
-        calib_size : Optional[float]
-            If X_calib and y_calib are not defined, then the calibration
-            dataset is created with the split defined by calib_size.
-        random_state : int, RandomState instance or None, default=None
+
+        calib_size: Optional[float]
+            If ``X_calib`` and ``y_calib`` are not defined,
+            then the calibration dataset is created with the split
+            defined by ``calib_size``.
+
+        random_state: Optional[Union[int, np.random.RandomState]], default=None
             For the ``sklearn.model_selection.train_test_split`` documentation.
             Controls the shuffling applied to the data before applying the
             split.
             Pass an int for reproducible output across multiple function calls.
             See :term:`Glossary <random_state>`.
-        shuffle : bool, default=True
+
+            By default ``None``.
+
+        shuffle: bool, default=True
             For the ``sklearn.model_selection.train_test_split`` documentation.
             Whether or not to shuffle the data before splitting.
             If shuffle=False
             then stratify must be None.
-        stratify : array-like, default=None
+
+            By default ``True``.
+
+        stratify: array-like, default=None
             For the ``sklearn.model_selection.train_test_split`` documentation.
-            If not None, data is split in a stratified fashion, using this as
-            the class labels.
+            If not `None``, data is split in a stratified fashion, using this
+            as the class labels.
             Read more in the :ref:`User Guide <stratification>`.
+
+            By default ``None``.
 
         Returns
         -------
@@ -627,15 +644,18 @@ class MapieQuantileRegressor(MapieRegressor):
 
         Parameters
         ----------
-        X : ArrayLike of shape (n_samples, n_features)
+        X: ArrayLike of shape (n_samples, n_features)
             Test data.
-        ensemble : bool
+
+        ensemble: bool
             Ensemble has not been defined in predict and therefore should
             will not have any effects in this method.
-        alpha : Optional[Union[float, Iterable[float]]]
+
+        alpha: Optional[Union[float, Iterable[float]]]
             For ``MapieQuantileRegresor`` the alpha has to be defined
             directly in initial arguments of the class.
-        symmetry : Optional[bool], optional
+
+        symmetry: Optional[bool]
             Deciding factor to whether to find the quantile value for
             each residuals separatly or to use the maximum of the two
             combined.
@@ -644,10 +664,10 @@ class MapieQuantileRegressor(MapieRegressor):
         -------
         Union[NDArray, Tuple[NDArray, NDArray]]
 
-        - NDArray of shape (n_samples,) if alpha is None.
+        - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
 
-        - Tuple[NDArray, NDArray] of shapes
-        (n_samples,) and (n_samples, 2, n_alpha) if alpha is not None.
+        - Tuple[NDArray, NDArray] of shapes (n_samples,) and
+          (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
 
             - [:, 0, :]: Lower bound of the prediction interval.
             - [:, 1, :]: Upper bound of the prediction interval.

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -74,11 +74,11 @@ class MapieQuantileRegressor(MapieRegressor):
 
     conformity_scores_: NDArray of shape (n_samples_train, 3)
         Conformity scores between ``y_calib`` and ``y_pred``.
-            - [:, 0]: for ``y_calib`` coming from prediction estimator
-                with quantile of alpha/2
-            - [:, 1]: for ``y_calib`` coming from prediction estimator
-                with quantile of 1 - alpha/2
-            - [:, 2]: maximum of those first two scores
+        - [:, 0]: for ``y_calib`` coming from prediction estimator
+          with quantile of alpha/2
+        - [:, 1]: for ``y_calib`` coming from prediction estimator
+          with quantile of 1 - alpha/2
+        - [:, 2]: maximum of those first two scores
 
     n_calib_samples: int
         Number of samples in the calibration dataset.
@@ -662,14 +662,11 @@ class MapieQuantileRegressor(MapieRegressor):
         Returns
         -------
         Union[NDArray, Tuple[NDArray, NDArray]]
-
-        - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
-
-        - Tuple[NDArray, NDArray] of shapes (n_samples,) and
-            (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
-
-            - [:, 0, :]: Lower bound of the prediction interval.
-            - [:, 1, :]: Upper bound of the prediction interval.
+            - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
+            - Tuple[NDArray, NDArray] of shapes (n_samples,) and
+              (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
+                - [:, 0, :]: Lower bound of the prediction interval.
+                - [:, 1, :]: Upper bound of the prediction interval.
         """
         check_is_fitted(self, self.fit_attributes)
         check_defined_variables_predict_cqr(ensemble, alpha)

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -45,7 +45,7 @@ class MapieQuantileRegressor(MapieRegressor):
 
     cv: Optional[str]
         The cross-validation strategy for computing conformity scores.
-        In theory a split method is implemented as it is needed to provided
+        In theory a split method is implemented as it is needed to provide
         both a training and calibration set.
 
         By default ``None``.

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -40,7 +40,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         Any regressor with scikit-learn API
         (i.e. with ``fit`` and ``predict`` methods).
         If ``None``, estimator defaults to a ``LinearRegression`` instance.
-        
+
         By default ``None``.
 
     method: str

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -38,8 +38,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
     ----------
     estimator: Optional[RegressorMixin]
         Any regressor with scikit-learn API
-        (i.e. with ``fit`` and ``predict`` methods), by default ``None``.
+        (i.e. with ``fit`` and ``predict`` methods).
         If ``None``, estimator defaults to a ``LinearRegression`` instance.
+        
+        By default ``None``.
 
     method: str
         Method to choose for prediction interval estimates.
@@ -83,7 +85,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         By default ``None``.
 
     test_size: Optional[Union[int, float]]
-        If float, should be between ``0.0`` and ``1.0`` and represent the
+        If ``float``, should be between ``0.0`` and ``1.0`` and represent the
         proportion of the dataset to include in the test split. If ``int``,
         represents the absolute number of test samples. If ``None``,
         it will be set to ``0.1``.
@@ -108,7 +110,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         Determines how to aggregate predictions from perturbed models, both at
         training and prediction time.
 
-        If ``None``, it is ignored except if cv class is ``Subsample``,
+        If ``None``, it is ignored except if ``cv`` class is ``Subsample``,
         in which case an error is raised.
         If ``"mean"`` or ``"median"``, returns the mean or median of the
         predictions computed from the out-of-folds models.
@@ -170,7 +172,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         Conformity scores between ``y_train`` and ``y_pred``.
 
     k_: ArrayLike
-        - Array of nans, of shape (len(y), 1) if cv is ``"prefit"``
+        - Array of nans, of shape (len(y), 1) if ``cv`` is ``"prefit"``
           (defined but not used)
         - Dummy array of folds containing each training sample, otherwise.
           Of shape (n_samples_train, cv.get_n_splits(X_train, y_train)).
@@ -553,7 +555,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         sample_weight : Optional[ArrayLike] of shape (n_samples,)
             Sample weights for fitting the out-of-fold models.
-            If None, then samples are equally weighted.
+            If ``None``, then samples are equally weighted.
             If some weights are null,
             their corresponding observations are removed
             before the fitting process and hence have no conformity scores.
@@ -660,10 +662,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         from the model clones are central to the computation.
         Prediction Intervals for a given ``alpha`` are deduced from either
 
-        - quantiles of conformity scores (naive and base methods),
-        - quantiles of (predictions +/- conformity scores) (plus method),
+        - quantiles of conformity scores (``naive`` and ``base`` methods),
+        - quantiles of (predictions +/- conformity scores) (``plus`` method),
         - quantiles of (max/min(predictions) +/- conformity scores)
-          (minmax method).
+          (``minmax`` method).
 
         Parameters
         ----------

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -697,14 +697,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         Returns
         -------
         Union[NDArray, Tuple[NDArray, NDArray]]
-
-        - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
-
-        - Tuple[NDArray, NDArray] of shapes (n_samples,) and
-          (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
-
-            - [:, 0, :]: Lower bound of the prediction interval.
-            - [:, 1, :]: Upper bound of the prediction interval.
+            - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
+            - Tuple[NDArray, NDArray] of shapes (n_samples,) and
+              (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
+                - [:, 0, :]: Lower bound of the prediction interval.
+                - [:, 1, :]: Upper bound of the prediction interval.
         """
         # Checks
         check_is_fitted(self, self.fit_attributes)

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -36,20 +36,20 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
     Parameters
     ----------
-    estimator : Optional[RegressorMixin]
+    estimator: Optional[RegressorMixin]
         Any regressor with scikit-learn API
-        (i.e. with fit and predict methods), by default ``None``.
+        (i.e. with ``fit`` and ``predict`` methods), by default ``None``.
         If ``None``, estimator defaults to a ``LinearRegression`` instance.
 
-    method: str, optional
+    method: str
         Method to choose for prediction interval estimates.
         Choose among:
 
-        - "naive", based on training set conformity scores,
-        - "base", based on validation sets conformity scores,
-        - "plus", based on validation conformity scores and
+        - ``"naive"``, based on training set conformity scores,
+        - ``"base"``, based on validation sets conformity scores,
+        - ``"plus"``, based on validation conformity scores and
           testing predictions,
-        - "minmax", based on validation conformity scores and
+        - ``"minmax"``, based on validation conformity scores and
           testing predictions (min/max among cross-validation clones).
 
         By default ``"plus"``.
@@ -61,13 +61,13 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         - ``None``, to use the default 5-fold cross-validation
         - integer, to specify the number of folds.
-          If equal to -1, equivalent to
+          If equal to ``-1``, equivalent to
           ``sklearn.model_selection.LeaveOneOut()``.
         - CV splitter: any ``sklearn.model_selection.BaseCrossValidator``
           Main variants are:
-          - ``sklearn.model_selection.LeaveOneOut`` (jackknife),
-          - ``sklearn.model_selection.KFold`` (cross-validation),
-          - ``subsample.Subsample`` object (bootstrap).
+            - ``sklearn.model_selection.LeaveOneOut`` (jackknife),
+            - ``sklearn.model_selection.KFold`` (cross-validation),
+            - ``subsample.Subsample`` object (bootstrap).
         - ``"split"``, does not involve cross-validation but a division
           of the data into training and calibration subsets. The splitter
           used is the following: ``sklearn.model_selection.ShuffleSplit``.
@@ -83,9 +83,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         By default ``None``.
 
     test_size: Optional[Union[int, float]]
-        If float, should be between 0.0 and 1.0 and represent the proportion
-        of the dataset to include in the test split. If int, represents the
-        absolute number of test samples. If None, it will be set to 0.1.
+        If float, should be between ``0.0`` and ``1.0`` and represent the
+        proportion of the dataset to include in the test split. If ``int``,
+        represents the absolute number of test samples. If ``None``,
+        it will be set to ``0.1``.
 
         If cv is not ``"split"``, ``test_size`` is ignored.
 
@@ -97,20 +98,20 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         If ``-1`` all CPUs are used.
         If ``1`` is given, no parallel computing code is used at all,
         which is useful for debugging.
-        For n_jobs below ``-1``, ``(n_cpus + 1 - n_jobs)`` are used.
-        None is a marker for `unset` that will be interpreted as ``n_jobs=1``
-        (sequential execution).
+        For ``n_jobs`` below ``-1``, ``(n_cpus + 1 - n_jobs)`` are used.
+        ``None`` is a marker for `unset` that will be interpreted as
+        ``n_jobs=1`` (sequential execution).
 
         By default ``None``.
 
-    agg_function : str
+    agg_function : Optional[str]
         Determines how to aggregate predictions from perturbed models, both at
         training and prediction time.
 
         If ``None``, it is ignored except if cv class is ``Subsample``,
         in which case an error is raised.
-        If "mean" or "median", returns the mean or median of the predictions
-        computed from the out-of-folds models.
+        If ``"mean"`` or ``"median"``, returns the mean or median of the
+        predictions computed from the out-of-folds models.
         Note: if you plan to set the ``ensemble`` argument to ``True`` in the
         ``predict`` method, you have to specify an aggregation function.
         Otherwise an error would be raised.
@@ -119,15 +120,15 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         median prediction, and is guaranteed to lie inside the interval,
         unlike the single estimator predictions.
 
-        When the cross-validation strategy is Subsample (i.e. for the
+        When the cross-validation strategy is ``Subsample`` (i.e. for the
         Jackknife+-after-Bootstrap method), this function is also used to
         aggregate the training set in-sample predictions.
 
-        If cv is ``"prefit"`` or ``"split"``, ``agg_function`` is ignored.
+        If ``cv`` is ``"prefit"`` or ``"split"``, ``agg_function`` is ignored.
 
         By default ``"mean"``.
 
-    verbose : int, optional
+    verbose : int
         The verbosity level, used with joblib for multiprocessing.
         The frequency of the messages increases with the verbosity level.
         If it more than ``10``, all iterations are reported.
@@ -138,7 +139,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
     conformity_score : Optional[ConformityScore]
         ConformityScore instance.
         It defines the link between the observed values, the predicted ones
-        and the conformity scores. For instance, the default None value
+        and the conformity scores. For instance, the default ``None`` value
         correspondonds to a conformity score which assumes
         y_obs = y_pred + conformity_score.
 
@@ -149,34 +150,33 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         By default ``None``.
 
     random_state: Optional[Union[int, RandomState]]
-        Pseudo random number generator state used for random uniform sampling
-        for evaluation quantiles and prediction sets in cumulated_score.
+        Pseudo random number generator state used for random sampling.
         Pass an int for reproducible output across multiple function calls.
 
         By default ``None``.
 
     Attributes
     ----------
-    valid_methods: List[str]
+    valid_methods_: List[str]
         List of all valid methods.
 
     single_estimator_ : sklearn.RegressorMixin
         Estimator fitted on the whole training set.
 
-    estimators_ : list
+    estimators_: list
         List of out-of-folds estimators.
 
-    conformity_scores_ : ArrayLike of shape (n_samples_train,)
+    conformity_scores_: ArrayLike of shape (n_samples_train,)
         Conformity scores between ``y_train`` and ``y_pred``.
 
-    k_ : ArrayLike
+    k_: ArrayLike
         - Array of nans, of shape (len(y), 1) if cv is ``"prefit"``
           (defined but not used)
         - Dummy array of folds containing each training sample, otherwise.
           Of shape (n_samples_train, cv.get_n_splits(X_train, y_train)).
 
     n_features_in_: int
-        Number of features passed to the fit method.
+        Number of features passed to the ``fit`` method.
 
     References
     ----------
@@ -211,11 +211,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
     [ 5.28571429  7.17142857  9.05714286 10.94285714 12.82857143 14.71428571]
     """
 
-    cv_need_agg_function = ["Subsample"]
+    cv_need_agg_function_ = ["Subsample"]
     no_agg_cv_ = ["prefit", "split"]
     valid_methods_ = ["naive", "base", "plus", "minmax"]
     no_agg_methods_ = ["naive", "base"]
-    plus_like_method = ["plus"]
     valid_agg_functions_ = [None, "median", "mean"]
     ensemble_agg_functions_ = ["median", "mean"]
     fit_attributes = [
@@ -258,14 +257,38 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         ValueError
             If parameters are not valid.
         """
-        if self.method not in self.valid_methods_:
-            raise ValueError(
-                f"Invalid method. Allowed values are {self.valid_methods_}."
-            )
-
+        self._check_method(self.method)
         check_n_jobs(self.n_jobs)
         check_verbose(self.verbose)
         check_random_state(self.random_state)
+
+    def _check_method(
+        self, method: str
+    ) -> str:
+        """
+        Check if ``method`` is correct.
+
+        Parameters
+        ----------
+        method: str
+            Method's name to check.
+
+        Returns
+        -------
+        str
+            ``method`` itself.
+
+        Raises
+        ------
+        ValueError
+            If ``method`` is not in ``self.valid_methods_``.
+        """
+        if method not in self.valid_methods_:
+            raise ValueError(
+                f"Invalid method. Allowed values are {self.valid_methods_}."
+            )
+        else:
+            return method
 
     def _check_agg_function(
         self, agg_function: Optional[str] = None
@@ -276,7 +299,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         Parameters
         ----------
-        agg_function : Optional[str], optional
+        agg_function: Optional[str]
             Aggregation function's name to check, by default ``None``.
 
         Returns
@@ -288,25 +311,24 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         ------
         ValueError
             If ``agg_function`` is not in [``None``, ``"mean"``, ``"median"``],
-            or is ``None`` while cv class is in ``cv_need_agg_function``.
+            or is ``None`` while cv class is in ``cv_need_agg_function_``.
         """
         if agg_function not in self.valid_agg_functions_:
             raise ValueError(
                 "Invalid aggregation function "
                 f"Allowed values are '{self.valid_agg_functions_}'."
             )
-
-        if (agg_function is None) and (
-            type(self.cv).__name__ in self.cv_need_agg_function
+        elif (agg_function is None) and (
+            type(self.cv).__name__ in self.cv_need_agg_function_
         ):
             raise ValueError(
                 "You need to specify an aggregation function when "
-                f"cv's type is in {self.cv_need_agg_function}."
+                f"cv's type is in {self.cv_need_agg_function_}."
             )
-        if (agg_function is not None) or (self.cv in self.no_agg_cv_):
+        elif (agg_function is not None) or (self.cv in self.no_agg_cv_):
             return agg_function
-
-        return "mean"
+        else:
+            return "mean"
 
     def _check_estimator(
         self, estimator: Optional[RegressorMixin] = None
@@ -319,7 +341,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         Parameters
         ----------
-        estimator : Optional[RegressorMixin], optional
+        estimator: Optional[RegressorMixin]
             Estimator to check, by default ``None``.
 
         Returns
@@ -331,39 +353,40 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         ------
         ValueError
             If the estimator is not ``None``
-            and has no fit nor predict methods.
+            and has no ``fit`` nor ``predict`` methods.
 
         NotFittedError
-            If the estimator is not fitted and ``cv`` attribute is "prefit".
+            If the estimator is not fitted
+            and ``cv`` attribute is ``"prefit"``.
         """
         if estimator is None:
             return LinearRegression()
-        check_estimator_fit_predict(estimator)
-        if self.cv == "prefit":
-            if isinstance(self.estimator, Pipeline):
-                check_is_fitted(self.estimator[-1])
-            else:
-                check_is_fitted(self.estimator)
-        return estimator
+        else:
+            check_estimator_fit_predict(estimator)
+            if self.cv == "prefit":
+                if isinstance(estimator, Pipeline):
+                    check_is_fitted(estimator[-1])
+                else:
+                    check_is_fitted(estimator)
+            return estimator
 
     def _check_ensemble(
-        self,
-        ensemble: bool,
+        self, ensemble: bool,
     ) -> None:
         """
-        Check if ``ensemble`` is False if ``self.agg_function`` is ``None``.
-        Else raise error.
+        Check if ``ensemble`` is ``False`` and if ``self.agg_function``
+        is ``None``. Else raise error.
 
         Parameters
         ----------
-        ensemble : bool
+        ensemble: bool
             ``ensemble`` argument to check the coherennce with
             ``self.agg_function``.
 
         Raises
         ------
         ValueError
-            If ``ensemble`` is True and ``self.agg_function`` is None.
+            If ``ensemble`` is ``True`` and ``self.agg_function`` is ``None``.
         """
         if ensemble and (self.agg_function is None):
             raise ValueError(
@@ -386,23 +409,23 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         Parameters
         ----------
-        estimator : RegressorMixin
+        estimator: RegressorMixin
             Estimator to train.
 
-        X : ArrayLike of shape (n_samples, n_features)
+        X: ArrayLike of shape (n_samples, n_features)
             Input data.
 
-        y : ArrayLike of shape (n_samples,)
+        y: ArrayLike of shape (n_samples,)
             Input labels.
 
-        train_index : ArrayLike of shape (n_samples_train)
+        train_index: ArrayLike of shape (n_samples_train)
             Training data indices.
 
-        val_index : ArrayLike of shape (n_samples_val)
+        val_index: ArrayLike of shape (n_samples_val)
             Validation data indices.
 
-        sample_weight : Optional[ArrayLike] of shape (n_samples,)
-            Sample weights. If None, then samples are equally weighted.
+        sample_weight: Optional[ArrayLike] of shape (n_samples,)
+            Sample weights. If ``None``, then samples are equally weighted.
             By default ``None``.
 
         Returns
@@ -431,7 +454,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             y_pred = np.array([])
         return estimator, y_pred, val_index
 
-    def _aggregate_with_mask(self, x: NDArray, k: NDArray) -> NDArray:
+    def _aggregate_with_mask(
+        self,
+        x: NDArray,
+        k: NDArray
+    ) -> NDArray:
         """
         Take the array of predictions, made by the refitted estimators,
         on the testing set, and the 1-or-nan array indicating for each training
@@ -440,11 +467,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         Parameters:
         -----------
-        x : ArrayLike of shape (n_samples_test, n_estimators)
+        x: ArrayLike of shape (n_samples_test, n_estimators)
             Array of predictions, made by the refitted estimators,
             for each sample of the testing set.
 
-        k : ArrayLike of shape (n_samples_training, n_estimators)
+        k: ArrayLike of shape (n_samples_training, n_estimators)
             1-or-nan array: indicates whether to integrate the prediction
             of a given estimator into the aggregation, for each training
             sample.
@@ -461,33 +488,35 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                 f"if cv is in '{self.no_agg_cv_}' "
                 f"or if method is in '{self.no_agg_methods_}'."
             )
-        if self.agg_function == "median":
+        elif self.agg_function == "median":
             return phi2D(A=x, B=k, fun=lambda x: np.nanmedian(x, axis=1))
-
         # To aggregate with mean() the aggregation coud be done
         # with phi2D(A=x, B=k, fun=lambda x: np.nanmean(x, axis=1).
         # However, phi2D contains a np.apply_along_axis loop which
         # is much slower than the matrices multiplication that can
         # be used to compute the means.
-        if self.agg_function in ["mean", None]:
+        elif self.agg_function in ["mean", None]:
             K = np.nan_to_num(k, nan=0.0)
             return np.matmul(x, (K / (K.sum(axis=1, keepdims=True))).T)
+        else:
+            raise ValueError("The value of self.agg_function is not correct")
 
-        raise ValueError("The value of self.agg_function is not correct")
-
-    def _pred_multi(self, X: ArrayLike) -> NDArray:
+    def _pred_multi(
+        self,
+        X: ArrayLike
+    ) -> NDArray:
         """
         Return a prediction per train sample for each test sample, by
-        aggregation with matrix  ``k_``.
+        aggregation with matrix ``k_``.
 
         Parameters
         ----------
-            X: NDArray of shape (n_samples_test, n_features)
-                Input data
+        X: NDArray of shape (n_samples_test, n_features)
+            Input data
 
         Returns
         -------
-            NDArray of shape (n_samples_test, n_samples_train)
+        NDArray of shape (n_samples_test, n_samples_train)
         """
         y_pred_multi = np.column_stack(
             [e.predict(X) for e in self.estimators_]
@@ -496,7 +525,6 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         # (n_samples_test, n_estimators_). The method
         # ``_aggregate_with_mask`` fits it to the right size
         # thanks to the shape of k_.
-
         y_pred_multi = self._aggregate_with_mask(y_pred_multi, self.k_)
         return y_pred_multi
 
@@ -639,25 +667,25 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         Parameters
         ----------
-        X : ArrayLike of shape (n_samples, n_features)
+        X: ArrayLike of shape (n_samples, n_features)
             Test data.
 
         ensemble: bool
             Boolean determining whether the predictions are ensembled or not.
-            If False, predictions are those of the model trained on the whole
-            training set.
-            If True, predictions from perturbed models are aggregated by
+            If ``False``, predictions are those of the model trained on the
+            whole training set.
+            If ``True``, predictions from perturbed models are aggregated by
             the aggregation function specified in the ``agg_function``
             attribute.
 
-            If cv is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
+            If ``cv`` is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
 
             By default ``False``.
 
         alpha: Optional[Union[float, Iterable[float]]]
             Can be a float, a list of floats, or a ``ArrayLike`` of floats.
-            Between 0 and 1, represents the uncertainty of the confidence
-            interval.
+            Between ``0`` and ``1``, represents the uncertainty of the
+            confidence interval.
             Lower ``alpha`` produce larger (more conservative) prediction
             intervals.
             ``alpha`` is the complement of the target coverage level.
@@ -668,14 +696,13 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         -------
         Union[NDArray, Tuple[NDArray, NDArray]]
 
-        - NDArray of shape (n_samples,) if alpha is None.
+        - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
 
-        - Tuple[NDArray, NDArray] of shapes
-        (n_samples,) and (n_samples, 2, n_alpha) if alpha is not None.
+        - Tuple[NDArray, NDArray] of shapes (n_samples,) and
+          (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
 
             - [:, 0, :]: Lower bound of the prediction interval.
             - [:, 1, :]: Upper bound of the prediction interval.
-
         """
         # Checks
         check_is_fitted(self, self.fit_attributes)

--- a/mapie/tests/test_quantile_regression.py
+++ b/mapie/tests/test_quantile_regression.py
@@ -363,7 +363,7 @@ def test_wrong_alphas(alphas: float) -> None:
     """Checking for alphas values that are too big according to all value."""
     with pytest.raises(
         ValueError,
-        match=r".*Invalid alpha. Allowed values are between 0 and .*",
+        match=r".*Invalid alpha. Allowed values are between .*",
     ):
         mapie_reg = MapieQuantileRegressor(alpha=alphas)
         mapie_reg.fit(X_train, y_train, X_calib=X_calib, y_calib=y_calib)

--- a/mapie/time_series_regression.py
+++ b/mapie/time_series_regression.py
@@ -273,14 +273,11 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         Returns
         -------
         Union[NDArray, Tuple[NDArray, NDArray]]
-
-        - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
-
-        - Tuple[NDArray, NDArray] of shapes (n_samples,) and
-            (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
-
-            - [:, 0, :]: Lower bound of the prediction interval.
-            - [:, 1, :]: Upper bound of the prediction interval.
+            - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
+            - Tuple[NDArray, NDArray] of shapes (n_samples,) and
+              (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
+                - [:, 0, :]: Lower bound of the prediction interval.
+                - [:, 1, :]: Upper bound of the prediction interval.
         """
         # Checks
         check_is_fitted(self, self.fit_attributes)

--- a/mapie/time_series_regression.py
+++ b/mapie/time_series_regression.py
@@ -20,7 +20,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
 
     This class implements the EnbPI strategy for estimating
     prediction intervals on single-output time series. The only valid
-    ``method`` is 'enbpi'.
+    ``method`` is ``"enbpi"``.
 
     Actually, EnbPI only corresponds to ``MapieTimeSeriesRegressor`` if the
     ``cv`` argument is of type ``BlockBootstrap``.
@@ -277,7 +277,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
 
         - Tuple[NDArray, NDArray] of shapes (n_samples,) and
-          (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
+            (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
 
             - [:, 0, :]: Lower bound of the prediction interval.
             - [:, 1, :]: Upper bound of the prediction interval.


### PR DESCRIPTION
# Description

The docstring of the classes and methods related to the regression methods is not updated.

Fixes #301 

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

Check the documentation.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`