### PR TITLE
ENH: grouped conditional coverage metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ target/
 
 # VSCode
 .vscode
+.idea/
 
 # Images
 *.jpeg

--- a/mapie/tests/test_metrics.py
+++ b/mapie/tests/test_metrics.py
@@ -5,12 +5,18 @@ import numpy as np
 import pytest
 from numpy.random import RandomState
 
+from typing_extensions import TypedDict
 from mapie._typing import ArrayLike
 from mapie.metrics import (classification_coverage_score,
                            classification_mean_width_score,
                            expected_calibration_error,
                            regression_coverage_score,
-                           regression_mean_width_score, top_label_ece)
+                           regression_mean_width_score, top_label_ece,
+                           regression_ssc,
+                           regression_ssc_score,
+                           classification_ssc,
+                           classification_ssc_score,
+                           hsic)
 
 y_toy = np.array([5, 7.5, 9.5, 10.5, 12.5])
 y_preds = np.array(
@@ -20,6 +26,25 @@ y_preds = np.array(
         [9.5, 9, 10.0],
         [10.5, 8.5, 12.5],
         [11.5, 10.5, 12.0],
+    ]
+)
+intervals = np.array(
+    [
+        [
+            [4, 4], [6, 7.5]
+        ],
+        [
+            [6.0, 8], [9.0, 10]
+        ],
+        [
+            [9, 9], [10.0, 10.0]
+        ],
+        [
+            [8.5, 9], [12.5, 12]
+        ],
+        [
+            [10.5, 10.5], [12.0, 12]
+        ]
     ]
 )
 
@@ -33,7 +58,179 @@ y_pred_set = np.array(
         [False, True, False, True],
     ]
 )
+y_pred_set_2alphas = np.array([
+    [
+        [False, False],
+        [False, True],
+        [False, True],
+        [False, False],
+    ],
+    [
+        [False, True],
+        [True, True],
+        [True, True],
+        [True, True]
+    ],
+    [
+        [False, False],
+        [True, False],
+        [False, False],
+        [False, False]
+    ],
+    [
+        [True, False],
+        [True, False],
+        [True, True],
+        [True, False],
+    ],
+    [
+        [False, False],
+        [True, True],
+        [False, True],
+        [True, True]
+    ]
+])
 
+Params_ssc_reg = TypedDict(
+    "Params_ssc_reg",
+    {
+        "intervals": ArrayLike,
+        "n_splits": int,
+        "method": str
+    },
+)
+Params_ssc_classif = TypedDict(
+    "Params_ssc_classif",
+    {
+        "y_pred_set": ArrayLike,
+        "n_splits": int,
+        "method": str
+    },
+)
+SSC_REG = {
+    "1alpha_base": Params_ssc_reg(
+        intervals=intervals[:, :, 0],
+        n_splits=2,
+        method="uniform"
+    ),
+    "1alpha_3sp": Params_ssc_reg(
+        intervals=intervals[:, :, 0],
+        n_splits=3,
+        method="uniform"
+    ),
+    "1alpha_3sp_quant": Params_ssc_reg(
+        intervals=intervals[:, :, 0],
+        n_splits=3,
+        method="quantile"
+    ),
+    "1alpha_quant": Params_ssc_reg(
+        intervals=intervals[:, :, 0],
+        n_splits=2,
+        method="quantile"
+    ),
+    "2alpha_base": Params_ssc_reg(
+        intervals=intervals,
+        n_splits=2,
+        method="uniform"
+    ),
+    "2alpha_3sp": Params_ssc_reg(
+        intervals=intervals,
+        n_splits=3,
+        method="uniform"
+    ),
+    "2alpha_3sp_quant": Params_ssc_reg(
+        intervals=intervals,
+        n_splits=3,
+        method="quantile"
+    ),
+    "2alpha_quant": Params_ssc_reg(
+        intervals=intervals,
+        n_splits=2,
+        method="quantile"
+    ),
+}
+SSC_CLASSIF = {
+    "1alpha_base": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas[:, :, 0],
+        n_splits=2,
+        method="uniform"
+    ),
+    "1alpha_3sp": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas[:, :, 0],
+        n_splits=3,
+        method="uniform"
+    ),
+    "1alpha_3sp_quant": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas[:, :, 0],
+        n_splits=3,
+        method="quantile"
+    ),
+    "1alpha_quant": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas[:, :, 0],
+        n_splits=2,
+        method="quantile"
+    ),
+    "2alpha_base": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas,
+        n_splits=2,
+        method="uniform"
+    ),
+    "2alpha_3sp": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas,
+        n_splits=3,
+        method="uniform"
+    ),
+    "2alpha_3sp_quant": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas,
+        n_splits=3,
+        method="quantile"
+    ),
+    "2alpha_quant": Params_ssc_classif(
+        y_pred_set=y_pred_set_2alphas,
+        n_splits=2,
+        method="quantile"
+    ),
+}
+SSC_REG_COVERAGES = {
+    "1alpha_base": np.array([[2/3, 1.]]),
+    "1alpha_3sp": np.array([[0.5, 1., 1.]]),
+    "1alpha_3sp_quant": np.array([[0.5, 1., 1.]]),
+    "1alpha_quant": np.array([[2/3, 1.]]),
+    "2alpha_base": np.array([[2/3, 1.], [1/3, 1.]]),
+    "2alpha_3sp": np.array([[0.5, 1., 1.], [0.5, 0.5, 1.]]),
+    "2alpha_3sp_quant": np.array([[0.5, 1., 1.], [0.5, 0., 1.]]),
+    "2alpha_quant": np.array([[2/3, 1.], [1/3, 1.]])
+}
+SSC_REG_COVERAGES_SCORE = {
+    "1alpha_base": np.array([2/3]),
+    "1alpha_3sp": np.array([0.5]),
+    "1alpha_3sp_quant": np.array([0.5]),
+    "1alpha_quant": np.array([2/3]),
+    "2alpha_base": np.array([2/3, 1/3]),
+    "2alpha_3sp": np.array([0.5, 0.5]),
+    "2alpha_3sp_quant": np.array([0.5, 0.]),
+    "2alpha_quant": np.array([2/3, 1/3])
+}
+SSC_CLASSIF_COVERAGES = {
+    "1alpha_base": np.array([[1/3, 1.]]),
+    "1alpha_3sp": np.array([[0.5, 0.5, 1.]]),
+    "1alpha_3sp_quant": np.array([[0.5, 0., 1.]]),
+    "1alpha_quant": np.array([[1/3, 1.]]),
+    "2alpha_base": np.array([[1/3, 1.], [1/3, 1.]]),
+    "2alpha_3sp": np.array([[0.5, 0.5, 1.], [0.5, 0.5, 1.]]),
+    "2alpha_3sp_quant": np.array([[0.5, 0., 1.], [0.5, 0., 1.]]),
+    "2alpha_quant": np.array([[1/3, 1.], [1/3, 1.]]),
+}
+SSC_CLASSIF_COVERAGES_SCORE = {
+    "1alpha_base": np.array([1 / 3]),
+    "1alpha_3sp": np.array([0.5]),
+    "1alpha_3sp_quant": np.array([0.]),
+    "1alpha_quant": np.array([1 / 3]),
+    "2alpha_base": np.array([1 / 3, 1 / 3]),
+    "2alpha_3sp": np.array([0.5, 0.5]),
+    "2alpha_3sp_quant": np.array([0., 0.]),
+    "2alpha_quant": np.array([1 / 3, 1 / 3]),
+}
 
 prng = RandomState(1234567890)
 y_score = prng.random(51)
@@ -57,12 +254,28 @@ def test_regression_ypredup_shape() -> None:
         regression_mean_width_score(y_preds[:, :2], y_preds[:, 2])
 
 
+def test_regression_intervals_shape() -> None:
+    """Test shape of intervals"""
+    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+        regression_ssc(y_toy, y_preds)
+    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+        regression_ssc_score(y_toy, y_preds)
+    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+        hsic(y_toy, y_preds)
+
+
 def test_regression_same_length() -> None:
     "Test when y_true and y_preds have different lengths."
     with pytest.raises(ValueError, match=r".*could not be broadcast*"):
         regression_coverage_score(y_toy, y_preds[:-1, 1], y_preds[:-1, 2])
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
         regression_mean_width_score(y_preds[:, :2], y_preds[:, 2])
+    with pytest.raises(ValueError, match=r".*could not be broadcast*"):
+        regression_ssc(y_toy, intervals[:-1, ])
+    with pytest.raises(ValueError, match=r".*could not be broadcast*"):
+        regression_ssc_score(y_toy, intervals[:-1, ])
+    with pytest.raises(ValueError, match=r".*could not be broadcast*"):
+        hsic(y_toy, intervals[:-1, ])
 
 
 def test_regression_toydata_coverage_score() -> None:
@@ -90,10 +303,18 @@ def test_regression_ypredup_type_coverage_score() -> None:
 
 
 def test_classification_y_true_shape() -> None:
-    "Test shape of y_true."
+    """Test shape of y_true."""
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
         classification_coverage_score(
             np.tile(y_true_class, (2, 1)), y_pred_set
+        )
+    with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
+        classification_ssc(
+            np.tile(y_true_class, (2, 1)), y_pred_set_2alphas
+        )
+    with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
+        classification_ssc_score(
+            np.tile(y_true_class, (2, 1)), y_pred_set_2alphas
         )
 
 
@@ -101,12 +322,20 @@ def test_classification_y_pred_set_shape() -> None:
     "Test shape of y_pred_set."
     with pytest.raises(ValueError, match=r".*Expected 2D array*"):
         classification_coverage_score(y_true_class, y_pred_set[:, 0])
+    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+        classification_ssc(y_true_class, y_pred_set[:, 0])
+    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+        classification_ssc_score(y_true_class, y_pred_set[:, 0])
 
 
 def test_classification_same_length() -> None:
     "Test when y_true and y_pred_set have different lengths."
     with pytest.raises(IndexError, match=r".*shape mismatch*"):
         classification_coverage_score(y_true_class, y_pred_set[:-1, :])
+    with pytest.raises(IndexError, match=r".*shape mismatch*"):
+        classification_ssc(y_true_class, y_pred_set_2alphas[:-1, :, :])
+    with pytest.raises(IndexError, match=r".*shape mismatch*"):
+        classification_ssc_score(y_true_class, y_pred_set_2alphas[:-1, :, :])
 
 
 def test_classification_toydata() -> None:
@@ -219,3 +448,193 @@ def test_top_label_same_result() -> None:
     assert scr1 == scr2
     assert scr1 == scr3
     assert scr1 == scr4
+
+
+@pytest.mark.parametrize("method", ["uniform", "quantile"])
+def test_valid_method_regression_ssc(method: str) -> None:
+    """Test that valid method for ssc splits raise no errors."""
+    regression_ssc(y_toy, intervals, method=method)
+
+
+@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
+def test_invalid_method_regression_ssc(method: str) -> None:
+    """Test that invalid method for ssc splits raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
+        regression_ssc(y_toy, intervals, method=method)
+
+
+@pytest.mark.parametrize("n_splits", [10, 0, 1])
+def test_invalid_splits_regression_ssc(n_splits: int) -> None:
+    """Test that invalid number of splits for ssc raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
+        regression_ssc(y_toy, intervals, n_splits=n_splits)
+
+
+@pytest.mark.parametrize("method", ["uniform", "quantile"])
+def test_valid_method_regression_ssc_score(method: str) -> None:
+    """Test that valid method for ssc splits raise no errors."""
+    regression_ssc_score(y_toy, intervals, method=method)
+
+
+@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
+def test_invalid_method_regression_ssc_score(method: str) -> None:
+    """Test that invalid method for ssc splits raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
+        regression_ssc_score(y_toy, intervals, method=method)
+
+
+@pytest.mark.parametrize("n_splits", [10, 0, 1])
+def test_invalid_splits_regression_ssc_score(n_splits: int) -> None:
+    """Test that invalid number of splits for ssc raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
+        regression_ssc_score(y_toy, intervals, n_splits=n_splits)
+
+
+@pytest.mark.parametrize("params", [*SSC_REG])
+def test_regression_ssc_return_shape(params: str) -> None:
+    """Test that the array returned by ssc metric has the correct shape."""
+    cond_cov = regression_ssc(y_toy, **SSC_REG[params])
+    assert cond_cov.shape == SSC_REG_COVERAGES[params].shape
+
+
+@pytest.mark.parametrize("params", [*SSC_REG])
+def test_regression_ssc_score_return_shape(params: str) -> None:
+    """Test that the array returned by ssc score has the correct shape."""
+    cond_cov_min = regression_ssc_score(y_toy, **SSC_REG[params])
+    assert cond_cov_min.shape == SSC_REG_COVERAGES_SCORE[params].shape
+
+
+@pytest.mark.parametrize("params", [*SSC_REG])
+def test_regression_ssc_coverage_values(params: str):
+    """Test that the conditional coverage values returned are correct."""
+    cond_cov = regression_ssc(y_toy, **SSC_REG[params])
+    np.testing.assert_allclose(cond_cov, SSC_REG_COVERAGES[params])
+
+
+@pytest.mark.parametrize("params", [*SSC_REG])
+def test_regression_ssc_score_coverage_values(params: str):
+    """Test that the conditional coverage values returned are correct."""
+    cond_cov_min = regression_ssc_score(y_toy, **SSC_REG[params])
+    np.testing.assert_allclose(cond_cov_min, SSC_REG_COVERAGES_SCORE[params])
+
+
+@pytest.mark.parametrize("method", ["uniform", "quantile"])
+def test_valid_method_classification_ssc(method: str) -> None:
+    """Test that valid method for ssc splits raise no errors."""
+    classification_ssc(y_true_class, y_pred_set_2alphas, method=method)
+
+
+@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
+def test_invalid_method_classification_ssc(method: str) -> None:
+    """Test that invalid method for ssc splits raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
+        classification_ssc(y_true_class, y_pred_set_2alphas, method=method)
+
+
+@pytest.mark.parametrize("n_splits", [10, 0, 1])
+def test_invalid_splits_classification_ssc(n_splits: int) -> None:
+    """Test that invalid number of splits for ssc raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
+        classification_ssc(y_true_class, y_pred_set_2alphas, n_splits=n_splits)
+
+
+@pytest.mark.parametrize("method", ["uniform", "quantile"])
+def test_valid_method_classification_ssc_score(method: str) -> None:
+    """Test that valid method for ssc splits raise no errors."""
+    classification_ssc_score(y_true_class, y_pred_set_2alphas, method=method)
+
+
+@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
+def test_invalid_method_classification_ssc_score(method: str) -> None:
+    """Test that invalid method for ssc splits raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
+        classification_ssc_score(
+            y_true_class, y_pred_set_2alphas, method=method
+        )
+
+
+@pytest.mark.parametrize("n_splits", [10, 0, 1])
+def test_invalid_splits_classification_ssc_score(n_splits: int) -> None:
+    """Test that invalid number of splits for ssc raise errors."""
+    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
+        classification_ssc_score(
+            y_true_class, y_pred_set_2alphas, n_splits=n_splits
+        )
+
+
+@pytest.mark.parametrize("params", [*SSC_CLASSIF])
+def test_classification_ssc_return_shape(params: str) -> None:
+    """Test that the arrays returned by ssc metrics have the correct shape."""
+    cond_cov = classification_ssc(y_true_class, **SSC_CLASSIF[params])
+    assert cond_cov.shape == SSC_CLASSIF_COVERAGES[params].shape
+
+
+@pytest.mark.parametrize("params", [*SSC_CLASSIF])
+def test_classification_ssc_score_return_shape(params: str) -> None:
+    """Test that the arrays returned by ssc metrics have the correct shape."""
+    cond_cov_min = classification_ssc_score(
+        y_true_class, **SSC_CLASSIF[params]
+    )
+    assert cond_cov_min.shape == SSC_CLASSIF_COVERAGES_SCORE[params].shape
+
+
+@pytest.mark.parametrize("params", [*SSC_CLASSIF])
+def test_classification_ssc_return_shape_n_classes(params: str) -> None:
+    """
+    Test that the arrays returned by ssc metrics have the correct shape,
+    when splits=None, there is n_classes+1 groups.
+    """
+    cond_cov = classification_ssc(y_true_class, **SSC_CLASSIF[params])
+    assert cond_cov.shape == SSC_CLASSIF_COVERAGES[params].shape
+
+
+@pytest.mark.parametrize("params", [*SSC_CLASSIF])
+def test_classification_ssc_score_return_shape_n_classes(params: str) -> None:
+    """
+    Test that the arrays returned by ssc metrics have the correct shape,
+    when splits=None, there is n_classes+1 groups.
+    """
+    cond_cov_min = classification_ssc_score(
+        y_true_class, **SSC_CLASSIF[params]
+    )
+    assert cond_cov_min.shape == SSC_CLASSIF_COVERAGES_SCORE[params]
+
+
+@pytest.mark.parametrize("params", [*SSC_CLASSIF])
+def test_classification_ssc_coverage_values(params: str):
+    """Test that the conditional coverage values returned are correct."""
+    cond_cov = classification_ssc(y_true_class, **SSC_CLASSIF[params])
+    np.testing.assert_allclose(cond_cov, SSC_CLASSIF_COVERAGES[params])
+
+
+@pytest.mark.parametrize("params", [*SSC_CLASSIF])
+def test_classification_ssc_score_coverage_values(params: str):
+    """Test that the conditional coverage values returned are correct."""
+    cond_cov_min = classification_ssc_score(
+        y_true_class, **SSC_CLASSIF[params]
+    )
+    np.testing.assert_allclose(
+        cond_cov_min, SSC_CLASSIF_COVERAGES_SCORE[params]
+    )
+
+
+@pytest.mark.parametrize("kernel_sizes", [(1, 2, 1), [1], 2, [[1, 2]]])
+def test_hsic_invalid_kernel_sizes(kernel_sizes: ArrayLike):
+    with pytest.raises(TypeError):
+        hsic(y_toy, intervals, kernel_sizes=kernel_sizes)
+
+
+@pytest.mark.parametrize("kernel_sizes", [(1, 1), (2, 2), (3, 1)])
+def test_hsic_valid_kernel_sizes(kernel_sizes: ArrayLike):
+    hsic(y_toy, intervals, kernel_sizes=kernel_sizes)
+
+
+@pytest.mark.parametrize("kernel_sizes", [(1, 1), (2, 2), (3, 1)])
+def test_hsic_return_shape(kernel_sizes: ArrayLike):
+    coef = hsic(y_toy, intervals, kernel_sizes=kernel_sizes)
+    assert coef.shape == (2,)
+
+
+def test_hsic_correlation_value():
+    coef = hsic(y_toy, intervals, kernel_sizes=(1, 1))
+    np.testing.assert_allclose(coef, np.array([0.16829506, 0.3052798]))

--- a/mapie/tests/test_metrics.py
+++ b/mapie/tests/test_metrics.py
@@ -239,7 +239,7 @@ y_true = prng.randint(0, 2, 51)
 
 
 def test_regression_ypredlow_shape() -> None:
-    "Test shape of y_pred_low."
+    """Test shape of y_pred_low."""
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
         regression_coverage_score(y_toy, y_preds[:, :2], y_preds[:, 2])
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
@@ -247,57 +247,74 @@ def test_regression_ypredlow_shape() -> None:
 
 
 def test_regression_ypredup_shape() -> None:
-    "Test shape of y_pred_up."
+    """Test shape of y_pred_up."""
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
         regression_coverage_score(y_toy, y_preds[:, 1], y_preds[:, 1:])
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
         regression_mean_width_score(y_preds[:, :2], y_preds[:, 2])
 
 
-def test_regression_intervals_shape() -> None:
-    """Test shape of intervals"""
-    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
-        regression_ssc(y_toy, y_preds)
-    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
-        regression_ssc_score(y_toy, y_preds)
-    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
-        hsic(y_toy, y_preds)
+def test_regression_intervals_invalid_shape() -> None:
+    """Test invalid shape of intervals raises an error"""
+    with pytest.raises(ValueError, match=r".*should be a 3D array*"):
+        regression_ssc(y_toy, y_preds[0])
+    with pytest.raises(ValueError, match=r".*should be a 3D array*"):
+        regression_ssc_score(y_toy, y_preds[0])
+    with pytest.raises(ValueError, match=r".*should be a 3D array*"):
+        hsic(y_toy, y_preds[0])
+
+
+def test_regression_ytrue_invalid_shape() -> None:
+    """Test invalid shape of y_true raises an error"""
+    with pytest.raises(ValueError, match=r".*should be a 1d array*"):
+        regression_ssc(np.tile(y_toy, 2).reshape(5, 2), y_preds)
+    with pytest.raises(ValueError, match=r".*should be a 1d array*"):
+        regression_ssc_score(np.tile(y_toy, 2).reshape(5, 2), y_preds)
+    with pytest.raises(ValueError, match=r".*should be a 1d array*"):
+        hsic(np.tile(y_toy, 2).reshape(5, 2), y_preds)
+
+
+def test_regression_valid_input_shape() -> None:
+    """Test valid shape of intervals raises no error"""
+    regression_ssc(y_toy, intervals)
+    regression_ssc_score(y_toy, intervals)
+    hsic(y_toy, intervals)
 
 
 def test_regression_same_length() -> None:
-    "Test when y_true and y_preds have different lengths."
+    """Test when y_true and y_preds have different lengths."""
     with pytest.raises(ValueError, match=r".*could not be broadcast*"):
         regression_coverage_score(y_toy, y_preds[:-1, 1], y_preds[:-1, 2])
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
         regression_mean_width_score(y_preds[:, :2], y_preds[:, 2])
-    with pytest.raises(ValueError, match=r".*could not be broadcast*"):
+    with pytest.raises(ValueError, match=r".*shape mismatch*"):
         regression_ssc(y_toy, intervals[:-1, ])
-    with pytest.raises(ValueError, match=r".*could not be broadcast*"):
+    with pytest.raises(ValueError, match=r".*shape mismatch*"):
         regression_ssc_score(y_toy, intervals[:-1, ])
-    with pytest.raises(ValueError, match=r".*could not be broadcast*"):
+    with pytest.raises(ValueError, match=r".*shape mismatch*"):
         hsic(y_toy, intervals[:-1, ])
 
 
 def test_regression_toydata_coverage_score() -> None:
-    "Test coverage_score for toy data."
+    """Test coverage_score for toy data."""
     scr = regression_coverage_score(y_toy, y_preds[:, 1], y_preds[:, 2])
     assert scr == 0.8
 
 
 def test_regression_ytrue_type_coverage_score() -> None:
-    "Test that list(y_true) gives right coverage."
+    """Test that list(y_true) gives right coverage."""
     scr = regression_coverage_score(list(y_toy), y_preds[:, 1], y_preds[:, 2])
     assert scr == 0.8
 
 
 def test_regression_ypredlow_type_coverage_score() -> None:
-    "Test that list(y_pred_low) gives right coverage."
+    """Test that list(y_pred_low) gives right coverage."""
     scr = regression_coverage_score(y_toy, list(y_preds[:, 1]), y_preds[:, 2])
     assert scr == 0.8
 
 
 def test_regression_ypredup_type_coverage_score() -> None:
-    "Test that list(y_pred_up) gives right coverage."
+    """Test that list(y_pred_up) gives right coverage."""
     scr = regression_coverage_score(y_toy, y_preds[:, 1], list(y_preds[:, 2]))
     assert scr == 0.8
 
@@ -309,78 +326,81 @@ def test_classification_y_true_shape() -> None:
             np.tile(y_true_class, (2, 1)), y_pred_set
         )
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
-        classification_ssc(
-            np.tile(y_true_class, (2, 1)), y_pred_set_2alphas
-        )
+        classification_ssc(np.tile(y_true_class, (2, 1)), y_pred_set_2alphas)
     with pytest.raises(ValueError, match=r".*y should be a 1d array*"):
-        classification_ssc_score(
-            np.tile(y_true_class, (2, 1)), y_pred_set_2alphas
-        )
+        classification_ssc_score(np.tile(y_true_class, (2, 1)),
+                                 y_pred_set_2alphas)
 
 
 def test_classification_y_pred_set_shape() -> None:
-    "Test shape of y_pred_set."
+    """Test shape of y_pred_set."""
     with pytest.raises(ValueError, match=r".*Expected 2D array*"):
         classification_coverage_score(y_true_class, y_pred_set[:, 0])
-    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+    with pytest.raises(ValueError, match=r".*should be a 3D array*"):
         classification_ssc(y_true_class, y_pred_set[:, 0])
-    with pytest.raises(ValueError, match=r".*Expected 3D array*"):
+    with pytest.raises(ValueError, match=r".*should be a 3D array*"):
         classification_ssc_score(y_true_class, y_pred_set[:, 0])
 
 
 def test_classification_same_length() -> None:
-    "Test when y_true and y_pred_set have different lengths."
+    """Test when y_true and y_pred_set have different lengths."""
     with pytest.raises(IndexError, match=r".*shape mismatch*"):
         classification_coverage_score(y_true_class, y_pred_set[:-1, :])
-    with pytest.raises(IndexError, match=r".*shape mismatch*"):
+    with pytest.raises(ValueError, match=r".*shape mismatch*"):
         classification_ssc(y_true_class, y_pred_set_2alphas[:-1, :, :])
-    with pytest.raises(IndexError, match=r".*shape mismatch*"):
+    with pytest.raises(ValueError, match=r".*shape mismatch*"):
         classification_ssc_score(y_true_class, y_pred_set_2alphas[:-1, :, :])
 
 
+def test_classification_valid_input_shape() -> None:
+    """Test that valid inputs shape raise no error."""
+    classification_ssc(y_true_class, y_pred_set_2alphas)
+    classification_ssc_score(y_true_class, y_pred_set_2alphas)
+
+
 def test_classification_toydata() -> None:
-    "Test coverage_score for toy data."
+    """Test coverage_score for toy data."""
     assert classification_coverage_score(y_true_class, y_pred_set) == 0.8
 
 
 def test_classification_ytrue_type() -> None:
-    "Test that list(y_true_class) gives right coverage."
+    """Test that list(y_true_class) gives right coverage."""
     scr = classification_coverage_score(list(y_true_class), y_pred_set)
     assert scr == 0.8
 
 
 def test_classification_y_pred_set_type() -> None:
-    "Test that list(y_pred_set) gives right coverage."
+    """Test that list(y_pred_set) gives right coverage."""
     scr = classification_coverage_score(y_true_class, list(y_pred_set))
     assert scr == 0.8
 
 
 @pytest.mark.parametrize("pred_set", [y_pred_set, list(y_pred_set)])
 def test_classification_toydata_width(pred_set: ArrayLike) -> None:
-    "Test width mean for toy data."
+    """Test width mean for toy data."""
     assert classification_mean_width_score(pred_set) == 2.0
 
 
 def test_classification_y_pred_set_width_shape() -> None:
-    "Test shape of y_pred_set in classification_mean_width_score."
+    """Test shape of y_pred_set in classification_mean_width_score."""
     with pytest.raises(ValueError, match=r".*Expected 2D array*"):
         classification_mean_width_score(y_pred_set[:, 0])
 
 
 def test_regression_toydata_mean_width_score() -> None:
-    "Test mean_width_score for toy data."
+    """Test mean_width_score for toy data."""
     scr = regression_mean_width_score(y_preds[:, 1], y_preds[:, 2])
     assert scr == 2.3
 
 
 def test_regression_ypredlow_type_mean_width_score() -> None:
-    "Test that list(y_pred_low) gives right coverage."
+    """Test that list(y_pred_low) gives right coverage."""
     scr = regression_mean_width_score(list(y_preds[:, 1]), y_preds[:, 2])
     assert scr == 2.3
 
 
 def test_regression_ypredup_type_mean_width_score() -> None:
-    "Test that list(y_pred_up) gives right coverage."
+    """Test that list(y_pred_up) gives right coverage."""
     scr = regression_mean_width_score(y_preds[:, 1], list(y_preds[:, 2]))
     assert scr == 2.3
 
@@ -404,7 +424,7 @@ def test_ece_scores() -> None:
 
 
 def test_top_lable_ece() -> None:
-    "Test that score is "
+    """Test that score is """
     scr = top_label_ece(y_true, y_scores)
     assert np.round(scr, 4) == 0.6997
 

--- a/mapie/tests/test_metrics.py
+++ b/mapie/tests/test_metrics.py
@@ -5,8 +5,10 @@ import numpy as np
 import pytest
 from numpy.random import RandomState
 
+from typing import Union
 from typing_extensions import TypedDict
-from mapie._typing import ArrayLike
+from mapie._typing import ArrayLike, NDArray
+
 from mapie.metrics import (classification_coverage_score,
                            classification_mean_width_score,
                            expected_calibration_error,
@@ -19,34 +21,20 @@ from mapie.metrics import (classification_coverage_score,
                            hsic)
 
 y_toy = np.array([5, 7.5, 9.5, 10.5, 12.5])
-y_preds = np.array(
-    [
-        [5, 4, 6],
-        [7.5, 6.0, 9.0],
-        [9.5, 9, 10.0],
-        [10.5, 8.5, 12.5],
-        [11.5, 10.5, 12.0],
-    ]
-)
-intervals = np.array(
-    [
-        [
-            [4, 4], [6, 7.5]
-        ],
-        [
-            [6.0, 8], [9.0, 10]
-        ],
-        [
-            [9, 9], [10.0, 10.0]
-        ],
-        [
-            [8.5, 9], [12.5, 12]
-        ],
-        [
-            [10.5, 10.5], [12.0, 12]
-        ]
-    ]
-)
+y_preds = np.array([
+    [5, 4, 6],
+    [7.5, 6.0, 9.0],
+    [9.5, 9, 10.0],
+    [10.5, 8.5, 12.5],
+    [11.5, 10.5, 12.0],
+])
+intervals = np.array([
+    [[4, 4], [6, 7.5]],
+    [[6.0, 8], [9.0, 10]],
+    [[9, 9], [10.0, 10.0]],
+    [[8.5, 9], [12.5, 12]],
+    [[10.5, 10.5], [12.0, 12]]
+])
 
 y_true_class = np.array([3, 3, 1, 2, 2])
 y_pred_set = np.array(
@@ -94,142 +82,88 @@ y_pred_set_2alphas = np.array([
 Params_ssc_reg = TypedDict(
     "Params_ssc_reg",
     {
-        "intervals": ArrayLike,
-        "n_splits": int,
-        "method": str
+        "y_intervals": NDArray,
+        "num_bins": int
     },
 )
 Params_ssc_classif = TypedDict(
     "Params_ssc_classif",
     {
-        "y_pred_set": ArrayLike,
-        "n_splits": int,
-        "method": str
+        "y_pred_set": NDArray,
+        "num_bins": Union[int, None]
     },
 )
 SSC_REG = {
     "1alpha_base": Params_ssc_reg(
-        intervals=intervals[:, :, 0],
-        n_splits=2,
-        method="uniform"
+        y_intervals=intervals[:, :, 0],
+        num_bins=2
     ),
     "1alpha_3sp": Params_ssc_reg(
-        intervals=intervals[:, :, 0],
-        n_splits=3,
-        method="uniform"
-    ),
-    "1alpha_3sp_quant": Params_ssc_reg(
-        intervals=intervals[:, :, 0],
-        n_splits=3,
-        method="quantile"
-    ),
-    "1alpha_quant": Params_ssc_reg(
-        intervals=intervals[:, :, 0],
-        n_splits=2,
-        method="quantile"
+        y_intervals=intervals[:, :, 0],
+        num_bins=3
     ),
     "2alpha_base": Params_ssc_reg(
-        intervals=intervals,
-        n_splits=2,
-        method="uniform"
+        y_intervals=intervals,
+        num_bins=2
     ),
     "2alpha_3sp": Params_ssc_reg(
-        intervals=intervals,
-        n_splits=3,
-        method="uniform"
-    ),
-    "2alpha_3sp_quant": Params_ssc_reg(
-        intervals=intervals,
-        n_splits=3,
-        method="quantile"
-    ),
-    "2alpha_quant": Params_ssc_reg(
-        intervals=intervals,
-        n_splits=2,
-        method="quantile"
+        y_intervals=intervals,
+        num_bins=3
     ),
 }
 SSC_CLASSIF = {
     "1alpha_base": Params_ssc_classif(
         y_pred_set=y_pred_set_2alphas[:, :, 0],
-        n_splits=2,
-        method="uniform"
+        num_bins=2
     ),
     "1alpha_3sp": Params_ssc_classif(
         y_pred_set=y_pred_set_2alphas[:, :, 0],
-        n_splits=3,
-        method="uniform"
+        num_bins=3
     ),
-    "1alpha_3sp_quant": Params_ssc_classif(
+    "1alpha_None": Params_ssc_classif(
         y_pred_set=y_pred_set_2alphas[:, :, 0],
-        n_splits=3,
-        method="quantile"
-    ),
-    "1alpha_quant": Params_ssc_classif(
-        y_pred_set=y_pred_set_2alphas[:, :, 0],
-        n_splits=2,
-        method="quantile"
+        num_bins=None
     ),
     "2alpha_base": Params_ssc_classif(
         y_pred_set=y_pred_set_2alphas,
-        n_splits=2,
-        method="uniform"
+        num_bins=2,
     ),
     "2alpha_3sp": Params_ssc_classif(
         y_pred_set=y_pred_set_2alphas,
-        n_splits=3,
-        method="uniform"
+        num_bins=3
     ),
-    "2alpha_3sp_quant": Params_ssc_classif(
+    "2alpha_None": Params_ssc_classif(
         y_pred_set=y_pred_set_2alphas,
-        n_splits=3,
-        method="quantile"
-    ),
-    "2alpha_quant": Params_ssc_classif(
-        y_pred_set=y_pred_set_2alphas,
-        n_splits=2,
-        method="quantile"
+        num_bins=None
     ),
 }
 SSC_REG_COVERAGES = {
     "1alpha_base": np.array([[2/3, 1.]]),
     "1alpha_3sp": np.array([[0.5, 1., 1.]]),
-    "1alpha_3sp_quant": np.array([[0.5, 1., 1.]]),
-    "1alpha_quant": np.array([[2/3, 1.]]),
     "2alpha_base": np.array([[2/3, 1.], [1/3, 1.]]),
     "2alpha_3sp": np.array([[0.5, 1., 1.], [0.5, 0.5, 1.]]),
-    "2alpha_3sp_quant": np.array([[0.5, 1., 1.], [0.5, 0., 1.]]),
-    "2alpha_quant": np.array([[2/3, 1.], [1/3, 1.]])
 }
 SSC_REG_COVERAGES_SCORE = {
     "1alpha_base": np.array([2/3]),
     "1alpha_3sp": np.array([0.5]),
-    "1alpha_3sp_quant": np.array([0.5]),
-    "1alpha_quant": np.array([2/3]),
     "2alpha_base": np.array([2/3, 1/3]),
     "2alpha_3sp": np.array([0.5, 0.5]),
-    "2alpha_3sp_quant": np.array([0.5, 0.]),
-    "2alpha_quant": np.array([2/3, 1/3])
 }
 SSC_CLASSIF_COVERAGES = {
     "1alpha_base": np.array([[1/3, 1.]]),
     "1alpha_3sp": np.array([[0.5, 0.5, 1.]]),
-    "1alpha_3sp_quant": np.array([[0.5, 0., 1.]]),
-    "1alpha_quant": np.array([[1/3, 1.]]),
+    "1alpha_None": np.array([[0., 1., 0., 1., 1.]]),
     "2alpha_base": np.array([[1/3, 1.], [1/3, 1.]]),
     "2alpha_3sp": np.array([[0.5, 0.5, 1.], [0.5, 0.5, 1.]]),
-    "2alpha_3sp_quant": np.array([[0.5, 0., 1.], [0.5, 0., 1.]]),
-    "2alpha_quant": np.array([[1/3, 1.], [1/3, 1.]]),
+    "2alpha_None": np.array([[0., 1., 0., 1., 1.], [0., 1., 0., 1., 1.]]),
 }
 SSC_CLASSIF_COVERAGES_SCORE = {
     "1alpha_base": np.array([1 / 3]),
     "1alpha_3sp": np.array([0.5]),
-    "1alpha_3sp_quant": np.array([0.]),
-    "1alpha_quant": np.array([1 / 3]),
+    "1alpha_None": np.array([0.]),
     "2alpha_base": np.array([1 / 3, 1 / 3]),
     "2alpha_3sp": np.array([0.5, 0.5]),
-    "2alpha_3sp_quant": np.array([0., 0.]),
-    "2alpha_quant": np.array([1 / 3, 1 / 3]),
+    "2alpha_None": np.array([0., 0.]),
 }
 
 prng = RandomState(1234567890)
@@ -470,44 +404,30 @@ def test_top_label_same_result() -> None:
     assert scr1 == scr4
 
 
-@pytest.mark.parametrize("method", ["uniform", "quantile"])
-def test_valid_method_regression_ssc(method: str) -> None:
-    """Test that valid method for ssc splits raise no errors."""
-    regression_ssc(y_toy, intervals, method=method)
+@pytest.mark.parametrize("num_bins", [10, 0, -1])
+def test_invalid_splits_regression_ssc(num_bins: int) -> None:
+    """Test that invalid number of bins for ssc raise errors."""
+    with pytest.raises(ValueError):
+        regression_ssc(y_toy, intervals, num_bins=num_bins)
 
 
-@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
-def test_invalid_method_regression_ssc(method: str) -> None:
-    """Test that invalid method for ssc splits raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
-        regression_ssc(y_toy, intervals, method=method)
+@pytest.mark.parametrize("num_bins", [10, 0, -1])
+def test_invalid_splits_regression_ssc_score(num_bins: int) -> None:
+    """Test that invalid number of bins for ssc raise errors."""
+    with pytest.raises(ValueError):
+        regression_ssc_score(y_toy, intervals, num_bins=num_bins)
 
 
-@pytest.mark.parametrize("n_splits", [10, 0, 1])
-def test_invalid_splits_regression_ssc(n_splits: int) -> None:
-    """Test that invalid number of splits for ssc raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
-        regression_ssc(y_toy, intervals, n_splits=n_splits)
+@pytest.mark.parametrize("num_bins", [1, 2, 3])
+def test_valid_splits_regression_ssc(num_bins: int) -> None:
+    """Test that valid number of bins for ssc raise no error."""
+    regression_ssc(y_toy, intervals, num_bins=num_bins)
 
 
-@pytest.mark.parametrize("method", ["uniform", "quantile"])
-def test_valid_method_regression_ssc_score(method: str) -> None:
-    """Test that valid method for ssc splits raise no errors."""
-    regression_ssc_score(y_toy, intervals, method=method)
-
-
-@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
-def test_invalid_method_regression_ssc_score(method: str) -> None:
-    """Test that invalid method for ssc splits raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
-        regression_ssc_score(y_toy, intervals, method=method)
-
-
-@pytest.mark.parametrize("n_splits", [10, 0, 1])
-def test_invalid_splits_regression_ssc_score(n_splits: int) -> None:
-    """Test that invalid number of splits for ssc raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
-        regression_ssc_score(y_toy, intervals, n_splits=n_splits)
+@pytest.mark.parametrize("num_bins", [1, 2, 3])
+def test_valid_splits_regression_ssc_score(num_bins: int) -> None:
+    """Test that valid number of bins for ssc score raise no error."""
+    regression_ssc_score(y_toy, intervals, num_bins=num_bins)
 
 
 @pytest.mark.parametrize("params", [*SSC_REG])
@@ -538,48 +458,32 @@ def test_regression_ssc_score_coverage_values(params: str):
     np.testing.assert_allclose(cond_cov_min, SSC_REG_COVERAGES_SCORE[params])
 
 
-@pytest.mark.parametrize("method", ["uniform", "quantile"])
-def test_valid_method_classification_ssc(method: str) -> None:
-    """Test that valid method for ssc splits raise no errors."""
-    classification_ssc(y_true_class, y_pred_set_2alphas, method=method)
+@pytest.mark.parametrize("num_bins", [10, 0, -1])
+def test_invalid_splits_classification_ssc(num_bins: int) -> None:
+    """Test that invalid number of bins for ssc raise errors."""
+    with pytest.raises(ValueError):
+        classification_ssc(y_true_class, y_pred_set_2alphas, num_bins=num_bins)
 
 
-@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
-def test_invalid_method_classification_ssc(method: str) -> None:
-    """Test that invalid method for ssc splits raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
-        classification_ssc(y_true_class, y_pred_set_2alphas, method=method)
+@pytest.mark.parametrize("num_bins", [10, 0, -1])
+def test_invalid_splits_classification_ssc_score(num_bins: int) -> None:
+    """Test that invalid number of bins for ssc raise errors."""
+    with pytest.raises(ValueError):
+        classification_ssc_score(y_true_class, y_pred_set_2alphas,
+                                 num_bins=num_bins)
 
 
-@pytest.mark.parametrize("n_splits", [10, 0, 1])
-def test_invalid_splits_classification_ssc(n_splits: int) -> None:
-    """Test that invalid number of splits for ssc raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
-        classification_ssc(y_true_class, y_pred_set_2alphas, n_splits=n_splits)
+@pytest.mark.parametrize("num_bins", [3, 2, None])
+def test_valid_splits_classification_ssc(num_bins: int) -> None:
+    """Test that valid number of bins for ssc raise no error."""
+    classification_ssc(y_true_class, y_pred_set_2alphas, num_bins=num_bins)
 
 
-@pytest.mark.parametrize("method", ["uniform", "quantile"])
-def test_valid_method_classification_ssc_score(method: str) -> None:
-    """Test that valid method for ssc splits raise no errors."""
-    classification_ssc_score(y_true_class, y_pred_set_2alphas, method=method)
-
-
-@pytest.mark.parametrize("method", ["equal", 5, [6, 7]])
-def test_invalid_method_classification_ssc_score(method: str) -> None:
-    """Test that invalid method for ssc splits raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid method for ssc splits*"):
-        classification_ssc_score(
-            y_true_class, y_pred_set_2alphas, method=method
-        )
-
-
-@pytest.mark.parametrize("n_splits", [10, 0, 1])
-def test_invalid_splits_classification_ssc_score(n_splits: int) -> None:
-    """Test that invalid number of splits for ssc raise errors."""
-    with pytest.raises(ValueError, match=r".*Invalid number of splits*"):
-        classification_ssc_score(
-            y_true_class, y_pred_set_2alphas, n_splits=n_splits
-        )
+@pytest.mark.parametrize("num_bins", [3, 2, None])
+def test_valid_splits_classification_ssc_score(num_bins: int) -> None:
+    """Test that valid number of bins for ssc raise no error."""
+    classification_ssc_score(y_true_class, y_pred_set_2alphas,
+                             num_bins=num_bins)
 
 
 @pytest.mark.parametrize("params", [*SSC_CLASSIF])
@@ -592,32 +496,9 @@ def test_classification_ssc_return_shape(params: str) -> None:
 @pytest.mark.parametrize("params", [*SSC_CLASSIF])
 def test_classification_ssc_score_return_shape(params: str) -> None:
     """Test that the arrays returned by ssc metrics have the correct shape."""
-    cond_cov_min = classification_ssc_score(
-        y_true_class, **SSC_CLASSIF[params]
-    )
+    cond_cov_min = classification_ssc_score(y_true_class,
+                                            **SSC_CLASSIF[params])
     assert cond_cov_min.shape == SSC_CLASSIF_COVERAGES_SCORE[params].shape
-
-
-@pytest.mark.parametrize("params", [*SSC_CLASSIF])
-def test_classification_ssc_return_shape_n_classes(params: str) -> None:
-    """
-    Test that the arrays returned by ssc metrics have the correct shape,
-    when splits=None, there is n_classes+1 groups.
-    """
-    cond_cov = classification_ssc(y_true_class, **SSC_CLASSIF[params])
-    assert cond_cov.shape == SSC_CLASSIF_COVERAGES[params].shape
-
-
-@pytest.mark.parametrize("params", [*SSC_CLASSIF])
-def test_classification_ssc_score_return_shape_n_classes(params: str) -> None:
-    """
-    Test that the arrays returned by ssc metrics have the correct shape,
-    when splits=None, there is n_classes+1 groups.
-    """
-    cond_cov_min = classification_ssc_score(
-        y_true_class, **SSC_CLASSIF[params]
-    )
-    assert cond_cov_min.shape == SSC_CLASSIF_COVERAGES_SCORE[params]
 
 
 @pytest.mark.parametrize("params", [*SSC_CLASSIF])
@@ -630,31 +511,34 @@ def test_classification_ssc_coverage_values(params: str):
 @pytest.mark.parametrize("params", [*SSC_CLASSIF])
 def test_classification_ssc_score_coverage_values(params: str):
     """Test that the conditional coverage values returned are correct."""
-    cond_cov_min = classification_ssc_score(
-        y_true_class, **SSC_CLASSIF[params]
-    )
+    cond_cov_min = classification_ssc_score(y_true_class,
+                                            **SSC_CLASSIF[params])
     np.testing.assert_allclose(
         cond_cov_min, SSC_CLASSIF_COVERAGES_SCORE[params]
     )
 
 
-@pytest.mark.parametrize("kernel_sizes", [(1, 2, 1), [1], 2, [[1, 2]]])
+@pytest.mark.parametrize("kernel_sizes", [[1], 2, [[1, 2]]])
 def test_hsic_invalid_kernel_sizes(kernel_sizes: ArrayLike):
-    with pytest.raises(TypeError):
+    """Test that invalid kernel sizes raises an error"""
+    with pytest.raises(ValueError):
         hsic(y_toy, intervals, kernel_sizes=kernel_sizes)
 
 
-@pytest.mark.parametrize("kernel_sizes", [(1, 1), (2, 2), (3, 1)])
+@pytest.mark.parametrize("kernel_sizes", [(1, 1), [2, 2], (3, 1)])
 def test_hsic_valid_kernel_sizes(kernel_sizes: ArrayLike):
+    """Test that valid kernel sizes raises no errors"""
     hsic(y_toy, intervals, kernel_sizes=kernel_sizes)
 
 
 @pytest.mark.parametrize("kernel_sizes", [(1, 1), (2, 2), (3, 1)])
 def test_hsic_return_shape(kernel_sizes: ArrayLike):
+    """Test that the arrau returned by hsic has the good shape"""
     coef = hsic(y_toy, intervals, kernel_sizes=kernel_sizes)
     assert coef.shape == (2,)
 
 
 def test_hsic_correlation_value():
+    """Test that the values returned by hsic are correct"""
     coef = hsic(y_toy, intervals, kernel_sizes=(1, 1))
     np.testing.assert_allclose(coef, np.array([0.16829506, 0.3052798]))

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1071,3 +1071,73 @@ def fix_number_of_classes(
         axis=1
     )
     return y_pred_full
+
+
+def check_array_shape_classification(
+        y_true: NDArray,
+        y_pred_set: NDArray
+) -> Tuple[NDArray, NDArray]:
+    """
+    Fix shape of y_true (to 1d array) and y_pred_sets (to 3d array
+    of shape (n_obs, n_class, n_alpha)).
+    Raise an error if y_true and y_pred_set doesn't have the same
+    number of observations, if y_pred_sets is an array of shape greater
+    than 3 or lower than 2.
+
+    Parameters
+    ----------
+    y_true : ArrayLike
+        True labels.
+    y_pred_set : ArrayLike
+        Prediction sets given by booleans of labels.
+    """
+    y_true = cast(NDArray, column_or_1d(y_true))
+    if y_true.shape[0] != y_pred_set.shape[0]:
+        raise ValueError(
+            f"shape mismatch between y_true {y_true.shape} \
+                and y_pred_set {y_pred_set.shape}"
+        )
+    if len(y_pred_set.shape) != 3:
+        if len(y_pred_set.shape) != 2:
+            raise ValueError(
+                "intervals should be a 3D array of shape \
+                (n_obs, n_classes, n_alpha)"
+            )
+        else:
+            y_pred_set = np.expand_dims(y_pred_set, axis=2)
+    return y_true, y_pred_set
+
+
+def check_array_shape_regression(
+        y_true: NDArray,
+        y_intervals: NDArray
+) -> Tuple[NDArray, NDArray]:
+    """
+    Fix shape of y_true (to 1d array) and y_intervals (to 3d array
+    of shape (n_obs, 2, n_alpha)).
+    Raise an error if y_true and y_intervals doesn't have the same
+    number of observations, if y_intervals is an array of shape greater
+    than 3 or lower than 2.
+
+    Parameters
+    ----------
+    y_true : NDArray
+        True labels.
+    y_intervals : NDArray
+        Lower and upper bound of prediction intervals
+        with different alpha risks.
+    """
+    y_true = cast(NDArray, column_or_1d(y_true))
+    if len(y_intervals.shape) != 3:
+        if len(y_intervals.shape) != 2:
+            raise ValueError(
+                "intervals should be a 3D array of shape (n_obs, 2, n_alpha)"
+            )
+        else:
+            y_intervals = np.expand_dims(y_intervals, axis=2)
+    if y_true.shape[0] != y_intervals.shape[0]:
+        raise ValueError(
+            f"shape mismatch between y_true {y_true.shape} \
+                and y_pred_set {y_intervals.shape}"
+        )
+    return y_true, y_intervals


### PR DESCRIPTION
# Description

There is no metrics to compute conditional coverage that can estimate the model capacity to have good "local" coverage that depends on interval or set size (both classification and regression).
Implement conditional coverage metrics for both classification and regression.

Fixes #309 

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Regression SSC function on toyset
- [ ] Test Classification SSC function on toyset
- [ ] Test HSIC function on toyset

# Checklist

- [X] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [X] Linting passes successfully : `make lint`
- [X] Typing passes successfully : `make type-check`
- [X] Unit tests pass successfully : `make tests`
- [X] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`