### PR TITLE
Adaptive conformal prediction method with a conformity score

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 ##### (##########)
 ------------------
+* Add a new conformity score : ConformalizedResidualFitting that takes X into account and allows to compute adaptive intervals.
 * Refactor MapieRegressor and ConformityScore to add the possibility to use X in ConformityScore.
 * Separate the handling of the estimator from MapieRegressor into a new class called EnsembleEstimator.
 * Fix an unfixed random state in one of the classification tests

--- a/mapie/conformity_scores/__init__.py
+++ b/mapie/conformity_scores/__init__.py
@@ -1,9 +1,11 @@
 from .conformity_scores import ConformityScore
 from .residual_conformity_scores import (AbsoluteConformityScore,
-                                         GammaConformityScore)
+                                         GammaConformityScore,
+                                         FittedResidualNormalisingScore)
 
 __all__ = [
     "ConformityScore",
     "AbsoluteConformityScore",
-    "GammaConformityScore"
+    "GammaConformityScore",
+    "FittedResidualNormalisingScore"
 ]

--- a/mapie/conformity_scores/__init__.py
+++ b/mapie/conformity_scores/__init__.py
@@ -1,11 +1,11 @@
 from .conformity_scores import ConformityScore
 from .residual_conformity_scores import (AbsoluteConformityScore,
                                          GammaConformityScore,
-                                         FittedResidualNormalisingScore)
+                                         ConformalResidualFittingScore)
 
 __all__ = [
     "ConformityScore",
     "AbsoluteConformityScore",
     "GammaConformityScore",
-    "FittedResidualNormalisingScore"
+    "ConformalResidualFittingScore"
 ]

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -387,7 +387,7 @@ class ConformalResidualFittingScore(ConformityScore):
             self.eps
         )
         signed_conformity_scores = np.divide(
-            np.abs(np.subtract(y[cal_indexes], y_pred[cal_indexes])),
+            np.subtract(y[cal_indexes], y_pred[cal_indexes]),
             residuals_pred
         )
 

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -188,9 +188,11 @@ class ConformalResidualFittingScore(ConformityScore):
         residual_estimator: Optional[RegressorMixin] = None,
         prefit: bool = False,
         split_size: Optional[Union[int, float]] = None,
-        random_state: Optional[Union[int, np.random.RandomState]] = None
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
+        sym: bool = True,
+        consistency_check: bool = False
     ) -> None:
-        super().__init__(sym=True, consistency_check=False)
+        super().__init__(sym=sym, consistency_check=consistency_check)
         self.prefit = prefit
         self.residual_estimator = residual_estimator
         self.split_size = split_size

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -433,7 +433,7 @@ class ConformalResidualFittingScore(ConformityScore):
         ``conformity_scores`` can be either the conformity scores or
         the quantile of the conformity scores.
         """
-        r_pred = self._predict_residual_estimator(X)
+        r_pred = self._predict_residual_estimator(X).reshape((-1, 1))
         if not self.prefit:
             return np.add(
                 y_pred,

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -392,12 +392,9 @@ class ConformalResidualFittingScore(ConformityScore):
         )
 
         # reconstruct array with nan and conformity scores
-        complete_signed_cs = np.zeros_like(y_pred)
+        complete_signed_cs = np.zeros_like(y_pred, dtype=float)
         complete_signed_cs[cal_indexes] = signed_conformity_scores
-        complete_signed_cs[train_indexes] = np.full(
-            (train_indexes.shape[0],),
-            np.nan
-        )
+        complete_signed_cs[train_indexes] = np.nan
         return signed_conformity_scores
 
     def get_estimation_distribution(

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -174,7 +174,7 @@ class ConformalResidualFittingScore(ConformityScore):
 
     split_size: Optional[Union[int, float]]
         The proportion of data that is used to fit the ``residual_estimator``.
-        By default it is the defaukt of
+        By default it is the default of
         ``sklearn.model_selection.train_test_split`` ie 0.2.
 
     random_state: Optional[Union[int, np.random.RandomState]]

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -143,11 +143,9 @@ class GammaConformityScore(ConformityScore):
         return np.multiply(y_pred, np.add(1, conformity_scores))
 
 
-class FittedResidualNormalisingScore(ConformityScore):
-    # or ConformalResiudalFittingScore
-    # or NormalizedScore
+class ConformalResidualFittingScore(ConformityScore):
     """
-    FittedResidualNormalisingScore (also called CRF) score.
+    ConformalResidualFittingScore (CRF) score.
 
     The signed conformity score = (y - y_pred) / r_pred. r_pred being the
     predicted residual (|y - y_pred|) of the base estimator.

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -392,7 +392,7 @@ class ConformalResidualFittingScore(ConformityScore):
         )
 
         # reconstruct array with nan and conformity scores
-        complete_signed_cs = np.zeros(y_pred.shape)
+        complete_signed_cs = np.zeros_like(y_pred)
         complete_signed_cs[cal_indexes] = signed_conformity_scores
         complete_signed_cs[train_indexes] = np.full(
             (train_indexes.shape[0],),

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -169,14 +169,14 @@ class ConformalResidualFittingScore(ConformityScore):
         If ``None``, estimator defaults to a ``LinearRegression`` instance.
 
     prefit: bool
-        Specify if the residual_estimator is already fitted or not.
+        Specify if the ``residual_estimator` is already fitted or not.
         By default ``False``.
 
     split_size: Optional[Union[int, float]]
-        The proportion of data that is used to fit the residual_estimator
+        The proportion of data that is used to fit the ``residual_estimator``.
         By default 0.5.
 
-    random_state: 0ptional[Union[int, np.random.RandomState]]
+    random_state: Optional[Union[int, np.random.RandomState]]
         Pseudo random number used for random sampling.
         Pass an int for reproducible output across multiple function calls.
         By default ``None``.
@@ -296,17 +296,17 @@ class ConformalResidualFittingScore(ConformityScore):
 
         Parameters
         ----------
-        X : NDArray
+        X: NDArray
             All the observed values used in the general fit.
 
-        y : NDArray
+        y: NDArray
             All the observed targets used in the general fit.
 
-        y_pred : NDArray
+        y_pred: NDArray
             Predicted targets.
 
-        calres_indexes : NDArray
-            Indexes used for the training of the estimaot and the calibration.
+        calres_indexes: NDArray
+            Indexes used for the training of the estimator and the calibration.
 
         Returns
         -------
@@ -401,7 +401,7 @@ class ConformalResidualFittingScore(ConformityScore):
         """
         Compute samples of the estimation distribution from the predicted
         values and the conformity scores, from the following formula:
-        y_pred + conformity_scores * r_pred.
+        `y_pred + conformity_scores * r_pred``.
 
         The learning has been done with the log of the residual so we use the
         exponential of the prediction to avoid negative values.

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -147,7 +147,7 @@ class ConformalResidualFittingScore(ConformityScore):
     """
     ConformalResidualFittingScore (CRF) score.
 
-    The signed conformity score = (y - y_pred) / r_pred. r_pred being the
+    The signed conformity score = (|y - y_pred|) / r_pred. r_pred being the
     predicted residual (|y - y_pred|) of the base estimator.
     It is calculated by a model that learns to predict these residuals.
     The learning is done with the log of the residual and we use the
@@ -249,7 +249,7 @@ class ConformalResidualFittingScore(ConformityScore):
         y: ArrayLike,
         y_pred: ArrayLike
     ) -> Tuple[NDArray, NDArray, NDArray, RegressorMixin,
-               Union[int, np.random.RandomState]]:
+    Union[int, np.random.RandomState]]:
         """
         Checks all the parameters of the class. Raises an error if the
         parameter are not well defined.

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -249,7 +249,7 @@ class ConformalResidualFittingScore(ConformityScore):
         y: ArrayLike,
         y_pred: ArrayLike
     ) -> Tuple[NDArray, NDArray, NDArray, RegressorMixin,
-    Union[int, np.random.RandomState]]:
+               Union[int, np.random.RandomState]]:
         """
         Checks all the parameters of the class. Raises an error if the
         parameter are not well defined.

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -349,7 +349,7 @@ class ConformalResidualFittingScore(ConformityScore):
             the residuals and predict the exponential of the predictions.
         """
         pred = self.residual_estimator_.predict(X)
-        if np.any(pred < 0):
+        if self.prefit and np.any(pred < 0):
             warnings.warn(
                 "WARNING: The residual model predicts negative values, "
                 + "they are later thresholded at self.eps."

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -169,7 +169,7 @@ class ConformalResidualFittingScore(ConformityScore):
         If ``None``, estimator defaults to a ``LinearRegression`` instance.
 
     prefit: bool
-        Specify if the ``residual_estimator` is already fitted or not.
+        Specify if the ``residual_estimator`` is already fitted or not.
         By default ``False``.
 
     split_size: Optional[Union[int, float]]
@@ -407,7 +407,7 @@ class ConformalResidualFittingScore(ConformityScore):
         """
         Compute samples of the estimation distribution from the predicted
         values and the conformity scores, from the following formula:
-        `y_pred + conformity_scores * r_pred``.
+        ``y_pred + conformity_scores * r_pred``.
 
         The learning has been done with the log of the residual so we use the
         exponential of the prediction to avoid negative values.

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -377,7 +377,8 @@ class ConformalResidualFittingScore(ConformityScore):
         if not self.prefit:
             cal_indexes, train_indexes = self._fit_residual_estimator(
                 clone(self.residual_estimator_), X, y, y_pred, full_indexes,
-                random_state)
+                random_state
+            )
         else:
             cal_indexes = full_indexes
             train_indexes = np.argwhere(np.isnan(y_pred)).reshape((-1,))

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -1,4 +1,13 @@
+from typing import Optional, Union, Tuple
+
 import numpy as np
+from sklearn.base import RegressorMixin, clone
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.utils.validation import (check_is_fitted,
+                                      check_random_state,
+                                      indexable)
 
 from mapie._machine_precision import EPSILON
 from mapie._typing import ArrayLike, NDArray
@@ -132,3 +141,275 @@ class GammaConformityScore(ConformityScore):
         """
         self._check_predicted_data(y_pred)
         return np.multiply(y_pred, np.add(1, conformity_scores))
+
+
+class FittedResidualNormalisingScore(ConformityScore):
+    # or ConformalResiudalFittingScore
+    # or NormalizedScore
+    """
+    FittedResidualNormalisingScore (also called CRF) score.
+
+    The signed conformity score = (y - y_pred) / r_pred. r_pred being the
+    predicted residual (|y - y_pred|) of the base estimator.
+    It is calculated by a model that learns to predict these residuals.
+    The learning is done with the log of the residual and we use the
+    exponential of the prediction to avoid negative values.
+
+    The conformity score is symmetrical and allows the calculation of adaptive
+    prediction intervals (taking X into account). It is possible to use it
+    only with split and prefit methods (not with cross methods).
+
+    Warning : if the estimator provided is not fitted a subset of the
+    calibration data will be used to fit the model (50% by default).
+
+    Parameters
+    ----------
+    residual_estimator: Optional[RegressorMixin]
+        The model that learns to predict the residuals of the base estimator.
+        It can be any regressor with scikit-learn API (i.e. with ``fit``
+        and ``predict`` methods).
+        If ``None``, estimator defaults to a ``LinearRegression`` instance.
+
+    prefit: bool
+        Specify if the residual_estimator is already fitted or not.
+        By default ``False``.
+
+    split_size: Optional[Union[int, float]]
+        The proportion of data that is used to fit the residual_estimator
+        By default 0.5.
+
+    random_state: 0ptional[Union[int, np.random.RandomState]]
+        Pseudo random number used for random sampling.
+        Pass an int for reproducible output across multiple function calls.
+        By default ``None``.
+    """
+
+    def __init__(
+        self,
+        residual_estimator: Optional[RegressorMixin] = None,
+        prefit: bool = False,
+        split_size: Optional[Union[int, float]] = None,
+        random_state: Optional[Union[int, np.random.RandomState]] = None
+    ) -> None:
+        super().__init__(sym=True, consistency_check=False)
+        self.prefit = prefit
+        self.residual_estimator = residual_estimator
+        self.split_size = split_size
+        self.random_state = random_state
+
+    def _check_estimator(
+        self, estimator: Optional[RegressorMixin] = None
+    ) -> RegressorMixin:
+        """
+        Check if estimator is ``None``,
+        and returns a ``LinearRegression`` instance if necessary.
+        If the ``prefit`` attribute is ``True``,
+        check if estimator is indeed already fitted.
+
+        Parameters
+        ----------
+        estimator: Optional[RegressorMixin]
+            Estimator to check, by default ``None``.
+
+        Returns
+        -------
+        RegressorMixin
+            The estimator itself or a default ``LinearRegression`` instance.
+
+        Raises
+        ------
+        ValueError
+            If the estimator is not ``None``
+            and has no ``fit`` nor ``predict`` methods.
+
+        NotFittedError
+            If the estimator is not fitted
+            and ``prefit`` attribute is ``True``.
+        """
+        if estimator is None:
+            return LinearRegression()
+        else:
+            if not (hasattr(estimator, "fit") and
+                    hasattr(estimator, "predict")):
+                raise ValueError(
+                    "Invalid estimator. "
+                    "Please provide a regressor with fit and predict methods."
+                )
+            if self.prefit:
+                if isinstance(estimator, Pipeline):
+                    check_is_fitted(estimator[-1])
+                else:
+                    check_is_fitted(estimator)
+            return estimator
+
+    def _check_parameters(
+        self,
+        X: ArrayLike,
+        y: ArrayLike,
+        y_pred: ArrayLike
+    ) -> Tuple[NDArray, NDArray, NDArray, RegressorMixin]:
+        """
+        Checks all the parameters of the class. Raises an error if the
+        parameter are not well defined.
+
+        Parameters
+        ----------
+        X: ArrayLike
+            Observed values.
+
+        y: ArrayLike
+            Target values.
+
+        y_pred: ArrayLike
+            Predicted targets.
+
+        Returns
+        -------
+        Tuple[NDArray, NDArray, NDArray, RegressorMixin]
+        Well initiated and typed :
+            - X
+            - y
+            - y_pred
+            - residual_estimator
+        """
+        residual_estimator = self._check_estimator(
+            self.residual_estimator
+        )
+        check_random_state(self.random_state)
+        if self.split_size is None:
+            self.split_size = 0.5
+        X, y, y_pred = indexable(X, y, y_pred)
+        X = np.array(X)
+        y = np.array(y)
+        y_pred = np.array(y_pred)
+        return X, y, y_pred, residual_estimator
+
+    def _fit_residual_estimator(
+        self,
+        residual_estimator_: RegressorMixin,
+        X: NDArray,
+        y: NDArray,
+        y_pred: NDArray,
+        calres_indexes: NDArray
+    ) -> Tuple[NDArray, NDArray]:
+        """
+        Fit the residual estimator and returns the indexes used for the
+        training of the base estimator and those needed for the calibration.
+
+        Parameters
+        ----------
+        X : NDArray
+            All the observed values used in the general fit.
+
+        y : NDArray
+            All the observed targets used in the general fit.
+
+        y_pred : NDArray
+            Predicted targets.
+
+        calres_indexes : NDArray
+            Indexes used for the training of the estimaot and the calibration.
+
+        Returns
+        -------
+        Tuple[NDArray, NDArray]
+            - indexes needed for the calibration.
+            - indexes used for the training of the base estimator.
+        """
+        (X_res_indexes,
+         X_cal_indexes,
+         y_res_indexes,
+         y_cal_indexes) = train_test_split(
+            calres_indexes,
+            calres_indexes,
+            test_size=self.split_size,
+            random_state=self.random_state,
+        )
+
+        residuals = np.abs(np.subtract(
+            y[y_res_indexes],
+            y_pred[y_res_indexes]
+        ))
+        residual_estimator_targets = np.log(np.maximum(
+            residuals,
+            np.full(residuals.shape, self.eps)
+        ))
+
+        residual_estimator_ = residual_estimator_.fit(
+            X[X_res_indexes],
+            residual_estimator_targets
+        )
+
+        cal_index = X_cal_indexes
+        train_index = list(set(np.arange(y_pred.shape[0])) - set(cal_index))
+
+        self.residual_estimator_ = residual_estimator_
+
+        return cal_index, np.array(train_index)
+
+    def get_signed_conformity_scores(
+        self,
+        X: ArrayLike,
+        y: ArrayLike,
+        y_pred: ArrayLike
+    ) -> NDArray:
+        """
+        Computes the signed conformity score = (y - y_pred) / r_pred.
+        r_pred being the predicted residual (y - y_pred) of the estimator.
+        It is calculated by a model (``residual_estimator_``) that learns
+        to predict this residual.
+
+        The learning is done with the log of the residual and later we
+        use the exponential of the prediction to avoid negative values.
+        """
+        X, y, y_pred, self.residual_estimator_ = self._check_parameters(
+            X, y, y_pred
+        )
+        calres_indexes = np.argwhere(
+                            np.logical_not(np.isnan(y_pred))
+                        ).reshape((-1, ))
+        if not self.prefit:
+            cal_indexes, train_indexes = self._fit_residual_estimator(
+                clone(self.residual_estimator_), X, y, y_pred, calres_indexes
+            )
+        else:
+            cal_indexes = calres_indexes
+            train_indexes = np.argwhere(np.isnan(y_pred)).reshape((-1,))
+
+        normalizer = np.maximum(
+            np.exp(self.residual_estimator_.predict(X[cal_indexes])),
+            self.eps
+        )
+        signed_conformity_scores = np.divide(
+            np.abs(np.subtract(y[cal_indexes], y_pred[cal_indexes])),
+            normalizer
+        )
+
+        # reconstruct array with nan and conformity scores
+        complete_signed_cs = np.zeros(y_pred.shape)
+        complete_signed_cs[cal_indexes] = signed_conformity_scores
+        complete_signed_cs[train_indexes] = np.full(
+            (train_indexes.shape[0],),
+            np.nan
+        )
+        return signed_conformity_scores
+
+    def get_estimation_distribution(
+        self,
+        X: ArrayLike,
+        y_pred: ArrayLike,
+        conformity_scores: ArrayLike
+    ) -> NDArray:
+        """
+        Compute samples of the estimation distribution from the predicted
+        values and the conformity scores, from the following formula:
+        y_pred + conformity_scores * r_pred.
+
+        The learning has been done with the log of the residual so we use the
+        exponential of the prediction to avoid negative values.
+
+        ``conformity_scores`` can be either the conformity scores or
+        the quantile of the conformity scores.
+        """
+        r_pred = np.exp(self.residual_estimator_.predict(X))
+        return np.add(y_pred, np.multiply(conformity_scores, r_pred))

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -174,7 +174,7 @@ class ConformalResidualFittingScore(ConformityScore):
 
     split_size: Optional[Union[int, float]]
         The proportion of data that is used to fit the ``residual_estimator``.
-        By default it is the default of
+        By default it is the default value of
         ``sklearn.model_selection.train_test_split`` ie 0.2.
 
     random_state: Optional[Union[int, np.random.RandomState]]

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -12,7 +12,8 @@ from sklearn.utils.validation import (_check_y, check_is_fitted,
                                       indexable)
 
 from mapie._typing import ArrayLike, NDArray
-from mapie.conformity_scores import ConformityScore
+from mapie.conformity_scores import (ConformityScore,
+                                     FittedResidualNormalisingScore)
 from mapie.estimator.estimator import EnsembleRegressor
 from mapie.utils import (check_alpha, check_alpha_and_n_samples,
                          check_conformity_score, check_cv,
@@ -388,6 +389,27 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         y: ArrayLike,
         sample_weight: Optional[ArrayLike] = None,
     ):
+        """
+        Perform several checks on class parameters.
+
+        Parameters
+        ----------
+        X: ArrayLike
+            Observed values.
+
+        y: ArrayLike
+            Target values.
+
+        sample_weight: Optional[NDArray] of shape (n_samples,)
+            Non-null sample weights.
+
+        Raises
+        ------
+        ValueError
+            If conformity score is FittedResidualNormalizing score and method
+            is neither ``"prefit"`` or ``"split"``
+
+        """
         # Checking
         self._check_parameters()
         cv = check_cv(
@@ -398,6 +420,13 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         cs_estimator = check_conformity_score(
             self.conformity_score
         )
+        if isinstance(cs_estimator, FittedResidualNormalisingScore) and \
+           self.cv not in ["split", "prefit"]:
+            raise ValueError(
+                "The FittedResisualNormalizingScore can be used only with "
+                "``split`` and ``prefit`` methods"
+            )
+
         X, y = indexable(X, y)
         y = _check_y(y)
         sample_weight, X, y = check_null_weight(sample_weight, X, y)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -13,7 +13,7 @@ from sklearn.utils.validation import (_check_y, check_is_fitted,
 
 from mapie._typing import ArrayLike, NDArray
 from mapie.conformity_scores import (ConformityScore,
-                                     FittedResidualNormalisingScore)
+                                     ConformalResidualFittingScore)
 from mapie.estimator.estimator import EnsembleRegressor
 from mapie.utils import (check_alpha, check_alpha_and_n_samples,
                          check_conformity_score, check_cv,
@@ -420,7 +420,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         cs_estimator = check_conformity_score(
             self.conformity_score
         )
-        if isinstance(cs_estimator, FittedResidualNormalisingScore) and \
+        if isinstance(cs_estimator, ConformalResidualFittingScore) and \
            self.cv not in ["split", "prefit"]:
             raise ValueError(
                 "The FittedResisualNormalizingScore can be used only with "

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -408,7 +408,6 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         ValueError
             If conformity score is FittedResidualNormalizing score and method
             is neither ``"prefit"`` or ``"split"``
-
         """
         # Checking
         self._check_parameters()

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -71,8 +71,9 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         - ``"split"``, does not involve cross-validation but a division
           of the data into training and calibration subsets. The splitter
           used is the following: ``sklearn.model_selection.ShuffleSplit``.
+          ``method`` parameter is set to ``"base"``.
         - ``"prefit"``, assumes that ``estimator`` has been fitted already,
-          and the ``method`` parameter is ignored.
+          and the ``method`` parameter is set to ``"base"``.
           All data provided in the ``fit`` method is then used
           for computing conformity scores only.
           At prediction time, quantiles of these conformity scores are used
@@ -407,13 +408,19 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         ------
         ValueError
             If conformity score is FittedResidualNormalizing score and method
-            is neither ``"prefit"`` or ``"split"``
+            is neither ``"prefit"`` or ``"split"``.
+
+        ValueError
+            If ``cv`` is `"prefit"`` or ``"split"`` and ``method`` is not
+            ``"base"``.
         """
         # Checking
         self._check_parameters()
         cv = check_cv(
             self.cv, test_size=self.test_size, random_state=self.random_state
         )
+        if self.cv in ["split", "prefit"] and self.method != "base":
+            self.method = "base"
         estimator = self._check_estimator(self.estimator)
         agg_function = self._check_agg_function(self.agg_function)
         cs_estimator = check_conformity_score(
@@ -422,8 +429,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         if isinstance(cs_estimator, ConformalResidualFittingScore) and \
            self.cv not in ["split", "prefit"]:
             raise ValueError(
-                "The FittedResisualNormalizingScore can be used only with "
-                "``split`` and ``prefit`` methods"
+                "The ConformalResidualFittingScore can be used only with "
+                "``cv='split'`` and ``cv='prefit'``"
             )
 
         X, y = indexable(X, y)

--- a/mapie/tests/test_conformity_scores.py
+++ b/mapie/tests/test_conformity_scores.py
@@ -254,7 +254,7 @@ def test_crf_conformity_score_get_conformity_scores(y_pred: NDArray) -> None:
         X_toy, y_toy, y_pred
     )
     expected_signed_conf_scores = np.array(
-        [4.641589e-10, 0.000000e+00, 3.000000e+08]
+        [0.38167789, 0.]
     )
     np.testing.assert_allclose(conf_scores, expected_signed_conf_scores)
 
@@ -276,7 +276,7 @@ def test_crf_score_prefit_with_default_params() -> None:
     conf_scores = crf_conf_score.get_conformity_scores(
         X_toy, y_toy, y_pred_list
     )
-    _, X, _, y = train_test_split(X_toy, y_toy, test_size=0.5)
+    _, X, _, y = train_test_split(X_toy, y_toy, test_size=0.2)
     crf_conf_score.get_estimation_distribution(X, y, conf_scores)
 
 

--- a/mapie/tests/test_conformity_scores.py
+++ b/mapie/tests/test_conformity_scores.py
@@ -279,7 +279,7 @@ def test_crf_score_prefit_with_default_params() -> None:
 
 
 def test_invalid_estimator() -> None:
-    """Test that an estimator without predct method raises an error."""
+    """Test that an estimator without predict method raises an error."""
     class DumbEstimator:
         def __init__(self):
             pass

--- a/mapie/tests/test_conformity_scores.py
+++ b/mapie/tests/test_conformity_scores.py
@@ -261,7 +261,7 @@ def test_crf_conformity_score_get_conformity_scores(y_pred: NDArray) -> None:
 def test_crf_score_prefit_with_notfitted_estim() -> None:
     """Test that a not fitted estimator and prefit=True raises an error."""
     crf_conf_score = ConformalResidualFittingScore(
-            residual_estimator=LinearRegression(), prefit=True
+        residual_estimator=LinearRegression(), prefit=True
     )
     with pytest.raises(ValueError):
         crf_conf_score.get_conformity_scores(

--- a/mapie/tests/test_conformity_scores.py
+++ b/mapie/tests/test_conformity_scores.py
@@ -10,7 +10,7 @@ from mapie._typing import ArrayLike, NDArray
 from mapie.conformity_scores import (AbsoluteConformityScore,
                                      ConformityScore,
                                      GammaConformityScore,
-                                     FittedResidualNormalisingScore)
+                                     ConformalResidualFittingScore)
 from mapie.regression import MapieRegressor
 
 X_toy = np.array([0, 1, 2, 3, 4, 5]).reshape(-1, 1)
@@ -231,7 +231,7 @@ def test_crf_prefit_conformity_score_get_conformity_scores(
     when prefit is True.
     """
     residual_estimator = LinearRegression().fit(X_toy, y_toy)
-    crf_conf_score = FittedResidualNormalisingScore(
+    crf_conf_score = ConformalResidualFittingScore(
         residual_estimator=residual_estimator,
         prefit=True,
         random_state=random_state
@@ -249,7 +249,7 @@ def test_crf_conformity_score_get_conformity_scores(y_pred: NDArray) -> None:
     Test conformity score computation for ConformalResidualFittingScore
     when prefit is False.
     """
-    crf_conf_score = FittedResidualNormalisingScore(random_state=random_state)
+    crf_conf_score = ConformalResidualFittingScore(random_state=random_state)
     conf_scores = crf_conf_score.get_conformity_scores(
         X_toy, y_toy, y_pred
     )
@@ -261,7 +261,7 @@ def test_crf_conformity_score_get_conformity_scores(y_pred: NDArray) -> None:
 
 def test_crf_score_prefit_with_notfitted_estim() -> None:
     """Test that a not fitted estimator and prefit=True raises an error."""
-    crf_conf_score = FittedResidualNormalisingScore(
+    crf_conf_score = ConformalResidualFittingScore(
             residual_estimator=LinearRegression(), prefit=True
     )
     with pytest.raises(ValueError):
@@ -272,7 +272,7 @@ def test_crf_score_prefit_with_notfitted_estim() -> None:
 
 def test_crf_score_prefit_with_default_params() -> None:
     """Test that no error is raised with default parameters."""
-    crf_conf_score = FittedResidualNormalisingScore()
+    crf_conf_score = ConformalResidualFittingScore()
     conf_scores = crf_conf_score.get_conformity_scores(
         X_toy, y_toy, y_pred_list
     )
@@ -286,7 +286,7 @@ def test_invalid_estimator() -> None:
         def __init__(self):
             pass
 
-    crf_conf_score = FittedResidualNormalisingScore(
+    crf_conf_score = ConformalResidualFittingScore(
         residual_estimator=DumbEstimator()
     )
     with pytest.raises(ValueError):
@@ -298,7 +298,7 @@ def test_invalid_estimator() -> None:
 def test_cross_crf() -> None:
     """Test that crf score called with cross method raises an error."""
     with pytest.raises(ValueError):
-        MapieRegressor(conformity_score=FittedResidualNormalisingScore()).fit(
+        MapieRegressor(conformity_score=ConformalResidualFittingScore()).fit(
             X_toy, y_toy
         )
 
@@ -312,7 +312,7 @@ def test_crf_score_pipe() -> None:
             ("linear", LinearRegression())
         ])
     mapie_reg = MapieRegressor(
-        conformity_score=FittedResidualNormalisingScore(
+        conformity_score=ConformalResidualFittingScore(
             residual_estimator=pipe, split_size=0.2
         ),
         cv="split",
@@ -333,7 +333,7 @@ def test_crf_score_pipe_prefit() -> None:
         ])
     pipe.fit(X_toy, y_toy)
     mapie_reg = MapieRegressor(
-        conformity_score=FittedResidualNormalisingScore(
+        conformity_score=ConformalResidualFittingScore(
             residual_estimator=pipe, split_size=0.2, prefit=True
         ),
         cv="split",

--- a/mapie/tests/test_conformity_scores.py
+++ b/mapie/tests/test_conformity_scores.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import PolynomialFeatures
 
@@ -254,7 +253,7 @@ def test_crf_conformity_score_get_conformity_scores(y_pred: NDArray) -> None:
         X_toy, y_toy, y_pred
     )
     expected_signed_conf_scores = np.array(
-        [0.38167789, 0.]
+        [np.nan, np.nan, 1.e+08, 1.e+08, 0.e+00, 3.e+08]
     )
     np.testing.assert_allclose(conf_scores, expected_signed_conf_scores)
 
@@ -276,8 +275,7 @@ def test_crf_score_prefit_with_default_params() -> None:
     conf_scores = crf_conf_score.get_conformity_scores(
         X_toy, y_toy, y_pred_list
     )
-    _, X, _, y = train_test_split(X_toy, y_toy, test_size=0.2)
-    crf_conf_score.get_estimation_distribution(X, y, conf_scores)
+    crf_conf_score.get_estimation_distribution(X_toy, y_toy, conf_scores)
 
 
 def test_invalid_estimator() -> None:

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -20,8 +20,10 @@ from typing_extensions import TypedDict
 
 from mapie._typing import NDArray
 from mapie.aggregation_functions import aggregate_all
-from mapie.conformity_scores import (AbsoluteConformityScore, ConformityScore,
-                                     GammaConformityScore)
+from mapie.conformity_scores import (AbsoluteConformityScore,
+                                     ConformityScore,
+                                     GammaConformityScore,
+                                     FittedResidualNormalisingScore)
 from mapie.metrics import regression_coverage_score
 from mapie.regression import MapieRegressor
 from mapie.estimator.estimator import EnsembleRegressor
@@ -585,6 +587,24 @@ def test_conformity_score(
     mapie_reg = MapieRegressor(
         conformity_score=conformity_score,
         **STRATEGIES[strategy]
+    )
+    mapie_reg.fit(X, y + 1e3)
+    mapie_reg.predict(X, alpha=0.05)
+
+
+@pytest.mark.parametrize(
+    "conformity_score", [FittedResidualNormalisingScore()]
+)
+def test_conformity_score_with_split_strategies(
+   conformity_score: ConformityScore
+) -> None:
+    """
+    Test that any conformity score function that handle only split strategies
+    with MAPIE raises no error.
+    """
+    mapie_reg = MapieRegressor(
+        conformity_score=conformity_score,
+        **STRATEGIES["split"]
     )
     mapie_reg.fit(X, y + 1e3)
     mapie_reg.predict(X, alpha=0.05)

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -23,7 +23,7 @@ from mapie.aggregation_functions import aggregate_all
 from mapie.conformity_scores import (AbsoluteConformityScore,
                                      ConformityScore,
                                      GammaConformityScore,
-                                     FittedResidualNormalisingScore)
+                                     ConformalResidualFittingScore)
 from mapie.metrics import regression_coverage_score
 from mapie.regression import MapieRegressor
 from mapie.estimator.estimator import EnsembleRegressor
@@ -593,7 +593,7 @@ def test_conformity_score(
 
 
 @pytest.mark.parametrize(
-    "conformity_score", [FittedResidualNormalisingScore()]
+    "conformity_score", [ConformalResidualFittingScore()]
 )
 def test_conformity_score_with_split_strategies(
    conformity_score: ConformityScore


### PR DESCRIPTION
# Description

Conformal Residual Fitting (or Fitted Residual Normalising as it has been name in MAPIE) is a regression conformity score that takes X into account and calculates adaptive intervals by estimation of the residuals of the base estimator.

Section 2.3.2 : Angelopoulos, A. N., & Bates, S. (2021). A gentle introduction to conformal prediction and distribution-free uncertainty quantification. arXiv preprint arXiv:2107.07511.

Fixes #316

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Classics tests for conformity scores
- [x] Tests of compatibility with MapieRegressor
- [x] Specific tests for this score

# Checklist

- [X] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [X] Linting passes successfully : `make lint`
- [X] Typing passes successfully : `make type-check`
- [X] Unit tests pass successfully : `make tests`
- [X] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`