### PR TITLE
Add tests for check_cv method with and without random_state

### DIFF
--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -171,6 +171,8 @@ def check_cv(
     ValueError
         If the cross-validator is not valid.
     """
+    if random_state is None:
+        random_state = np.random.choice(np.random.get_state()[1])
     if cv is None:
         return KFold(
             n_splits=5, shuffle=True, random_state=random_state


### PR DESCRIPTION
# Description

The modification proposes to resolve the bug by imposing a default value for random_state in check_cv method tests, so that the method retains split behavior even if random_state is set to None.

Fixes #336

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Test if check_cv retains split behavior if random_state is set to None.
- [ ] Test if check_cv retains split behavior if random_state is set a certain value.

# Checklist

- [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully : `make lint`
- [ ] Typing passes successfully : `make type-check`
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`