### PR TITLE
FIX doc on calibration

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -51,6 +51,7 @@ clean:
 	-rm -rf examples_regression/
 	-rm -rf examples_classification/
 	-rm -rf examples_multilabel_classification/
+	-rm -rf examples_calibration/
 	-rm -rf generated/*
 	-rm -rf modules/generated/*
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -314,11 +314,13 @@ sphinx_gallery_conf = {
     "examples_dirs": [
         "../examples/regression",
         "../examples/classification",
-        "../examples/multilabel_classification"],
+        "../examples/multilabel_classification",
+        "../examples/calibration"],
     "gallery_dirs": [
         "examples_regression",
         "examples_classification",
-        "examples_multilabel_classification"
+        "examples_multilabel_classification",
+        "examples_calibration"
     ],
     "doc_module": "mapie",
     "backreferences_dir": os.path.join("generated"),

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -315,7 +315,8 @@ sphinx_gallery_conf = {
         "../examples/regression",
         "../examples/classification",
         "../examples/multilabel_classification",
-        "../examples/calibration"],
+        "../examples/calibration"
+    ],
     "gallery_dirs": [
         "examples_regression",
         "examples_classification",

--- a/doc/theoretical_description_calibration.rst
+++ b/doc/theoretical_description_calibration.rst
@@ -97,7 +97,7 @@ We also introduce a typical normalization scale :math:`\sigma`:
 Tho Kolmogorov-Smirnov statisitc is then defined as : 
 
 .. math::
-   G = \max|C_k|/sigma
+   G = \max|C_k|/\sigma
 
 It can be shown [2] that, under the null hypothesis of well calibrated scores, this quantity asymptotically (i.e. when N goes to infinity)
 converges to the maximum absolute value of a standard Brownian motion over the unit interval :math:`[0, 1]`. [3, 4] also provide closed-form 
@@ -112,7 +112,7 @@ So we state the p-value associated to the statistical test of well calibration a
 Kuiper test was derived in [2, 3, 4] and is very similar to Kolmogorov-Smirnov. This time, the statistic is defined as:
 
 .. math::
-   H = (\max_k|C_k| - \min_k|C_k|)/sigma
+   H = (\max_k|C_k| - \min_k|C_k|)/\sigma
 
 It can be shown [2] that, under the null hypothesis of well calibrated scores, this quantity asymptotically (i.e. when N goes to infinity)
 converges to the range of a standard Brownian motion over the unit interval :math:`[0, 1]`. [3, 4] also provide closed-form 

--- a/examples/calibration/1-quickstart/calibration_hypothesis_testing.py
+++ b/examples/calibration/1-quickstart/calibration_hypothesis_testing.py
@@ -2,10 +2,10 @@
 =========================================================
 Testing for calibration in binary classification settings
 =========================================================
-This example uses :function:`~mapie.metrics.kolmogorov_smirnov_pvalue`
+This example uses :func:`~mapie.metrics.kolmogorov_smirnov_pvalue`
 to test for calibration of scores output by binary classifiers.
-Other alternatives are :function:`~mapie.metrics.kuiper_pvalue` and
-:function:`~mapie.metrics.spieglehalter_pvalue`.
+Other alternatives are :func:`~mapie.metrics.kuiper_pvalue` and
+:func:`~mapie.metrics.spieglehalter_pvalue`.
 
 These statistical tests are based on the following references:
 
@@ -100,7 +100,7 @@ plt.show()
 # ------------------------------------------------------------------
 #
 # We leverage the Kolomogorov-Smirnov statistical test
-# :function:`~mapie.metrics.kolmogorov_smirnov_pvalue`. It is based
+# :func:`~mapie.metrics.kolmogorov_smirnov_pvalue`. It is based
 # on the cumulative difference between sorted scores and labels.
 # If the null hypothesis holds (i.e., the scores are well calibrated),
 # the curve of the cumulative differences share some nice properties

--- a/examples/calibration/2-advanced-analysis/asymptotic_convergence_of_p_values.py
+++ b/examples/calibration/2-advanced-analysis/asymptotic_convergence_of_p_values.py
@@ -2,9 +2,9 @@
 =================================================
 Evaluating the asymptotic convergence of p-values
 =================================================
-This example uses :function:`~mapie.metrics.kolmogorov_smirnov_pvalue`,
-:function:`~mapie.metrics.kuiper_pvalue` and
-:function:`~mapie.metrics.spieglehalter_pvalue`. We investigate
+This example uses :func:`~mapie.metrics.kolmogorov_smirnov_pvalue`,
+:func:`~mapie.metrics.kuiper_pvalue` and
+:func:`~mapie.metrics.spieglehalter_pvalue`. We investigate
 the asymptotic convergence of these functions toward real p-values.
 Indeed, these quantities are only asymptotic p-values, i.e. when
 the number of observations is infinite. However, they can be safely

--- a/examples/calibration/README.rst
+++ b/examples/calibration/README.rst
@@ -1,4 +1,4 @@
-.. _calibration_examples_1:
+.. _calibration_examples:
 
 1. Quickstart examples
 ----------------------

--- a/examples/calibration/README.rst
+++ b/examples/calibration/README.rst
@@ -1,6 +1,4 @@
 .. _calibration_examples:
 
-1. Quickstart examples
-----------------------
-
-The following examples present the main functionalities of MAPIE through basic quickstart calibration problems.
+Calibration examples
+=======================


### PR DESCRIPTION
# Description

There was a typo in the theoretical description of calibration tests. Furthermore, gallery examples were not integrated to the web doc, this PR fixes this.

Fixes #351 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`