### PR TITLE
UPD: sign of normalized residual conformity scores

### DIFF
--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -404,7 +404,7 @@ class ResidualNormalisedScore(ConformityScore):
             )
 
         signed_conformity_scores = np.divide(
-            np.abs(np.subtract(y[cal_indexes], y_pred[cal_indexes])),
+            np.subtract(y[cal_indexes], y_pred[cal_indexes]),
             residuals_pred
         )
 


### PR DESCRIPTION
# Description

Propose to fix a bug with the sign of normalized residual conformity scores.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`