### PR TITLE
FIX: trivial typo in quantile regression and time series regression files

### DIFF
--- a/environment.ci.yml
+++ b/environment.ci.yml
@@ -6,7 +6,7 @@ dependencies:
     - codecov
     - flake8
     - mypy
-    - pandas
+    - pandas=1.5.3
     - pytest-cov
     - scikit-learn
     - typed-ast

--- a/environment.ci.yml
+++ b/environment.ci.yml
@@ -6,7 +6,7 @@ dependencies:
     - codecov
     - flake8
     - mypy
-    - pandas=1.4.4
+    - pandas
     - pytest-cov
     - scikit-learn
     - typed-ast

--- a/environment.ci.yml
+++ b/environment.ci.yml
@@ -6,7 +6,7 @@ dependencies:
     - codecov
     - flake8
     - mypy
-    - pandas=1.5.3
+    - pandas=1.4.4
     - pytest-cov
     - scikit-learn
     - typed-ast

--- a/mapie/quantile_regression.py
+++ b/mapie/quantile_regression.py
@@ -6,7 +6,7 @@ from mapie.regression import MapieQuantileRegressor as NewClass
 @deprecated(
     "WARNING: Deprecated path to import MapieQuantileRegressor. "
     "Please prefer the new path: "
-    "[form mapie.regression import MapieQuantileRegressor]."
+    "[from mapie.regression import MapieQuantileRegressor]."
 )
 class MapieQuantileRegressor(NewClass):
     pass

--- a/mapie/time_series_regression.py
+++ b/mapie/time_series_regression.py
@@ -6,7 +6,7 @@ from mapie.regression import MapieTimeSeriesRegressor as NewClass
 @deprecated(
     "WARNING: Deprecated path to import MapieTimeSeriesRegressor. "
     "Please prefer the new path: "
-    "[form mapie.regression import MapieTimeSeriesRegressor]."
+    "[from mapie.regression import MapieTimeSeriesRegressor]."
 )
 class MapieTimeSeriesRegressor(NewClass):
     pass


### PR DESCRIPTION
# Description

- There is a trivial typo in the file [quantile_regression.py](https://github.com/scikit-learn-contrib/MAPIE/blob/7820eed3388de65bcaea8a41c6640289acfce32d/mapie/quantile_regression.py#L9C7-L9C11)
- There is a trivial typo in the file [time_series_regression.py](https://github.com/scikit-learn-contrib/MAPIE/blob/7820eed3388de65bcaea8a41c6640289acfce32d/mapie/time_series_regression.py#L9C7-L9C11)

In both files it should read `from` rather than `form`.

Fixes #364 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] See `WARNING: Deprecated path` with changes when importing `MapieQuantileRegressor` and `MapieTimeSeriesRegressor`

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`