### PR TITLE
[DOC] updated reference for Residual Normalised Score

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,4 +33,5 @@ Contributors
 * Candice Moyet <cmoyet@quantmetry.com>
 * Sofiane Ziane <sziane@quantmetry.com>
 * Rafael Saraiva <rafael.saraiva.de@gmail.com>
+* Mehdi Elion <mehdi.elion@gmail.com>
 To be continued ...

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 ##### (##########)
 ------------------
 * Add new checks for metrics calculations
+* Fix reference for residual normalised score in documentation
 
 
 0.7.0 (2023-09-14)

--- a/doc/theoretical_description_conformity_scores.rst
+++ b/doc/theoretical_description_conformity_scores.rst
@@ -109,8 +109,8 @@ Key takeaways
 References
 ==========
 
-[1] Angelopoulos, A. N., & Bates, S. (2021). A gentle introduction to conformal
-prediction and distribution-free uncertainty quantification. arXiv preprint arXiv:2107.07511.
+[1] Lei, J., G'Sell, M., Rinaldo, A., Tibshirani, R. J., & Wasserman, L. (2017). Distribution-Free
+Predictive Inference For Regression. arXiv:1604.04173.
 
 [2] Cordier, T., Blot, V., Lacombe, L., Morzadec, T., Capitaine, A. &amp; Brunel, N.. (2023).
 Flexible and Systematic Uncertainty Estimation with Conformal Prediction via the MAPIE library.

--- a/doc/theoretical_description_conformity_scores.rst
+++ b/doc/theoretical_description_conformity_scores.rst
@@ -109,8 +109,9 @@ Key takeaways
 References
 ==========
 
-[1] Lei, J., G'Sell, M., Rinaldo, A., Tibshirani, R. J., & Wasserman, L. (2017). Distribution-Free
-Predictive Inference For Regression. arXiv:1604.04173.
+[1] Lei, J., G'Sell, M., Rinaldo, A., Tibshirani, R. J., & Wasserman, L. (2018). Distribution-Free 
+Predictive Inference for Regression. Journal of the American Statistical Association, 113(523), 1094–1111. 
+Available from https://doi.org/10.1080/01621459.2017.1307116
 
 [2] Cordier, T., Blot, V., Lacombe, L., Morzadec, T., Capitaine, A. &amp; Brunel, N.. (2023).
 Flexible and Systematic Uncertainty Estimation with Conformal Prediction via the MAPIE library.


### PR DESCRIPTION
# Description

Changed the reference for the residual normalized score from
```
[1] Angelopoulos, A. N., & Bates, S. (2021). A gentle introduction to conformal
prediction and distribution-free uncertainty quantification. arXiv preprint arXiv:2107.07511.
```
to
```
[1] Lei, J., G'Sell, M., Rinaldo, A., Tibshirani, R. J., & Wasserman, L. (2017). Distribution-Free
Predictive Inference For Regression. arXiv:1604.04173.
```

Fixes #366 

## Type of change

This is a simple documentation update.

# How Has This Been Tested?

This has been tested according to the items of the checklist below.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`