### PR TITLE
Allow `MapieTimeSeriesRegressor` to use any `ConformityScore`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,8 +5,7 @@ History
 ##### (##########)
 ------------------
 * Integrate ConformityScore into MapieTimeSeriesRegressor.
-* Adapt MapieTimeSeriesRegressor to use any ConformityScore
-* Add new checks for metrics calculations
+* Add new checks for metrics calculations.
 
 
 0.7.0 (2023-09-14)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 ##### (##########)
 ------------------
+* Adapt MapieTimeSeriesRegressor to use any ConformityScore
 * Add new checks for metrics calculations
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 ##### (##########)
 ------------------
+* Integrate ConformityScore into MapieTimeSeriesRegressor.
 * Adapt MapieTimeSeriesRegressor to use any ConformityScore
 * Add new checks for metrics calculations
 

--- a/mapie/conformity_scores/residual_conformity_scores.py
+++ b/mapie/conformity_scores/residual_conformity_scores.py
@@ -29,8 +29,9 @@ class AbsoluteConformityScore(ConformityScore):
 
     def __init__(
         self,
+        sym: bool = True,
     ) -> None:
-        super().__init__(sym=True, consistency_check=True)
+        super().__init__(sym=sym, consistency_check=True)
 
     def get_signed_conformity_scores(
         self,
@@ -77,8 +78,9 @@ class GammaConformityScore(ConformityScore):
 
     def __init__(
         self,
+        sym: bool = False,
     ) -> None:
-        super().__init__(sym=False, consistency_check=False, eps=EPSILON)
+        super().__init__(sym=sym, consistency_check=False, eps=EPSILON)
 
     def _check_observed_data(
         self,

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -305,7 +305,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         """
         if agg_function not in self.valid_agg_functions_:
             raise ValueError(
-                "Invalid aggregation function "
+                "Invalid aggregation function. "
                 f"Allowed values are '{self.valid_agg_functions_}'."
             )
         elif (agg_function is None) and (

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -93,8 +93,8 @@ class MapieTimeSeriesRegressor(MapieRegressor):
             The conformity scores corresponding to the input data set.
         """
         y_pred, _ = super().predict(X, alpha=0.5, ensemble=ensemble)
-        scores = self.conformity_score_function_.get_conformity_scores(
-            X, y, y_pred
+        scores = np.array(
+            self.conformity_score_function_.get_conformity_scores(X, y, y_pred)
         )
         return scores
 

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -10,6 +10,7 @@ from sklearn.utils.validation import check_is_fitted
 from mapie._compatibility import np_nanquantile
 from mapie._typing import ArrayLike, NDArray
 from mapie.aggregation_functions import aggregate_all
+from mapie.conformity_scores import ConformityScore
 from .regression import MapieRegressor
 from mapie.utils import check_alpha, check_alpha_and_n_samples
 
@@ -44,6 +45,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         n_jobs: Optional[int] = None,
         agg_function: Optional[str] = "mean",
         verbose: int = 0,
+        conformity_score: Optional[ConformityScore] = None,
         random_state: Optional[Union[int, np.random.RandomState]] = None,
     ) -> None:
         super().__init__(
@@ -53,6 +55,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
             n_jobs=n_jobs,
             agg_function=agg_function,
             verbose=verbose,
+            conformity_score=conformity_score,
             random_state=random_state
         )
 
@@ -60,24 +63,40 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         self,
         X: ArrayLike,
         y: ArrayLike,
+        ensemble: bool = False,
     ) -> NDArray:
         """
         Compute the conformity scores on a data set.
 
         Parameters
         ----------
-            X : ArrayLike of shape (n_samples, n_features)
+        X : ArrayLike of shape (n_samples, n_features)
             Input data.
 
-            y : ArrayLike of shape (n_samples,)
+        y : ArrayLike of shape (n_samples,)
                 Input labels.
+
+        ensemble: bool
+            Boolean determining whether the predictions are ensembled or not.
+            If ``False``, predictions are those of the model trained on the
+            whole training set.
+            If ``True``, predictions from perturbed models are aggregated by
+            the aggregation function specified in the ``agg_function``
+            attribute.
+
+            If ``cv`` is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
+
+            By default ``False``.
 
         Returns
         -------
             The conformity scores corresponding to the input data set.
         """
-        y_pred, _ = super().predict(X, alpha=0.5, ensemble=True)
-        return np.asarray(y) - np.asarray(y_pred)
+        y_pred, _ = super().predict(X, alpha=0.5, ensemble=ensemble)
+        scores = self.conformity_score_function_.get_conformity_scores(
+            X, y, y_pred
+        )
+        return scores
 
     def _beta_optimize(
         self,
@@ -92,8 +111,10 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         ----------
         alpha: Union[float, NDArray]
             The quantiles to compute.
+
         upper_bounds: NDArray
             The array of upper values.
+
         lower_bounds: NDArray
             The array of lower values.
 
@@ -149,6 +170,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         X: ArrayLike,
         y: ArrayLike,
         sample_weight: Optional[ArrayLike] = None,
+        ensemble: bool = False,
     ) -> MapieTimeSeriesRegressor:
         """
         Compared to the method ``fit`` of ``MapieRegressor``, the ``fit``
@@ -174,19 +196,34 @@ class MapieTimeSeriesRegressor(MapieRegressor):
 
             By default ``None``.
 
+        ensemble: bool
+            Boolean determining whether the predictions are ensembled or not.
+            If ``False``, predictions are those of the model trained on the
+            whole training set.
+            If ``True``, predictions from perturbed models are aggregated by
+            the aggregation function specified in the ``agg_function``
+            attribute.
+
+            If ``cv`` is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
+
+            By default ``False``.
+
         Returns
         -------
         MapieTimeSeriesRegressor
             The model itself.
         """
         self = super().fit(X=X, y=y, sample_weight=sample_weight)
-        self.conformity_scores_ = self._relative_conformity_scores(X, y)
+        self.conformity_scores_ = self._relative_conformity_scores(
+            X, y, ensemble=ensemble
+        )
         return self
 
     def partial_fit(
         self,
         X: ArrayLike,
         y: ArrayLike,
+        ensemble: bool = False,
     ) -> MapieTimeSeriesRegressor:
         """
         Update the ``conformity_scores_`` attribute when new data with known
@@ -200,6 +237,18 @@ class MapieTimeSeriesRegressor(MapieRegressor):
 
         y: ArrayLike of shape (n_samples_test,)
             Input labels.
+
+        ensemble: bool
+            Boolean determining whether the predictions are ensembled or not.
+            If ``False``, predictions are those of the model trained on the
+            whole training set.
+            If ``True``, predictions from perturbed models are aggregated by
+            the aggregation function specified in the ``agg_function``
+            attribute.
+
+            If ``cv`` is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
+
+            By default ``False``.
 
         Returns
         -------
@@ -221,7 +270,9 @@ class MapieTimeSeriesRegressor(MapieRegressor):
                 "The number of observations to update is higher than the"
                 "number of training instances."
             )
-        new_conformity_scores_ = self._relative_conformity_scores(X, y)
+        new_conformity_scores_ = self._relative_conformity_scores(
+            X, y, ensemble=ensemble
+        )
         self.conformity_scores_ = np.roll(
             self.conformity_scores_, -len(new_conformity_scores_)
         )


### PR DESCRIPTION
# Description

Propose the integration of any conformity score into the `MapieTimeSeriesRegressor` class as has been done in `MapieRegressor`.

Fixes #382 

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test that all existing `MapieTimeSeriesRegressor` works

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`