### PR TITLE
Allow `MapieRegressor` to use the optimal estimation strategy for the bounds of the prediction intervals

### DIFF
--- a/examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py
+++ b/examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py
@@ -36,7 +36,6 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import RandomizedSearchCV, TimeSeriesSplit
 
 from mapie._typing import NDArray
-from mapie.conformity_scores import AbsoluteConformityScore
 from mapie.metrics import (regression_coverage_score,
                            regression_mean_width_score)
 from mapie.subsample import BlockBootstrap
@@ -112,7 +111,6 @@ mapie_enpbi = MapieTimeSeriesRegressor(
     model,
     method="enbpi",
     cv=cv_mapietimeseries,
-    conformity_score=AbsoluteConformityScore(sym=False),
     agg_function="mean",
     n_jobs=-1,
 )

--- a/examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py
+++ b/examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py
@@ -36,6 +36,7 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import RandomizedSearchCV, TimeSeriesSplit
 
 from mapie._typing import NDArray
+from mapie.conformity_scores import AbsoluteConformityScore
 from mapie.metrics import (regression_coverage_score,
                            regression_mean_width_score)
 from mapie.subsample import BlockBootstrap
@@ -111,6 +112,7 @@ mapie_enpbi = MapieTimeSeriesRegressor(
     model,
     method="enbpi",
     cv=cv_mapietimeseries,
+    conformity_score=AbsoluteConformityScore(sym=False),
     agg_function="mean",
     n_jobs=-1,
 )

--- a/examples/regression/4-tutorials/plot_ts-tutorial.py
+++ b/examples/regression/4-tutorials/plot_ts-tutorial.py
@@ -51,7 +51,6 @@ from scipy.stats import randint
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import RandomizedSearchCV, TimeSeriesSplit
 
-from mapie.conformity_scores import AbsoluteConformityScore
 from mapie.metrics import (regression_coverage_score,
                            regression_mean_width_score)
 from mapie.subsample import BlockBootstrap
@@ -188,10 +187,8 @@ gap = 1
 cv_mapiets = BlockBootstrap(
     n_resamplings=10, n_blocks=10, overlapping=False, random_state=59
 )
-cs = AbsoluteConformityScore(sym=False)
 mapie_enbpi = MapieTimeSeriesRegressor(
-    model, method="enbpi", cv=cv_mapiets, conformity_score=cs,
-    agg_function="mean", n_jobs=-1
+    model, method="enbpi", cv=cv_mapiets, agg_function="mean", n_jobs=-1
 )
 
 ##############################################################################

--- a/mapie/conformity_scores/conformity_scores.py
+++ b/mapie/conformity_scores/conformity_scores.py
@@ -279,17 +279,7 @@ class ConformityScore(metaclass=ABCMeta):
         NDArray
             Array of betas minimizing the differences
             ``(1-alpa+beta)-quantile - beta-quantile``.
-
-        # Raises  # TODO
-        # ------
-        # ValueError
-        #     If lower and upper bounds arrays don't have the same shape.
         """
-        # TODO
-        # if lower_bounds.shape != upper_bounds.shape:
-        #     raise ValueError(
-        #         "Lower and upper bounds arrays should have the same shape."
-        #     )
         beta_np = np.full(
             shape=(len(lower_bounds), len(alpha_np)),
             fill_value=np.nan,
@@ -377,8 +367,17 @@ class ConformityScore(metaclass=ABCMeta):
             (n_samples, n_alpha).
             - The upper bounds of the prediction intervals of shape
             (n_samples, n_alpha).
+
+        Raises
+        ------
+        ValueError
+            If beta optimisation with symmetrical conformity score function.
         """
-        assert not (self.sym and optimize_beta)  # TODO
+        if self.sym and optimize_beta:
+            raise ValueError(
+                "Beta optimisation cannot be used with "
+                + "symmetrical conformity score function."
+            )
 
         y_pred, y_pred_low, y_pred_up = estimator.predict(X, ensemble)
         signed = -1 if self.sym else 1

--- a/mapie/estimator/estimator.py
+++ b/mapie/estimator/estimator.py
@@ -496,9 +496,12 @@ class EnsembleRegressor(EnsembleEstimator):
             if self.method == "minmax":
                 y_pred_multi_low = np.min(y_pred_multi, axis=1, keepdims=True)
                 y_pred_multi_up = np.max(y_pred_multi, axis=1, keepdims=True)
-            else:
+            elif self.method == "plus":
                 y_pred_multi_low = y_pred_multi
                 y_pred_multi_up = y_pred_multi
+            else:
+                y_pred_multi_low = y_pred[:, np.newaxis]
+                y_pred_multi_up = y_pred[:, np.newaxis]
 
             if ensemble:
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -522,6 +522,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         X: ArrayLike,
         ensemble: bool = False,
         alpha: Optional[Union[float, Iterable[float]]] = None,
+        optimize_beta: bool = False,
     ) -> Union[NDArray, Tuple[NDArray, NDArray]]:
         """
         Predict target on new samples with confidence intervals.
@@ -561,6 +562,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
             By default ``None``.
 
+        optimize_beta: bool
+            Whether to optimize the PIs' width or not.
+
+            By default ``False``.
+
         Returns
         -------
         Union[NDArray, Tuple[NDArray, NDArray]]
@@ -592,7 +598,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                     self.estimator_,
                     self.conformity_scores_,
                     alpha_np,
-                    ensemble,
-                    self.method
+                    ensemble=ensemble,
+                    method=self.method,
+                    optimize_beta=optimize_beta
                 )
             return np.array(y_pred), np.stack([y_pred_low, y_pred_up], axis=1)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -209,6 +209,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
     no_agg_methods_ = ["naive", "base"]
     valid_agg_functions_ = [None, "median", "mean"]
     ensemble_agg_functions_ = ["median", "mean"]
+    default_sym_ = True
     fit_attributes = [
         "estimator_",
         "conformity_scores_",
@@ -424,7 +425,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         estimator = self._check_estimator(self.estimator)
         agg_function = self._check_agg_function(self.agg_function)
         cs_estimator = check_conformity_score(
-            self.conformity_score
+            self.conformity_score, self.default_sym_
         )
         if isinstance(cs_estimator, ResidualNormalisedScore) and \
            self.cv not in ["split", "prefit"]:

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -591,7 +591,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             if optimize_beta and self.method != 'enbpi':
                 raise UserWarning(
                     "Beta optimisation should only be used for "
-                    "the method='enbpi'."
+                    "method='enbpi'."
                 )
 
             n = len(self.conformity_scores_)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -588,6 +588,12 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             return np.array(y_pred)
 
         else:
+            if optimize_beta and self.method != 'enbpi':
+                raise UserWarning(
+                    "Beta optimisation should only be used for "
+                    "the method='enbpi'."
+                )
+
             n = len(self.conformity_scores_)
             alpha_np = cast(NDArray, alpha)
             check_alpha_and_n_samples(alpha_np, n)

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -33,6 +33,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
     cv_need_agg_function_ = MapieRegressor.cv_need_agg_function_ \
         + ["BlockBootstrap"]
     valid_methods_ = ["enbpi"]
+    default_sym_ = False
 
     def __init__(
         self,

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -1,17 +1,14 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional, Tuple, Union, cast
+from typing import Optional, Union, cast
 
 import numpy as np
 from sklearn.base import RegressorMixin
 from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils.validation import check_is_fitted
 
-from mapie._compatibility import np_nanquantile
 from mapie._typing import ArrayLike, NDArray
-from mapie.aggregation_functions import aggregate_all
 from .regression import MapieRegressor
-from mapie.utils import check_alpha, check_alpha_and_n_samples
 
 
 class MapieTimeSeriesRegressor(MapieRegressor):
@@ -78,71 +75,6 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         """
         y_pred, _ = super().predict(X, alpha=0.5, ensemble=True)
         return np.asarray(y) - np.asarray(y_pred)
-
-    def _beta_optimize(
-        self,
-        alpha: Union[float, NDArray],
-        upper_bounds: NDArray,
-        lower_bounds: NDArray,
-    ) -> NDArray:
-        """
-        Minimize the width of the PIs, for a given difference of quantiles.
-
-        Parameters
-        ----------
-        alpha: Union[float, NDArray]
-            The quantiles to compute.
-        upper_bounds: NDArray
-            The array of upper values.
-        lower_bounds: NDArray
-            The array of lower values.
-
-        Returns
-        -------
-        NDArray
-            Array of betas minimizing the differences
-            ``(1-alpa+beta)-quantile - beta-quantile``.
-
-        Raises
-        ------
-        ValueError
-            If lower and upper bounds arrays don't have the same shape.
-        """
-        if lower_bounds.shape != upper_bounds.shape:
-            raise ValueError(
-                "Lower and upper bounds arrays should have the same shape."
-            )
-        alpha = cast(NDArray, alpha)
-        betas_0 = np.full(
-            shape=(len(lower_bounds), len(alpha)),
-            fill_value=np.nan,
-            dtype=float,
-        )
-
-        for ind_alpha, _alpha in enumerate(alpha):
-            betas = np.linspace(
-                _alpha / (len(lower_bounds) + 1),
-                _alpha,
-                num=len(lower_bounds),
-                endpoint=True,
-            )
-            one_alpha_beta = np_nanquantile(
-                upper_bounds.astype(float),
-                1 - _alpha + betas,
-                axis=1,
-                method="higher",
-            )
-            beta = np_nanquantile(
-                lower_bounds.astype(float),
-                betas,
-                axis=1,
-                method="lower",
-            )
-            betas_0[:, ind_alpha] = betas[
-                np.argmin(one_alpha_beta - beta, axis=0)
-            ]
-
-        return betas_0
 
     def fit(
         self,
@@ -229,109 +161,6 @@ class MapieTimeSeriesRegressor(MapieRegressor):
             -len(new_conformity_scores_):
         ] = new_conformity_scores_
         return self
-
-    def predict(
-        self,
-        X: ArrayLike,
-        ensemble: bool = False,
-        alpha: Optional[Union[float, Iterable[float]]] = None,
-        optimize_beta: bool = True,
-    ) -> Union[NDArray, Tuple[NDArray, NDArray]]:
-        """
-        Correspond to 'Conformal prediction for dynamic time-series'.
-
-        Parameters
-        ----------
-        X: ArrayLike of shape (n_samples, n_features)
-            Test data.
-
-        ensemble: bool
-            Boolean determining whether the predictions are ensembled or not.
-            If ``False``, predictions are those of the model trained on the
-            whole training set.
-            If ``True``, predictions from perturbed models are aggregated by
-            the aggregation function specified in the ``agg_function``
-            attribute.
-
-            If ``cv`` is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
-
-            By default ``False``.
-
-        alpha: Optional[Union[float, Iterable[float]]]
-            Can be a float, a list of floats, or a ``ArrayLike`` of floats.
-            Between ``0`` and ``1``, represents the uncertainty of the
-            confidence interval.
-            Lower ``alpha`` produce larger (more conservative) prediction
-            intervals.
-            ``alpha`` is the complement of the target coverage level.
-
-            By default ``None``.
-
-        optimize_beta: bool
-            Whether to optimize the PIs' width or not.
-
-        Returns
-        -------
-        Union[NDArray, Tuple[NDArray, NDArray]]
-            - NDArray of shape (n_samples,) if ``alpha`` is ``None``.
-            - Tuple[NDArray, NDArray] of shapes (n_samples,) and
-              (n_samples, 2, n_alpha) if ``alpha`` is not ``None``.
-                - [:, 0, :]: Lower bound of the prediction interval.
-                - [:, 1, :]: Upper bound of the prediction interval.
-        """
-        # Checks
-        check_is_fitted(self, self.fit_attributes)
-        self._check_ensemble(ensemble)
-        alpha = cast(Optional[NDArray], check_alpha(alpha))
-        y_pred = self.estimator_.single_estimator_.predict(X)
-        n = len(self.conformity_scores_)
-
-        if alpha is None:
-            return np.array(y_pred)
-
-        alpha_np = cast(NDArray, alpha)
-        check_alpha_and_n_samples(alpha_np, n)
-
-        if optimize_beta:
-            betas_0 = self._beta_optimize(
-                alpha_np,
-                self.conformity_scores_.reshape(1, -1),
-                self.conformity_scores_.reshape(1, -1),
-            )
-        else:
-            betas_0 = np.repeat(alpha[:, np.newaxis] / 2, n, axis=0)
-
-        lower_quantiles = np_nanquantile(
-            self.conformity_scores_.astype(float),
-            betas_0[0, :],
-            axis=0,
-            method="lower",
-        ).T
-        higher_quantiles = np_nanquantile(
-            self.conformity_scores_.astype(float),
-            1 - alpha_np + betas_0[0, :],
-            axis=0,
-            method="higher",
-        ).T
-        self.lower_quantiles_ = lower_quantiles
-        self.higher_quantiles_ = higher_quantiles
-
-        if self.method in self.no_agg_methods_ \
-                or self.cv in self.no_agg_cv_:
-            y_pred_low = y_pred[:, np.newaxis] + lower_quantiles
-            y_pred_up = y_pred[:, np.newaxis] + higher_quantiles
-        else:
-            y_pred_multi = self.estimator_._pred_multi(X)
-            pred = aggregate_all(self.agg_function, y_pred_multi)
-            lower_bounds, upper_bounds = pred, pred
-
-            y_pred_low = lower_bounds.reshape(-1, 1) + lower_quantiles
-            y_pred_up = upper_bounds.reshape(-1, 1) + higher_quantiles
-
-            if ensemble:
-                y_pred = aggregate_all(self.agg_function, y_pred_multi)
-
-        return y_pred, np.stack([y_pred_low, y_pred_up], axis=1)
 
     def _more_tags(self):
         return {

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -89,7 +89,7 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         -------
             The conformity scores corresponding to the input data set.
         """
-        y_pred, _ = super().predict(X, alpha=0.5, ensemble=ensemble)
+        y_pred = super().predict(X, ensemble=ensemble)
         scores = np.array(
             self.conformity_score_function_.get_conformity_scores(X, y, y_pred)
         )

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -632,3 +632,14 @@ def test_return_multi_pred(ensemble: bool) -> None:
         X_toy, ensemble=ensemble, return_multi_pred=True
     )
     assert len(output) == 3
+
+
+def test_beta_optimize_user_warning() -> None:
+    """
+    Test that a UserWarning is displayed when optimize_beta is used.
+    """
+    mapie_reg = MapieRegressor().fit(X, y)
+    with pytest.raises(
+        UserWarning, match=r"Beta optimisation should only be used for*",
+    ):
+        mapie_reg.predict(X, alpha=0.05, optimize_beta=True)

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -371,16 +371,41 @@ def test_MapieTimeSeriesRegressor_partial_fit_too_big() -> None:
         mapie_ts_reg = mapie_ts_reg.partial_fit(X=X, y=y)
 
 
-# TODO: delete or move
-# def test_MapieTimeSeriesRegressor_beta_optimize_eeror() -> None:
-#     """Test ``beta_optimize`` raised error."""
-#     mapie_ts_reg = MapieTimeSeriesRegressor(cv=-1)
-#     with pytest.raises(
-#         ValueError, match=r".*Lower and upper bounds arrays*"
-#     ):
-#         mapie_ts_reg._beta_optimize(
-#             alpha=0.1, upper_bounds=X, lower_bounds=X_toy
-#         )
+def test_MapieTimeSeriesRegressor_beta_optimize_error() -> None:
+    """Test ``beta_optimize`` raised error."""
+    mapie_ts_reg = MapieTimeSeriesRegressor(
+        cv=-1, conformity_score=AbsoluteConformityScore(sym=True)
+    ).fit(X_toy, y_toy)
+    with pytest.raises(
+        ValueError, match=r"Beta optimisation cannot be used*"
+    ):
+        mapie_ts_reg.predict(X_toy, alpha=0.4, optimize_beta=True)
+
+
+def test_interval_prediction_with_beta_optimize() -> None:
+    """Test use of ``beta_optimize`` in prediction."""
+    X_train_val, X_test, y_train_val, y_test = train_test_split(
+        X, y, test_size=1 / 10, random_state=random_state
+    )
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train_val, y_train_val, test_size=1 / 9, random_state=random_state
+    )
+    estimator = LinearRegression().fit(X_train, y_train)
+    mapie_ts_reg = MapieTimeSeriesRegressor(
+        estimator=estimator,
+        cv=BlockBootstrap(
+            n_resamplings=30, n_blocks=5, random_state=random_state
+        ),
+        conformity_score=AbsoluteConformityScore(sym=False)
+    )
+    mapie_ts_reg.fit(X_val, y_val)
+    _, y_pis = mapie_ts_reg.predict(X_test, alpha=0.05, optimize_beta=True)
+    width_mean = (y_pis[:, 1, 0] - y_pis[:, 0, 0]).mean()
+    coverage = regression_coverage_score(
+        y_test, y_pis[:, 0, 0], y_pis[:, 1, 0]
+    )
+    np.testing.assert_allclose(width_mean, 4.22, rtol=1e-2)
+    np.testing.assert_allclose(coverage, 0.9, rtol=1e-2)
 
 
 def test_deprecated_path_warning() -> None:

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -12,7 +12,7 @@ from typing_extensions import TypedDict
 
 from mapie._typing import NDArray
 from mapie.aggregation_functions import aggregate_all
-from mapie.conformity_scores import ConformityScore, AbsoluteConformityScore
+from mapie.conformity_scores import AbsoluteConformityScore
 from mapie.metrics import regression_coverage_score
 from mapie.regression import MapieTimeSeriesRegressor
 from mapie.subsample import BlockBootstrap
@@ -34,7 +34,6 @@ Params = TypedDict(
         "method": str,
         "agg_function": str,
         "cv": Optional[Union[int, KFold, BlockBootstrap]],
-        "conformity_score": ConformityScore
     },
 )
 STRATEGIES = {
@@ -44,7 +43,6 @@ STRATEGIES = {
         cv=BlockBootstrap(
             n_resamplings=30, n_blocks=5, random_state=random_state
         ),
-        conformity_score=AbsoluteConformityScore(sym=False),
     ),
     "jackknife_enbpi_median_ab_wopt": Params(
         method="enbpi",
@@ -54,7 +52,6 @@ STRATEGIES = {
             n_blocks=5,
             random_state=random_state,
         ),
-        conformity_score=AbsoluteConformityScore(sym=False),
     ),
     "jackknife_enbpi_mean_ab": Params(
         method="enbpi",
@@ -62,7 +59,6 @@ STRATEGIES = {
         cv=BlockBootstrap(
             n_resamplings=30, n_blocks=5, random_state=random_state
         ),
-        conformity_score=AbsoluteConformityScore(sym=False),
     ),
     "jackknife_enbpi_median_ab": Params(
         method="enbpi",
@@ -72,7 +68,6 @@ STRATEGIES = {
             n_blocks=5,
             random_state=random_state,
         ),
-        conformity_score=AbsoluteConformityScore(sym=False),
     ),
 }
 
@@ -275,8 +270,7 @@ def test_results_prefit() -> None:
     )
     estimator = LinearRegression().fit(X_train, y_train)
     mapie_ts_reg = MapieTimeSeriesRegressor(
-        estimator=estimator, cv="prefit",
-        conformity_score=AbsoluteConformityScore(sym=False)
+        estimator=estimator, cv="prefit"
     )
     mapie_ts_reg.fit(X_val, y_val)
     _, y_pis = mapie_ts_reg.predict(X_test, alpha=0.05)
@@ -348,9 +342,7 @@ def test_MapieTimeSeriesRegressor_if_alpha_is_None() -> None:
 
 def test_MapieTimeSeriesRegressor_partial_fit_ensemble() -> None:
     """Test ``partial_fit``."""
-    mapie_ts_reg = MapieTimeSeriesRegressor(
-        cv=-1, conformity_score=AbsoluteConformityScore(sym=False)
-    )
+    mapie_ts_reg = MapieTimeSeriesRegressor(cv=-1)
     mapie_ts_reg = mapie_ts_reg.fit(X_toy, y_toy, ensemble=True)
     assert round(mapie_ts_reg.conformity_scores_[-1], 2) == round(
         np.abs(CONFORMITY_SCORES[0]), 2
@@ -395,8 +387,7 @@ def test_interval_prediction_with_beta_optimize() -> None:
         estimator=estimator,
         cv=BlockBootstrap(
             n_resamplings=30, n_blocks=5, random_state=random_state
-        ),
-        conformity_score=AbsoluteConformityScore(sym=False)
+        )
     )
     mapie_ts_reg.fit(X_val, y_val)
     _, y_pis = mapie_ts_reg.predict(X_test, alpha=0.05, optimize_beta=True)

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -371,13 +371,16 @@ def test_MapieTimeSeriesRegressor_partial_fit_too_big() -> None:
         mapie_ts_reg = mapie_ts_reg.partial_fit(X=X, y=y)
 
 
-def test_MapieTimeSeriesRegressor_beta_optimize_eeror() -> None:
-    """Test ``beta_optimize`` raised error."""
-    mapie_ts_reg = MapieTimeSeriesRegressor(cv=-1)
-    with pytest.raises(ValueError, match=r".*Lower and upper bounds arrays*"):
-        mapie_ts_reg._beta_optimize(
-            alpha=0.1, upper_bounds=X, lower_bounds=X_toy
-        )
+# TODO: delete or move
+# def test_MapieTimeSeriesRegressor_beta_optimize_eeror() -> None:
+#     """Test ``beta_optimize`` raised error."""
+#     mapie_ts_reg = MapieTimeSeriesRegressor(cv=-1)
+#     with pytest.raises(
+#         ValueError, match=r".*Lower and upper bounds arrays*"
+#     ):
+#         mapie_ts_reg._beta_optimize(
+#             alpha=0.1, upper_bounds=X, lower_bounds=X_toy
+#         )
 
 
 def test_deprecated_path_warning() -> None:

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -543,13 +543,16 @@ def check_lower_upper_bounds(
 
 def check_conformity_score(
     conformity_score: Optional[ConformityScore],
+    sym: bool = True,
 ) -> ConformityScore:
     """
     Check parameter ``conformity_score``.
+
     Raises
     ------
     ValueError
         If parameter is not valid.
+
     Examples
     --------
     >>> from mapie.utils import check_conformity_score
@@ -562,7 +565,7 @@ def check_conformity_score(
     Must be None or a ConformityScore instance.
     """
     if conformity_score is None:
-        return AbsoluteConformityScore()
+        return AbsoluteConformityScore(sym=sym)
     elif isinstance(conformity_score, ConformityScore):
         return conformity_score
     else:


### PR DESCRIPTION
# Description

In the MAPIE code, only the `predict` method of `MapieTimeSeriesRegressor` class can use `optimize_beta` to optimize the bounds of the prediction interval.

Propose the integration of the same feature into the MapieRegressor class (deleguate this feature in `ConformityScore` class). Merge the two `predict` methods to create a single method for easier maintenance.

Fixes #384
Fixes #389

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Adapt test for `optimize_beta` in `MapieTimeSeriesRegressor`
- [x] Check that the other tests still work

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`