### PR TITLE
FIX: Remove pandas in package import

### DIFF
--- a/examples/regression/4-tutorials/plot_ts-tutorial.py
+++ b/examples/regression/4-tutorials/plot_ts-tutorial.py
@@ -253,8 +253,8 @@ y_pred_aci_npfit[:gap], y_pis_aci_npfit[:gap, :, :] = mapie_aci.predict(
 )
 for step in range(gap, len(X_test), gap):
     mapie_aci.adapt_conformal_inference(
-        X_test.iloc[(step - gap):step, :],
-        y_test.iloc[(step - gap):step],
+        X_test.iloc[(step - gap):step, :].to_numpy(),
+        y_test.iloc[(step - gap):step].to_numpy(),
         gamma=0.05
     )
     (
@@ -357,8 +357,8 @@ for step in range(gap, len(X_test), gap):
         y_test.iloc[(step - gap):step],
     )
     mapie_aci.adapt_conformal_inference(
-        X_test.iloc[(step - gap):step, :],
-        y_test.iloc[(step - gap):step],
+        X_test.iloc[(step - gap):step, :].to_numpy(),
+        y_test.iloc[(step - gap):step].to_numpy(),
         gamma=0.05
     )
     (

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -12,7 +12,7 @@ from sklearn.utils.validation import check_is_fitted
 from mapie._typing import ArrayLike, NDArray
 from mapie.conformity_scores import ConformityScore
 from mapie.regression import MapieRegressor
-from mapie.utils import (check_alpha, check_gamma, convert_to_numpy)
+from mapie.utils import (check_alpha, check_gamma)
 
 
 class MapieTimeSeriesRegressor(MapieRegressor):
@@ -296,7 +296,6 @@ class MapieTimeSeriesRegressor(MapieRegressor):
         check_is_fitted(self, self.fit_attributes)
         check_gamma(gamma)
         X, y = cast(NDArray, X), cast(NDArray, y)
-        X, y = convert_to_numpy(X, y)
 
         self._get_alpha()
         alpha = cast(Optional[NDArray], check_alpha(alpha))

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any, Optional, Tuple
 
 import numpy as np
-import pandas as pd
 import pytest
 from numpy.random import RandomState
 from sklearn.datasets import make_regression
@@ -20,8 +19,8 @@ from mapie.utils import (check_alpha, check_alpha_and_n_samples,
                          check_lower_upper_bounds, check_n_features_in,
                          check_n_jobs, check_no_agg_cv, check_null_weight,
                          check_number_bins, check_split_strategy,
-                         check_verbose, compute_quantiles, convert_to_numpy,
-                         fit_estimator, get_binning_groups)
+                         check_verbose, compute_quantiles, fit_estimator,
+                         get_binning_groups)
 
 
 X_toy = np.array([0, 1, 2, 3, 4, 5]).reshape(-1, 1)
@@ -521,38 +520,3 @@ def test_check_no_agg_cv_value_error(cv: Any) -> None:
         match=r"Allowed values must have the `get_n_splits` method"
     ):
         check_no_agg_cv(X_toy, cv, array)
-
-
-def test_convert_to_numpy_dataframe_and_series():
-    X_df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
-    y_series = pd.Series([7, 8, 9])
-    X_array, y_array = convert_to_numpy(X_df, y_series)
-    assert isinstance(X_array, np.ndarray)
-    assert isinstance(y_array, np.ndarray)
-    assert np.array_equal(X_array, X_df.values)
-    assert np.array_equal(y_array, y_series.values)
-
-
-def test_convert_to_numpy_numpy_arrays():
-    X_array = np.array([[1, 2], [3, 4]])
-    y_array = np.array([5, 6])
-    X_result, y_result = convert_to_numpy(X_array, y_array)
-    assert isinstance(X_result, np.ndarray)
-    assert isinstance(y_result, np.ndarray)
-    assert np.array_equal(X_result, X_array)
-    assert np.array_equal(y_result, y_array)
-
-
-def test_convert_to_numpy_invalid_input_df():
-    with pytest.raises(ValueError):
-        invalid_input = "Invalid Input"
-        convert_to_numpy(invalid_input, [1, 2, 3])
-
-
-def test_convert_to_numpy_invalid_input_series():
-    with pytest.raises(ValueError):
-        invalid_input = "Invalid Input"
-        convert_to_numpy(
-            pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]}),
-            invalid_input
-        )

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -3,7 +3,6 @@ from inspect import signature
 from typing import Any, Iterable, Optional, Tuple, Union, cast
 
 import numpy as np
-from pandas import DataFrame, Series
 from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import (BaseCrossValidator, KFold, LeaveOneOut,
@@ -1273,43 +1272,6 @@ def check_nb_sets_sizes(sizes: NDArray, num_bins: int) -> None:
                 "The number of bins should be less than the number of \
                 different set sizes."
             )
-
-
-def convert_to_numpy(
-    X: DataFrame, y_true: Series
-) -> Tuple[NDArray, NDArray]:
-    """
-    Converts pandas DataFrame and Series to NumPy arrays.
-
-    Parameters
-    ----------
-    X: panda.DataFrame
-        The input DataFrame to be converted.
-    y_true: panda.Series)
-        The input Series to be converted.
-
-    Returns
-    -------
-    Tuple[NDArray, NDArray]
-        A tuple containing two NumPy arrays.
-        The first element is the NumPy array corresponding to X,
-        and the second element is the NumPy array corresponding to y_true.
-    """
-    if isinstance(X, DataFrame):
-        X_values = X.values
-    elif isinstance(X, np.ndarray):
-        X_values = X
-    else:
-        raise ValueError("X must be a pandas DataFrame or a NumPy array")
-
-    if isinstance(y_true, Series):
-        y_true_values = y_true.values
-    elif isinstance(y_true, np.ndarray):
-        y_true_values = y_true
-    else:
-        raise ValueError("y_true must be a pandas Series or a NumPy array")
-
-    return X_values, y_true_values
 
 
 def check_array_nan(array: NDArray) -> None:

--- a/notebooks/regression/ts-changepoint.ipynb
+++ b/notebooks/regression/ts-changepoint.ipynb
@@ -383,8 +383,8 @@
     "        y_test.iloc[(step - gap):step],\n",
     "    )\n",
     "    mapie_aci.adapt_conformal_inference(\n",
-    "        X_test.iloc[(step - gap):step, :],\n",
-    "        y_test.iloc[(step - gap):step],\n",
+    "        X_test.iloc[(step - gap):step, :].to_numpy(),\n",
+    "        y_test.iloc[(step - gap):step].to_numpy(),\n",
     "        gamma = 0.05\n",
     "    )\n",
     "    (\n",
@@ -775,8 +775,8 @@
     "        y_test.iloc[(step - gap):step],\n",
     "    )\n",
     "    mapie_aci.adapt_conformal_inference(\n",
-    "        X_test.iloc[(step - gap):step, :],\n",
-    "        y_test.iloc[(step - gap):step],\n",
+    "        X_test.iloc[(step - gap):step, :].to_numpy(),\n",
+    "        y_test.iloc[(step - gap):step].to_numpy(),\n",
     "        gamma = 0.05\n",
     "    )\n",
     "    (\n",
@@ -997,7 +997,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# Description

Error importing `MapieTimeSeriesRegressor` because pandas is not a required package in mapie. It is therefore proposed that this unnecessary dependency be removed and that only numpy arrays be managed.

Fixes #395 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Import `MapieTimeSeriesRegressor` without pandas requirement.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`