### PR TITLE
Fix: corrected spelling throughout doc  #402

### DIFF
--- a/doc/split_cross_conformal.rst
+++ b/doc/split_cross_conformal.rst
@@ -2,7 +2,7 @@
 Split/Cross-Conformal Prediction
 ################################
 
-**MAPIE** is basically based on two types of techniques:
+**MAPIE** is based on two types of techniques:
 
 - the split-conformal predictions,
 - the cross-conformal predictions.

--- a/doc/theoretical_description_binary_classification.rst
+++ b/doc/theoretical_description_binary_classification.rst
@@ -28,7 +28,7 @@ In a few words, what you need to remember about these concepts :
 
 * *Calibration* is useful for transforming a score (typically given by an ML model)
   into the probability of making a good prediction.
-* *Set Prediction* gives the set of likely predictions with a probabilisic guarantee that the true label is in this set.
+* *Set Prediction* gives the set of likely predictions with a probabilistic guarantee that the true label is in this set.
 * *Probabilistic Prediction* gives a confidence interval for the predictive distribution.
 
 
@@ -79,7 +79,7 @@ See :class:`~sklearn.calibration.CalibratedClassifierCV` or :class:`~mapie.calib
 to use a calibrator.
 
 In the CP framework, it is worth noting that Venn predictors produce probability-type predictions
-for the labels of test objects which are guaranteed to be well calibrated under the standard assumption
+for the labels of test objects which are guaranteed to be well-calibrated under the standard assumption
 that the observations are generated independently from the same distribution [2].
 
 
@@ -87,7 +87,7 @@ that the observations are generated independently from the same distribution [2]
 -------------
 
 [1] Gupta, Chirag, Aleksandr Podkopaev, and Aaditya Ramdas.
-"Distribution-free binary classification: prediction sets, confidence intervals and calibration."
+"Distribution-free binary classification: prediction sets, confidence intervals, and calibration."
 Advances in Neural Information Processing Systems 33 (2020): 3711-3723.
 
 [2] Vovk, Vladimir, Alexander Gammerman, and Glenn Shafer.

--- a/doc/theoretical_description_calibration.rst
+++ b/doc/theoretical_description_calibration.rst
@@ -14,7 +14,7 @@ The goal of binary calibration is to transform a score (typically given by an ML
 probability. The algorithms that are used for calibration can be interpreted as estimators of the confidence level. Hence,
 they need independent and dependent variables to be fitted.
 
-The figure below illustrates what we would expect as a result from a calibration, with the scores predicted being closer to the
+The figure below illustrates what we would expect as a result of a calibration, with the scores predicted being closer to the
 true probability compared to the original output.
 
 .. image:: images/calibration_basic.png
@@ -56,7 +56,7 @@ according to Top-Label calibration if:
 **Expected calibration error**
 
 The main metric to check if the calibration is correct is the Expected Calibration Error (ECE). It is based on two
-components, accuracy and confidence per bin. The number of bins is an hyperparamater :math:`M`, and we refer to a specific bin by
+components, accuracy and confidence per bin. The number of bins is a hyperparamater :math:`M`, and we refer to a specific bin by
 :math:`B_m`.
 
 .. math::
@@ -64,7 +64,7 @@ components, accuracy and confidence per bin. The number of bins is an hyperparam
     \text{conf}(B_m) &= \frac{1}{\left| B_m \right|} \sum_{i \in B_m} \hat{f}(x)_i
 
 
-The ECE is the combination of these two metrics combined together.
+The ECE is the combination of these two metrics combined.
 
 .. math::
     \text{ECE} = \sum_{m=1}^M \frac{\left| B_m \right|}{n} \left| acc(B_m) - conf(B_m) \right|
@@ -94,12 +94,12 @@ We also introduce a typical normalization scale :math:`\sigma`:
 .. math::
     \sigma = \frac{1}{N}\sqrt{\sum_{i=1}^N s_i(1 - s_i)}
 
-Tho Kolmogorov-Smirnov statisitc is then defined as : 
+The Kolmogorov-Smirnov statistic is then defined as : 
 
 .. math::
    G = \max|C_k|/\sigma
 
-It can be shown [2] that, under the null hypothesis of well calibrated scores, this quantity asymptotically (i.e. when N goes to infinity)
+It can be shown [2] that, under the null hypothesis of well-calibrated scores, this quantity asymptotically (i.e. when N goes to infinity)
 converges to the maximum absolute value of a standard Brownian motion over the unit interval :math:`[0, 1]`. [3, 4] also provide closed-form 
 formulas for the cumulative distribution function (CDF) of the maximum absolute value of such a standard Brownian motion.
 So we state the p-value associated to the statistical test of well calibration as:
@@ -114,7 +114,7 @@ Kuiper test was derived in [2, 3, 4] and is very similar to Kolmogorov-Smirnov. 
 .. math::
    H = (\max_k|C_k| - \min_k|C_k|)/\sigma
 
-It can be shown [2] that, under the null hypothesis of well calibrated scores, this quantity asymptotically (i.e. when N goes to infinity)
+It can be shown [2] that, under the null hypothesis of well-calibrated scores, this quantity asymptotically (i.e. when N goes to infinity)
 converges to the range of a standard Brownian motion over the unit interval :math:`[0, 1]`. [3, 4] also provide closed-form 
 formulas for the cumulative distribution function (CDF) of the range of such a standard Brownian motion.
 So we state the p-value associated to the statistical test of well calibration as:
@@ -124,7 +124,7 @@ So we state the p-value associated to the statistical test of well calibration a
 
 **Spiegelhalter test**
 
-Spiegelhalter test was derived in [6]. It is basically based on a decomposition of the Brier score: 
+Spiegelhalter test was derived in [6]. It is based on a decomposition of the Brier score: 
 
 .. math::
    B = \frac{1}{N}\sum_{i=1}^N(y_i - s_i)^2
@@ -146,7 +146,7 @@ So we can build a Z-score as follows:
 .. math::
    Z = \frac{B - E(B)}{\sqrt{Var(B)}} = \frac{\sum_{i=1}^N(y_i - s_i)(1 - 2s_i)}{\sqrt{\sum_{i=1}^N(1 - 2s_i)^2 s_i(1 - s_i)}}
 
-This statistic follows a normal distribution of cumulative distribution CDF, so that we state the associated p-value:
+This statistic follows a normal distribution of cumulative distribution CDF so that we state the associated p-value:
 
 .. math::
    p = 1 - CDF(Z)

--- a/doc/theoretical_description_classification.rst
+++ b/doc/theoretical_description_classification.rst
@@ -7,7 +7,7 @@ Theoretical Description
 =======================
 
 
-Three methods for multi-class uncertainty-quantification have been implemented in MAPIE so far :
+Three methods for multi-class uncertainty quantification have been implemented in MAPIE so far :
 LAC (that stands for Least Ambiguous set-valued Classifier) [1], Adaptive Prediction Sets [2, 3] and Top-K [3].
 The difference between these methods is the way the conformity scores are computed. 
 The figure below illustrates the three methods implemented in MAPIE:
@@ -35,7 +35,7 @@ Note that the guarantee is possible only on the marginal coverage, and not on th
 1. LAC
 ------
 
-In the LAC method, the conformity score is defined as as one minus the score of the true label. For each point :math:`i` of the calibration set : 
+In the LAC method, the conformity score is defined as one minus the score of the true label. For each point :math:`i` of the calibration set : 
 
 .. math:: 
     s_i(X_i, Y_i) = 1 - \hat{\mu}(X_i)_{Y_i}
@@ -53,7 +53,7 @@ Finally, we construct a prediction set by including all labels with a score high
     \hat{C}(X_{test}) = \{y : \hat{\mu}(X_{test})_y \geq 1 - \hat{q}\}
 
 
-This simple approach allows us to construct prediction sets which have a theoretical guarantee on the marginal coverage.
+This simple approach allows us to construct prediction sets that have a theoretical guarantee on the marginal coverage.
 However, although this method generally results in small prediction sets, it tends to produce empty ones when the model is uncertain,
 for example at the border between two classes.
 
@@ -133,11 +133,11 @@ For the construction of the prediction set for a new test point, the following p
 .. math::
    \hat{C}(X_{test}) = \{\pi_1, ..., \pi_k\} \quad \text{where} \quad k = \text{inf}\{k : \sum^k_{j=1} \hat{\mu}(X_{test})_{\pi_j} + \lambda(k-k_{reg})^+ \geq \hat{q}\}
 
-Intuitively, the goal of the method is to penalize the prediction sets whose size are greater than the optimal prediction set size. The level of this 
+Intuitively, the goal of the method is to penalize the prediction sets whose sizes are greater than the optimal prediction set size. The level of this 
 regularization is controlled by the parameter :math:`\lambda`.
 
-Despite that RAPS method has relatively small set size, its coverage tends to be higher than the one required (especially for high values of
-:math:`\alpha`, which means low level of confidence). Hence, to achieve exact coverage, one can implement a randomization concerning the inclusion
+Despite the RAPS method having a relatively small set size, its coverage tends to be higher than the one required (especially for high values of
+:math:`\alpha`, which means a low level of confidence). Hence, to achieve exact coverage, one can implement a randomization concerning the inclusion
 of the last label in the prediction set. This randomization is done as follows:
 
 - First : define the :math:`V` parameter:

--- a/doc/theoretical_description_conformity_scores.rst
+++ b/doc/theoretical_description_conformity_scores.rst
@@ -3,7 +3,7 @@
 .. _theoretical_description_conformity_scores:
 
 =============================================
-Theoretical Description for conformity scores
+Theoretical Description for Conformity Scores
 =============================================
 
 The :class:`mapie.conformity_scores.ConformityScore` class implements various
@@ -13,7 +13,7 @@ Note that it is possible for the user to create any conformal scores that are no
 already included in MAPIE by inheriting this class.
 
 Before describing the methods, let's briefly present the mathematical setting.
-With conformal predictions we want to transform an heuristic notion of uncertainty
+With conformal predictions, we want to transform a heuristic notion of uncertainty
 from a model into a rigorous one, and the first step to do it is to choose a conformal score.
 The only requirement for the score function :math:`s(X, Y) \in \mathbb{R}` is
 that larger scores should encode worse agreement between :math:`X` and :math:`Y`. [1]
@@ -29,7 +29,7 @@ and the other on the left side.
 
 The absolute residual score (:class:`mapie.conformity_scores.AbsoluteConformityScore`)
 is the simplest and most commonly used conformal score, it translates the error
-of the model : in regression it is called the residual.
+of the model : in regression, it is called the residual.
 
 .. math:: |Y-\hat{\mu}(X)|
 
@@ -40,7 +40,7 @@ The intervals of prediction's bounds are then computed from the following formul
 Where :math:`q(s)` is the :math:`(1-\alpha)` quantile of the conformity scores.
 (see :doc:`theoretical_description_regression` for more details).
 
-With this score the intervals of predictions will be constant over the whole dataset.
+With this score, the intervals of predictions will be constant over the whole dataset.
 This score is by default symmetric (*see above for definition*).
 
 2. The gamma score
@@ -61,17 +61,17 @@ Where :math:`q(s)` is the :math:`(1-\alpha)` quantile of the conformity scores.
 
 This score is by default asymmetric (*see definition above*).
 
-Compared to the absolute residual score, it allows to see regions with smaller intervals
+Compared to the absolute residual score, it allows us to see regions with smaller intervals
 than others which are interpreted as regions with more certainty than others.
 It is important to note that, this conformity score is inversely proportional to the
 order of magnitude of the predictions. Therefore, the uncertainty is proportional to
-the order of magitude of the predictions, implying that this score should be used
+the order of magnitude of the predictions, implying that this score should be used
 in use cases where we want greater uncertainty when the prediction is high.
 
-3. The residual normalised score
+3. The residual normalized score
 =======================================
 
-The residual normalised score [1] (:class:`mapie.conformity_scores.ResidualNormalisedScore`)
+The residual normalized score [1] (:class:`mapie.conformity_scores.ResidualNormalisedScore`)
 is slightly more complex than the previous scores.
 The normalization of the residual is now done by the predictions of an additional model
 :math:`\hat\sigma` which learns to predict the base model residuals from :math:`X`.
@@ -88,9 +88,9 @@ Where :math:`q(s)` is the :math:`(1-\alpha)` quantile of the conformity scores.
 (see :doc:`theoretical_description_regression` for more details).
 
 This score is by default symmetric (*see definition above*). Unlike the scores above,
-and due to the additionnal model required this score can only be used with split methods.
+and due to the additional model required this score can only be used with split methods.
 
-Normalisation by the learned residuals from :math:`X` adds to the score a knowledge of
+Normalization by the learned residuals from :math:`X` adds to the score a knowledge of
 :math:`X` and its similarity to the other examples in the dataset.
 Compared to the gamma score, the other adaptive score implemented in MAPIE,
 it is not proportional to the uncertainty.
@@ -100,11 +100,11 @@ Key takeaways
 =============
 
 - The absolute residual score is the basic conformity score and gives constant intervals. It is the one used by default by :class:`mapie.regression.MapieRegressor`.
-- The gamma conformity score adds a notion of adaptivity by giving intervals of different sizes,
+- The gamma conformity score adds a notion of adaptivity by giving intervals of different sizes
   and is proportional to the uncertainty.
-- The residual normalised score is a conformity score that requires an additional model
+- The residual normalized score is a conformity score that requires an additional model
   to learn the residuals of the model from :math:`X`. It gives very adaptive intervals
-  without specific asumptions on the data.
+  without specific assumptions on the data.
 
 References
 ==========

--- a/doc/theoretical_description_multilabel_classification.rst
+++ b/doc/theoretical_description_multilabel_classification.rst
@@ -7,7 +7,7 @@ Theoretical Description
 =======================
 
 
-Three methods for multi-label uncertainty-quantification have been implemented in MAPIE so far :
+Three methods for multi-label uncertainty quantification have been implemented in MAPIE so far :
 Risk-Controlling Prediction Sets (RCPS) [1], Conformal Risk Control (CRC) [2] and Learn Then Test (LTT) [3].
 The difference between these methods is the way the conformity scores are computed. 
 
@@ -16,7 +16,7 @@ our training data :math:`(X, Y) = \{(x_1, y_1), \ldots, (x_n, y_n)\}`` has an un
 
 For any risk level :math:`\alpha` between 0 and 1, the methods implemented in MAPIE allow the user to construct a prediction
 set :math:`\hat{C}_{n, \alpha}(X_{n+1})` for a new observation :math:`\left( X_{n+1},Y_{n+1} \right)` with a guarantee
-on the recall. RCPS, LTT and CRC give three slightly different guarantees:
+on the recall. RCPS, LTT, and CRC give three slightly different guarantees:
 
 - RCPS:
 
@@ -66,7 +66,7 @@ The goal of the method is to compute an Upper Confidence Bound (UCB) :math:`\hat
 .. math::
     \hat{\lambda} = \inf\{\lambda \in \Lambda: \hat{R}^+(\lambda ') < \alpha, \forall \lambda ' \geq \lambda \}
 
-The figure bellow explains this procedure:
+The figure below explains this procedure:
 
 .. image:: images/r_hat_plus.png
    :width: 600
@@ -82,7 +82,7 @@ Following those settings, the RCPS method gives the following guarantee on the r
 -----------------------
 
 In this section, we will consider only bounded losses (as for now, only the :math:`1-recall` loss is implemented).
-We will show three different Upper Calibration Bounds (UCB) (Hoeffding, Bernstein and Waudby-Smith–Ramdas) of :math:`R(\lambda)`
+We will show three different Upper Calibration Bounds (UCB) (Hoeffding, Bernstein, and Waudby-Smith–Ramdas) of :math:`R(\lambda)`
 based on the empirical risk which is defined as follows:
 
 .. math::
@@ -106,8 +106,8 @@ Which implies the following UCB:
 1.2.2. Bernstein Bound
 ----------------------
 
-Contrary to the Hoeffding bound, which can sometimes be too simple, the Bernstein UCB is taking into account the variance
-and gives smaller prediction set size:
+Contrary to the Hoeffding bound, which can sometimes be too simple, the Bernstein UCB takes into account the variance
+and gives a smaller prediction set size:
 
 .. math::
     \hat{R}_{Bernstein}^+(\lambda) = \hat{R}(\lambda) + \hat{\sigma}(\lambda)\sqrt{\frac{2\log(2/\delta)}{n}} + \frac{7\log (2/\delta)}{3(n-1)}
@@ -121,7 +121,7 @@ Where:
 1.2.3. Waudby-Smith–Ramdas
 --------------------------
 
-This last UCB is the one recommended by the authors of [1] to use when using a bounded loss as this is the one which gives
+This last UCB is the one recommended by the authors of [1] to use when using a bounded loss as this is the one that gives
 the smallest prediction sets size while having the same risk guarantees. This UCB is defined as follows:
 
 Let :math:`L_i (\lambda) = L(Y_i, T_{\lambda}(X_i))` and
@@ -170,7 +170,7 @@ With :
 
 3.1. General settings
 ---------------------
-We are going to present the Learn Then Test framework that allow the user to control non monotonic risk such as precision score.
+We are going to present the Learn Then Test framework that allows the user to control non-monotonic risk such as precision score.
 This method has been introduced in article [3].
 The settings here are the same as RCPS and CRC, we just need to introduce some new parameters:
 
@@ -178,7 +178,7 @@ The settings here are the same as RCPS and CRC, we just need to introduce some n
 
 - Let :math:`p_\lambda` be a valid p-value for the null hypothesis :math:`\mathbb{H}_j: R(\lambda_j)>\alpha`.
 
-The goal of this method is to control any loss whether monotonic, bounded or not, by performing risk control through multiple
+The goal of this method is to control any loss whether monotonic, bounded, or not, by performing risk control through multiple
 hypothesis testing. We can express the goal of the procedure as follows:
 
 .. math::
@@ -197,13 +197,13 @@ In order to find all the parameters :math:`\lambda` that satisfy the above condi
   introduced in the paper [3].
 
 - Return :math:`\hat{\Lambda} =  \mathcal{A}(\{p_j\}_{j\in\{1,\dots,\lvert \Lambda \rvert})`, where :math:`\mathcal{A}`, is an algorithm
-  that controls the family-wise-error-rate (FWER), for example bonferonni correction.
+  that controls the family-wise error rate (FWER), for example, Bonferonni correction.
 
 
 4. References
 -------------
 
-[1] Lihua Lei Jitendra Malik Stephen Bates, Anastasios Angelopoulos
+[1] Lihua Lei Jitendra Malik Stephen Bates, Anastasios Angelopoulos,
 and Michael I. Jordan. Distribution-free, risk-controlling prediction
 sets. CoRR, abs/2101.02703, 2021. URL https://arxiv.org/abs/2101.02703.39
 

--- a/doc/theoretical_description_regression.rst
+++ b/doc/theoretical_description_regression.rst
@@ -47,7 +47,7 @@ or
 where :math:`\hat{q}_{n, \alpha}^+` is the :math:`(1-\alpha)` quantile of the distribution.
 
 Since this method estimates the conformity scores only on the training set, it tends to be too 
-optimistic and under-estimates the width of prediction intervals because of a potential overfit. 
+optimistic and underestimates the width of prediction intervals because of a potential overfit. 
 As a result, the probability that a new point lies in the interval given by the 
 naive method would be lower than the target level :math:`(1-\alpha)`.
 
@@ -218,8 +218,8 @@ aggregated prediction and residual by only taking subsets in which the
 By analogy with the CV+ method, estimating the prediction intervals with 
 jackknife+-after-bootstrap is performed in four main steps:
 
-- We resample the training set with replacement (boostrap) :math:`K` times,
-  and thus we get the (non disjoint) bootstraps :math:`B_{1},..., B_{K}` of equal size.
+- We resample the training set with replacement (bootstrap) :math:`K` times,
+  and thus we get the (non-disjoint) bootstraps :math:`B_{1},..., B_{K}` of equal size.
 
 
 - :math:`K` regressions functions :math:`\hat{\mu}_{B_{k}}` are then fitted on 
@@ -241,7 +241,7 @@ As for jackknife+, this method guarantees a coverage level higher than
 :math:`1 - 2\alpha` for a target coverage level of :math:`1 - \alpha`, without 
 any a priori assumption on the distribution of the data. 
 In practice, this method results in wider prediction intervals, when the 
-uncertainty is higher, than :math:`CV+`, because the models' prediction spread 
+uncertainty is higher than :math:`CV+`, because the models' prediction spread 
 is then higher.
 
 
@@ -250,7 +250,7 @@ is then higher.
 
 The conformalized quantile method allows for better interval widths with
 heteroscedastic data. It uses quantile regressors with different quantile
-values to estimate the prediction bounds and the residuals of these methods is
+values to estimate the prediction bounds and the residuals of these methods are
 used to create the guaranteed coverage value.
 
 .. math:: 


### PR DESCRIPTION
Fixed various typos throughout the rst files in the doc folder. Each commit is for each rst file.

Fixes #402 