### PR TITLE
Added regression_MWI_score function

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,4 +38,6 @@ Contributors
 * Mehdi Elion <mehdi.elion@gmail.com>
 * Sami Kaddani <sami.kaddani@gmail.com>
 * Pierre de Fréminville <pidefrem>
+* Ambros Marzetta <ambrosm>
+* Carl McBride Ellis <Carl-McBride-Ellis>
 To be continued ...

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ History
   :meth:`~classification.MapieClassifier.fit()`.
 * Add possibility of passing fit parameters used by estimators.
 * Fix memory issue CQR when testing for upper and lower bounds.
+* Add Winkler Interval Score
 
 0.8.0 (2024-01-03)
 ------------------

--- a/mapie/metrics.py
+++ b/mapie/metrics.py
@@ -1575,3 +1575,52 @@ def spiegelhalter_p_value(y_true: NDArray, y_score: NDArray) -> float:
     sp_stat = spiegelhalter_statistic(y_true, y_score)
     sp_p_value = 1 - scipy.stats.norm.cdf(sp_stat)
     return sp_p_value
+
+
+def regression_MWI_score(y_true, y_pis, alpha):
+    """
+    This is an implementation of the Winkler interval score
+    (https://otexts.com/fpp3/distaccuracy.html#winkler-score).
+
+    Parameters
+    ----------
+    y_true: ArrayLike of shape (n_samples,)
+        Ground truth values
+    y_pis: ArrayLike of shape (n_samples, 2, 1)
+        Lower and upper bounds of prediction intervals
+        output from a MAPIE regressor
+    alpha: float
+        The value of alpha
+
+    Returns
+    -------
+    float
+        The mean Winkler interval score
+
+    References
+    ----------
+    [1] Robert L. Winkler
+    "A Decision-Theoretic Approach to Interval Estimation",
+    Journal of the American Statistical Association,
+    volume 67, pages 187-191 (1972)
+    (https://doi.org/10.1080/01621459.1972.10481224)
+    [2] Tilmann Gneiting and Adrian E Raftery
+    "Strictly Proper Scoring Rules, Prediction, and Estimation",
+    Journal of the American Statistical Association,
+    volume 102, pages 359-378 (2007)
+    (https://doi.org/10.1198/016214506000001437) (Section 6.2)
+    """
+
+    # undo any possible quantile crossing
+    low_tmp = y_pis[:, 0, 0]
+    up_tmp = y_pis[:, 1, 0]
+    y_pred_low = np.minimum(low_tmp, up_tmp)
+    y_pred_up = np.maximum(low_tmp, up_tmp)
+
+    width = y_pred_up.sum() - y_pred_low.sum()
+    error_above = (y_true - y_pred_up)[y_true > y_pred_up].sum()
+    error_below = (y_pred_low - y_true)[y_true < y_pred_low].sum()
+    total_error = error_above + error_below
+    MWIs = (width + total_error*2/alpha)/len(y_true)
+
+    return MWIs

--- a/mapie/metrics.py
+++ b/mapie/metrics.py
@@ -1577,14 +1577,16 @@ def spiegelhalter_p_value(y_true: NDArray, y_score: NDArray) -> float:
     return sp_p_value
 
 
-def regression_MWI_score(
+def regression_mwi_score(
         y_true: NDArray,
         y_pis: NDArray,
         alpha: float
 ) -> float:
     """
-    This is an implementation of the Winkler interval score
-    (https://otexts.com/fpp3/distaccuracy.html#winkler-score).
+    The Winkler score, proposed by Winkler (1972), is a measure used to
+    evaluate prediction intervals, combining the length of the interval
+    with a penalty that increases proportionally to the distance of an
+    observation outside the interval.
 
     Parameters
     ----------
@@ -1630,5 +1632,5 @@ def regression_MWI_score(
     error_above = np.sum((y_true - y_pred_up)[y_true > y_pred_up])
     error_below = np.sum((y_pred_low - y_true)[y_true < y_pred_low])
     total_error = error_above + error_below
-    MWIs = (width + total_error * 2 / alpha) / len(y_true)
-    return MWIs
+    mwi = (width + total_error * 2 / alpha) / len(y_true)
+    return mwi

--- a/mapie/tests/test_metrics.py
+++ b/mapie/tests/test_metrics.py
@@ -26,6 +26,7 @@ from mapie.metrics import (add_jitter,
                            kuiper_p_value,
                            kuiper_statistic,
                            length_scale,
+                           regression_MWI_score,
                            regression_coverage_score,
                            regression_coverage_score_v2,
                            regression_mean_width_score,
@@ -807,3 +808,32 @@ def test_spiegelhalter_p_value_calibrated() -> None:
     y_true = (uniform <= y_score).astype(float)
     ks_stat = spiegelhalter_p_value(y_true, y_score)
     np.testing.assert_allclose(ks_stat, 0.174832, atol=1e-6)
+
+
+def test_regression_MWI_score() -> None:
+    """
+    Test the mean Winkler interval score.
+    There are four predictions in y_pis.
+    For each the ground truth value is 10.0.
+    The first interval covers the true value.
+    The second interval is above the true value.
+    The third interval has lower > upper, i.e.
+    quantile crossing.
+    The fourth interval is below the true value.
+    """
+
+    y_true = np.array([10.0, 10.0, 10.0, 10.0])
+    y_pis = np.array([
+        [[5.0],
+            [15.0]],
+        [[15.0],
+            [25.0]],
+        [[12.0],
+            [8.0]],
+        [[-5.0],
+            [0.0]]])
+
+    alpha = 0.1
+
+    MWI_score = regression_MWI_score(y_true, y_pis, alpha)
+    np.testing.assert_allclose(MWI_score, 82.25, rtol=1e-2)

--- a/mapie/tests/test_metrics.py
+++ b/mapie/tests/test_metrics.py
@@ -26,7 +26,7 @@ from mapie.metrics import (add_jitter,
                            kuiper_p_value,
                            kuiper_statistic,
                            length_scale,
-                           regression_MWI_score,
+                           regression_mwi_score,
                            regression_coverage_score,
                            regression_coverage_score_v2,
                            regression_mean_width_score,
@@ -810,7 +810,7 @@ def test_spiegelhalter_p_value_calibrated() -> None:
     np.testing.assert_allclose(ks_stat, 0.174832, atol=1e-6)
 
 
-def test_regression_MWI_score() -> None:
+def test_regression_mwi_score() -> None:
     """
     Test the mean Winkler interval score.
     There are four predictions in y_pis.
@@ -835,5 +835,5 @@ def test_regression_MWI_score() -> None:
 
     alpha = 0.1
 
-    MWI_score = regression_MWI_score(y_true, y_pis, alpha)
-    np.testing.assert_allclose(MWI_score, 82.25, rtol=1e-2)
+    mwi_score = regression_mwi_score(y_true, y_pis, alpha)
+    np.testing.assert_allclose(mwi_score, 82.25, rtol=1e-2)


### PR DESCRIPTION
# Description

This is an efficient implementation for calculating the mean [Winkler interval score](https://otexts.com/fpp3/distaccuracy.html#winkler-score), based on the code written by Kaggle user [AmbrosM](https://www.kaggle.com/ambrosm) and published in the topic ["Accelerating the scoring function"](https://www.kaggle.com/competitions/prediction-interval-competition-i-birth-weight/discussion/461997).

Fixes #407

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Private testing was performed in the Kaglge competition [Prediction interval competition I: Birth weight](https://www.kaggle.com/competitions/prediction-interval-competition-i-birth-weight/overview) by comparing correspondence with the results to those output by the competition metric code published in [Winkler Interval score metric](https://www.kaggle.com/datasets/carlmcbrideellis/winkler-interval-score-metric).

#### Update (2024-02-27)
A test routine for the function `regression_MWI_score` has been written and added to the end of `mapie/tests/test_metrics.py` ([b101cb0](https://github.com/scikit-learn-contrib/MAPIE/pull/408/commits/b101cb04a4bf9816da8a83ce458e9a74ed56bd04)).

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`