### PR TITLE
Fix KeyError by Correcting Key Name in Dataset Loading Process

### DIFF
--- a/notebooks/classification/Cifar10.ipynb
+++ b/notebooks/classification/Cifar10.ipynb
@@ -209,7 +209,7 @@
     "        as_supervised=True,\n",
     "        with_info=True\n",
     "    )\n",
-    "    label_names = info.features['lac'].names\n",
+    "    label_names = info.features['label'].names\n",
     "\n",
     "    dataset = tfds.as_numpy(dataset)\n",
     "    X_train, y_train = dataset['train']\n",


### PR DESCRIPTION
# Description

This pull request addresses issue an issue, where the key name used to access label names in the dataset loading process was incorrect. The key 'lac' has been replaced with the correct key 'label' to ensure proper retrieval of label names.

# Motivation and Context:

The motivation behind this change is to rectify the KeyError that occurs during the dataset loading process due to the incorrect key name usage. By replacing the key with the correct one, we ensure that the code functions as intended and retrieves the label names successfully.

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# Dependencies:

No new dependencies are introduced by this change.

# How Has This Been Tested:

- [ ] Ran the updated code with the fix applied.
- [ ] Verified that the KeyError no longer occurs during the dataset loading process.
- [ ] Ensured that label names are retrieved correctly.
- [ ] Ran unit tests to verify the correctness of the fix.

# Instructions for Testing:

1. Pull the latest changes from the repository.
2. Apply this pull request to your local environment.
3. Run the dataset loading process.
4. Verify that the process completes without encountering KeyError.
5. Check that label names are retrieved correctly.


# Checklist

- [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully : `make lint`
- [ ] Typing passes successfully : `make type-check`
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`