### PR TITLE
400 create citations using GitHub

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -14,3 +14,8 @@ replace = __version__ = "{new_version}"
 [bumpversion:file:doc/conf.py]
 search = version = "{current_version}"
 replace = version = "{new_version}"
+
+[bumpversion:file:CITATION.cff]
+search = version = "{current_version}"
+replace = version = "{new_version}"
+

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ date-released: 2019-04-30
 url: "https://github.com/scikit-learn-contrib/MAPIE"
 preferred-citation:
   type: conference-paper
+  title: "Flexible and Systematic Uncertainty Estimation with Conformal Prediction via the MAPIE library"
   authors:
   - family-names: "Cordier"
     given-names: "Thibault"
@@ -23,8 +24,8 @@ preferred-citation:
     given-names: "Arnaud"
   - family-names: "Brunel"
     given-names: "Nicolas"
-  title: "Flexible and Systematic Uncertainty Estimation with Conformal Prediction via the MAPIE library"
-  booktitle: "Conformal and Probabilistic Prediction with Applications"
+  collection-title: "Conformal and Probabilistic Prediction with Applications"
+  collection-type: proceedings
   pages: "549--581"
   year: 2023
   organization: "PMLR"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,27 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Cordier"
+  given-names: "Thibault"
+  orcid: "https://orcid.org/0000-0000-0000-0000"
+title: "MAPIE - Model Agnostic Prediction Interval Estimator"
+version: 0.8.3
+date-released: 2019-04-30
+url: "https://github.com/scikit-learn-contrib/MAPIE"
+preferred-citation:
+  type: article
+  authors:
+  - family-names: "Taquet"
+    given-names: "Vianney"
+  - family-names: "Blot"
+    given-names: "Vincent"
+  - family-names: "Morzadec"
+    given-names: "Thomas"
+  - family-names: "Lacombe"
+    given-names: "Louis"
+  - family-names: "Brunel"
+    given-names: "Nicolas"
+  doi: "10.48550/arXiv.2207.12274"
+  journal: "arXiv preprint arXiv:2207.12274"
+  title: "MAPIE: an open-source library for distribution-free uncertainty quantification"
+  year: 2021

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,26 @@ version: 0.8.3
 date-released: 2019-04-30
 url: "https://github.com/scikit-learn-contrib/MAPIE"
 preferred-citation:
+  type: conference-paper
+  authors:
+  - family-names: "Cordier"
+    given-names: "Thibault"
+  - family-names: "Blot"
+    given-names: "Vincent"
+  - family-names: "Lacombe"
+    given-names: "Louis"
+  - family-names: "Morzadec"
+    given-names: "Thomas"
+  - family-names: "Capitaine"
+    given-names: "Arnaud"
+  - family-names: "Brunel"
+    given-names: "Nicolas"
+  title: "Flexible and Systematic Uncertainty Estimation with Conformal Prediction via the MAPIE library"
+  booktitle: "Conformal and Probabilistic Prediction with Applications"
+  pages: "549--581"
+  year: 2023
+  organization: "PMLR"
+old-citation:
   type: article
   authors:
   - family-names: "Taquet"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * Fix conda versionning.
 * Reduce precision for test in `MapieCalibrator`.
+* Add citations utility to the documentation.
 
 0.8.3 (2024-03-01)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -229,4 +229,4 @@ MAPIE is free and open-source software licensed under the `3-clause BSD license 
 📚 Citation
 ===========
 
-If you use MAPIE in your research, please cite using `citations file <CITATION.CFF>`_ on our repository.
+If you use MAPIE in your research, please cite using `citations file <CITATION.cff>`_ on our repository.

--- a/README.rst
+++ b/README.rst
@@ -224,3 +224,9 @@ and with the financial support from Région Ile de France and Confiance.ai.
 ==========
 
 MAPIE is free and open-source software licensed under the `3-clause BSD license <https://github.com/simai-ml/MAPIE/blob/master/LICENSE>`_.
+
+
+📚 Citation
+===========
+
+If you use MAPIE in your research, please cite using `citations file <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files>`_ on our repository.

--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,7 @@ and with the financial support from Région Ile de France and Confiance.ai.
 📝 License
 ==========
 
-MAPIE is free and open-source software licensed under the `3-clause BSD license <https://github.com/simai-ml/MAPIE/blob/master/LICENSE>`_.
+MAPIE is free and open-source software licensed under the `3-clause BSD license <LICENSE>`_.
 
 
 📚 Citation

--- a/README.rst
+++ b/README.rst
@@ -229,4 +229,4 @@ MAPIE is free and open-source software licensed under the `3-clause BSD license 
 📚 Citation
 ===========
 
-If you use MAPIE in your research, please cite using `citations file <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files>`_ on our repository.
+If you use MAPIE in your research, please cite using `citations file <CITATION.CFF>`_ on our repository.

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@
     :target: https://mapie.readthedocs.io/en/stable/?badge=stable
     :alt: Documentation Status
 
-.. |License| image:: https://img.shields.io/github/license/simai-ml/MAPIE
+.. |License| image:: https://img.shields.io/github/license/scikit-learn-contrib/MAPIE
    :target: https://github.com/scikit-learn-contrib/MAPIE/blob/master/LICENSE
 
 .. |PythonVersion| image:: https://img.shields.io/pypi/pyversions/mapie
@@ -33,7 +33,7 @@
 .. |DOI| image:: https://img.shields.io/badge/10.48550/arXiv.2207.12274-B31B1B.svg
    :target: https://arxiv.org/abs/2207.12274
 
-.. image:: https://github.com/simai-ml/MAPIE/raw/master/doc/images/mapie_logo_nobg_cut.png
+.. image:: https://github.com/scikit-learn-contrib/MAPIE/raw/master/doc/images/mapie_logo_nobg_cut.png
     :width: 400
     :align: center
 
@@ -158,7 +158,7 @@ The full documentation can be found `on this link <https://mapie.readthedocs.io/
 ===============
 
 You are welcome to propose and contribute new ideas.
-We encourage you to `open an issue <https://github.com/simai-ml/MAPIE/issues>`_ so that we can align on the work to be done.
+We encourage you to `open an issue <https://github.com/scikit-learn-contrib/MAPIE/issues>`_ so that we can align on the work to be done.
 It is generally a good idea to have a quick discussion before opening a pull request that is potentially out-of-scope.
 For more information on the contribution process, please go `here <CONTRIBUTING.rst>`_.
 


### PR DESCRIPTION
# Description
This pull request introduces the addition of citation details to the MAPIE project by including a `CITATIONS.cff` file. The goal is to facilitate proper citation of MAPIE in academic and professional work by providing a standardized citation format. This change addresses the issue raised regarding the beneficial use of citations directly from the GitHub features. The `CITATIONS.cff` file includes author details, software title, version, release date, URL, and a preferred citation format.

Fixes #400.

## Type of change:
Please remove options that are irrelevant.
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Verified that the `CITATIONS.cff` file is properly formatted and recognized by GitHub
- [x] Ensured the citation information is correct and matches the required format

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`