### PR TITLE
Solve conflict between ACI and base methods in MapieTimeSeriesRegressor

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,4 +40,5 @@ Contributors
 * Pierre de Fréminville <pidefrem>
 * Ambros Marzetta <ambrosm>
 * Carl McBride Ellis <Carl-McBride-Ellis>
+* Baptiste Calot <baptiste.calot@capgemini.com>
 To be continued ...

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.8.3 (2024-**-**)
 ------------------
-* Fix shift in power from one method to base method when use MapieRegressor fit : issue 447
+* Fixed overloading of the value of the ‘method’ attribute when using MapieRegressor and MapieTimeSeriesRegressor
 * Fix conda versionning.
 * Reduce precision for test in `MapieCalibrator`.
 * Fix invalid certificate when downloading data.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.8.3 (2024-**-**)
 ------------------
-
+* Fix shift in power from one method to base method when use MapieRegressor fit : issue 447
 * Fix conda versionning.
 * Reduce precision for test in `MapieCalibrator`.
 * Fix invalid certificate when downloading data.

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -425,7 +425,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         cv = check_cv(
             self.cv, test_size=self.test_size, random_state=self.random_state
         )
-        if self.cv in ["split", "prefit"] and (self.method == "naive" or self.method == "plus"):
+        if self.cv in ["split", "prefit"] and (self.method == "naive" or
+                                               self.method == "plus"):
             self.method = "base"
         estimator = self._check_estimator(self.estimator)
         agg_function = self._check_agg_function(self.agg_function)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -425,7 +425,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         cv = check_cv(
             self.cv, test_size=self.test_size, random_state=self.random_state
         )
-        if self.cv in ["split", "prefit"] and self.method != "base":
+        if self.cv in ["split", "prefit"] and (self.method == "naive" or self.method == "plus"):
             self.method = "base"
         estimator = self._check_estimator(self.estimator)
         agg_function = self._check_agg_function(self.agg_function)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -425,8 +425,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         cv = check_cv(
             self.cv, test_size=self.test_size, random_state=self.random_state
         )
-        if self.cv in ["split", "prefit"] and (self.method == "naive" or
-                                               self.method == "plus"):
+        if self.cv in ["split", "prefit"] and \
+            self.method in ["naive", "plus", "minmax]:
             self.method = "base"
         estimator = self._check_estimator(self.estimator)
         agg_function = self._check_agg_function(self.agg_function)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -426,7 +426,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             self.cv, test_size=self.test_size, random_state=self.random_state
         )
         if self.cv in ["split", "prefit"] and \
-            self.method in ["naive", "plus", "minmax]:
+                self.method in ["naive", "plus", "minmax"]:
             self.method = "base"
         estimator = self._check_estimator(self.estimator)
         agg_function = self._check_agg_function(self.agg_function)

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -753,7 +753,7 @@ def test_predict_infinite_intervals() -> None:
 @pytest.mark.parametrize("method", ["minmax", "naive", "plus", "base"])
 @pytest.mark.parametrize("cv", ["split", "prefit"])
 def test_check_change_method_to_base(method: str, cv: str) -> None:
-    """Test of shift in power from one method to base method in fit"""
+    """Test of the overloading of method attribute to `base` method in fit"""
 
     X_train, X_val, y_train, y_val = train_test_split(
         X, y, test_size=0.5, random_state=random_state

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -748,3 +748,20 @@ def test_predict_infinite_intervals() -> None:
     _, y_pis = mapie_reg.predict(X, alpha=0., allow_infinite_bounds=True)
     np.testing.assert_allclose(y_pis[:, 0, 0], -np.inf)
     np.testing.assert_allclose(y_pis[:, 1, 0], np.inf)
+
+
+@pytest.mark.parametrize("method", ["minmax", "naive", "plus"])
+@pytest.mark.parametrize("cv", ["split", "prefit"])
+def test_check_change_method_to_base(method: str, cv: str) -> None:
+    """Test of shift in power from one method to base method in fit"""
+
+    X_train, X_val, y_train, y_val = train_test_split(
+        X, y, test_size=0.5, random_state=random_state
+    )
+    estimator = LinearRegression().fit(X_train, y_train)
+    mapie_reg = MapieRegressor(
+        cv=cv, method=method, estimator=estimator
+    )
+    mapie_reg.fit(X_val, y_val)
+    assert mapie_reg.method == "base", \
+        f"Expected method base, but got {mapie_reg.method}"

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -750,7 +750,7 @@ def test_predict_infinite_intervals() -> None:
     np.testing.assert_allclose(y_pis[:, 1, 0], np.inf)
 
 
-@pytest.mark.parametrize("method", ["minmax", "naive", "plus"])
+@pytest.mark.parametrize("method", ["minmax", "naive", "plus", "base"])
 @pytest.mark.parametrize("cv", ["split", "prefit"])
 def test_check_change_method_to_base(method: str, cv: str) -> None:
     """Test of shift in power from one method to base method in fit"""
@@ -763,5 +763,4 @@ def test_check_change_method_to_base(method: str, cv: str) -> None:
         cv=cv, method=method, estimator=estimator
     )
     mapie_reg.fit(X_val, y_val)
-    assert mapie_reg.method == "base", \
-        f"Expected method base, but got {mapie_reg.method}"
+    assert mapie_reg.method == "base"

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -518,3 +518,23 @@ def test_method_error_in_update(monkeypatch: Any, method: str) -> None:
     with pytest.raises(ValueError, match=r".*Invalid method.*"):
         mapie_ts_reg.fit(X_toy, y_toy)
         mapie_ts_reg.update(X_toy, y_toy)
+
+
+def test_aci_method() -> None:
+    
+    """Test of aci method in fit"""
+    X_train_val, X_test, y_train_val, y_test = train_test_split(
+        X, y, test_size=0.33, random_state=random_state
+    )
+    X_train, X_val, y_train, y_val = train_test_split(
+        X_train_val, y_train_val, test_size=0.5, random_state=random_state
+    )
+    estimator = LinearRegression().fit(X_train, y_train)
+    mapie_ts_reg = MapieTimeSeriesRegressor(
+        estimator=estimator,
+        cv="prefit", method = "aci"
+    )
+    mapie_ts_reg.fit(X_val, y_val)
+    mapie_ts_reg.update(X_test, y_test, gamma=0.1, alpha=0.1)
+
+    assert mapie_ts_reg.method == "base"

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -520,8 +520,11 @@ def test_method_error_in_update(monkeypatch: Any, method: str) -> None:
         mapie_ts_reg.update(X_toy, y_toy)
 
 
-def test_aci_method_in_fit() -> None:
-    """Test of aci method in fit"""
+@pytest.mark.parametrize("method", ["enbpi", "aci"])
+@pytest.mark.parametrize("cv", ["split", "prefit"])
+def test_methods_preservation_in_fit(method: str, cv: str) -> None:
+    """Test of enbpi and aci method preservation in the fit MapieRegressor"""
+
     X_train_val, X_test, y_train_val, y_test = train_test_split(
         X, y, test_size=0.33, random_state=random_state
     )
@@ -531,8 +534,9 @@ def test_aci_method_in_fit() -> None:
     estimator = LinearRegression().fit(X_train, y_train)
     mapie_ts_reg = MapieTimeSeriesRegressor(
         estimator=estimator,
-        cv="prefit", method="aci"
+        cv=cv, method=method
     )
     mapie_ts_reg.fit(X_val, y_val)
     mapie_ts_reg.update(X_test, y_test, gamma=0.1, alpha=0.1)
-    assert mapie_ts_reg.method == "aci"
+    assert mapie_ts_reg.method == method, \
+        f"Expected method {method}, but got {mapie_ts_reg.method}"

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -538,5 +538,4 @@ def test_methods_preservation_in_fit(method: str, cv: str) -> None:
     )
     mapie_ts_reg.fit(X_val, y_val)
     mapie_ts_reg.update(X_test, y_test, gamma=0.1, alpha=0.1)
-    assert mapie_ts_reg.method == method, \
-        f"Expected method {method}, but got {mapie_ts_reg.method}"
+    assert mapie_ts_reg.method == method

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -520,8 +520,7 @@ def test_method_error_in_update(monkeypatch: Any, method: str) -> None:
         mapie_ts_reg.update(X_toy, y_toy)
 
 
-def test_aci_method() -> None:
-    
+def test_aci_method_in_fit() -> None:
     """Test of aci method in fit"""
     X_train_val, X_test, y_train_val, y_test = train_test_split(
         X, y, test_size=0.33, random_state=random_state
@@ -532,9 +531,8 @@ def test_aci_method() -> None:
     estimator = LinearRegression().fit(X_train, y_train)
     mapie_ts_reg = MapieTimeSeriesRegressor(
         estimator=estimator,
-        cv="prefit", method = "aci"
+        cv="prefit", method="aci"
     )
     mapie_ts_reg.fit(X_val, y_val)
     mapie_ts_reg.update(X_test, y_test, gamma=0.1, alpha=0.1)
-
-    assert mapie_ts_reg.method == "base"
+    assert mapie_ts_reg.method == "aci"


### PR DESCRIPTION
# Description

This PR is to fix issue 447 where the method of MapieTimesSeriesRegressor is "aci" but when we use the fit method of MapieRegressor, the method become "base"

## Type of change

- Bug fix : In MapieRegressor, when cv is prefit or split and method different from "naive" or "plus", you don't force the method to become "base"

# How Has This Been Tested?

- [x] re-create example and make sure it works:
- [x] Build instance of MapieTimeSeriesRegressor with method "aci"
- [x] Fit instance (with fit method from MapieRegressor)
- [x] Update the instance
- [x] Finaly check the instance's method and see if it still "aci"

# Checklist
- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`
