### PR TITLE
Switch from the bostom dataset to the toy dataset

### DIFF
--- a/examples/regression/2-advanced-analysis/plot_nested-cv.py
+++ b/examples/regression/2-advanced-analysis/plot_nested-cv.py
@@ -26,7 +26,7 @@ it results in :math:`N * P` calculations, where *N* is the number of
 *out-of-fold* models and *P* the number of parameter search cross-validations,
 versus :math:`N + P` for the non-nested approach.
 
-Here, we compare the two strategies on the Boston dataset. We use the Random
+Here, we compare the two strategies on a toy dataset. We use the Random
 Forest Regressor as a base regressor for the CV+ strategy. For the sake of
 light computation, we adopt a RandomizedSearchCV parameter search strategy
 with a low number of iterations and with a reproducible random state.


### PR DESCRIPTION
# Description

Documentation construction is interrupted due to the inaccessibility of the bostom dataset, which fails the current PR.
We propose to switch from the bostom dataset to the toy dataset.

Fixes #460

## Type of change

Please remove options that are irrelevant.
- This change requires a documentation update

# How Has This Been Tested?

- [x] Code execution: ok

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`