### PR TITLE
Unit tests for different subsamples

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.8.x (2024-xx-xx)
 ------------------
 
+* Building unit tests for different `Subsample` and `BlockBooststrap` instances
 * Building a training set with a fraction between 0 and 1 with `n_samples` attribute when using `split` method from `Subsample` class.
 
 0.8.6 (2024-06-14)

--- a/mapie/tests/test_subsample.py
+++ b/mapie/tests/test_subsample.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Union
+
 import numpy as np
 import pytest
 
@@ -76,6 +78,24 @@ def test_n_samples_none(n_resamplings: int) -> None:
     assert len(val_set) == 0
 
 
+@pytest.mark.parametrize("n_samples", [0.4, 0.6, 3, 6])
+@pytest.mark.parametrize("n_resamplings", [2, 3, 4])
+def test_split_samples_Subsample(n_resamplings: int,
+                                 n_samples: Union[int, float]) -> None:
+    """Test that outputs of subsamplings are all different."""
+    X = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    cv = Subsample(n_resamplings=n_resamplings,
+                   n_samples=n_samples, replace=False, random_state=0)
+    trains = [x[0] for x in cv.split(X)]
+    tests = [x[1] for x in cv.split(X)]
+    for i in range(n_resamplings):
+        for j in range(i + 1, n_resamplings):
+            with np.testing.assert_raises(AssertionError):
+                np.testing.assert_equal(trains[i], trains[j])
+            with np.testing.assert_raises(AssertionError):
+                np.testing.assert_equal(tests[i], tests[j])
+
+
 def test_default_parameters_BlockBootstrap() -> None:
     """Test default values of Subsample."""
     cv = BlockBootstrap()
@@ -131,3 +151,21 @@ def test_split_BlockBootstrap_error() -> None:
     cv = BlockBootstrap()
     with pytest.raises(ValueError, match=r".*Exactly one argument*"):
         next(cv.split(X))
+
+
+@pytest.mark.parametrize("length", [2, 3, 4])
+@pytest.mark.parametrize("n_resamplings", [2, 3, 4])
+def test_split_samples_BlockBootstrap(n_resamplings: int,
+                                      length: int) -> None:
+    """Test that outputs of subsamplings are all different."""
+    X = np.arange(31)
+    cv = BlockBootstrap(n_resamplings=n_resamplings,
+                        length=length, random_state=0)
+    trains = [x[0] for x in cv.split(X)]
+    tests = [x[1] for x in cv.split(X)]
+    for i in range(n_resamplings):
+        for j in range(i + 1, n_resamplings):
+            with np.testing.assert_raises(AssertionError):
+                np.testing.assert_equal(trains[i], trains[j])
+            with np.testing.assert_raises(AssertionError):
+                np.testing.assert_equal(tests[i], tests[j])

--- a/mapie/tests/test_subsample.py
+++ b/mapie/tests/test_subsample.py
@@ -185,12 +185,12 @@ def test_split_samples_BlockBootstrap(n_resamplings: int,
                         length=length, random_state=0)
     trains = [x[0] for x in cv.split(X)]
     tests = [x[1] for x in cv.split(X)]
-    for i in range(n_resamplings):
-        for j in range(i + 1, n_resamplings):
-            with np.testing.assert_raises(AssertionError):
-                np.testing.assert_equal(trains[i], trains[j])
-            with np.testing.assert_raises(AssertionError):
-                np.testing.assert_equal(tests[i], tests[j])
+    for (train1, train2), (test1, test2) in product(
+            combinations(trains, 2), combinations(tests, 2)):
+        with np.testing.assert_raises(AssertionError):
+            np.testing.assert_equal(train1, train2)
+        with np.testing.assert_raises(AssertionError):
+            np.testing.assert_equal(test1, test2)
 
 
 @pytest.mark.parametrize("length", [2, 3, 4])
@@ -215,5 +215,5 @@ def test_reproductibility_samples_BlockBootstrap(
     )
     trains2 = [x[0] for x in list(cv2.split(X))]
     tests2 = [x[1] for x in list(cv2.split(X))]
-    np.testing.assert_array_equal(trains1, trains2)
+    np.testing.assert_equal(trains1, trains2)
     np.testing.assert_equal(tests1, tests2)

--- a/mapie/tests/test_subsample.py
+++ b/mapie/tests/test_subsample.py
@@ -114,8 +114,8 @@ def test_reproductibility_samples_Subsample(
                     n_samples=n_samples, replace=False, random_state=0)
     trains2 = [x[0] for x in cv2.split(X)]
     tests2 = [x[1] for x in cv2.split(X)]
-    assert np.array_equal(trains1, trains2)
-    assert np.array_equal(tests1, tests2)
+    np.testing.assert_array_equal(trains1, trains2)
+    np.testing.assert_array_equal(tests1, tests2)
 
 
 def test_default_parameters_BlockBootstrap() -> None:
@@ -215,7 +215,5 @@ def test_reproductibility_samples_BlockBootstrap(
     )
     trains2 = [x[0] for x in list(cv2.split(X))]
     tests2 = [x[1] for x in list(cv2.split(X))]
-    tests1_set = {tuple(sorted(arr)) for arr in tests1}
-    tests2_set = {tuple(sorted(arr)) for arr in tests2}
-    assert np.array_equal(trains1, trains2)
-    assert np.array_equal(np.array(tests1_set), np.array(tests2_set))
+    np.testing.assert_array_equal(trains1, trains2)
+    np.testing.assert_equal(tests1, tests2)


### PR DESCRIPTION
# Description

This PR aims to create unit tests to verify that the train and test sets of the split method from Subsample and BlockBootstrap classes are different even though the random state is the same

Fix issue #290

# Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- 2 unit tests

# Checklist : OK

- [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully : `make lint`
- [ ] Typing passes successfully : `make type-check`
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`