### PR TITLE
Change the sign in the equation of  C_k in the Kolmogorov-Smirnov statistical test documentation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 0.8.x (2024-xx-xx)
 ------------------
 
-* Changed the sign of C_k in the `Kolmogorov-Smirnov` test documentation to resolve issue 369.
+* Change the sign of C_k in the `Kolmogorov-Smirnov` test documentation
 * Building a training set with a fraction between 0 and 1 with `n_samples` attribute when using `split` method from `Subsample` class.
 
 0.8.6 (2024-06-14)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,7 @@ History
 0.8.x (2024-xx-xx)
 ------------------
 
+* Changed the sign of C_k in the `Kolmogorov-Smirnov` test documentation to resolve issue 369.
 * Building a training set with a fraction between 0 and 1 with `n_samples` attribute when using `split` method from `Subsample` class.
 
 0.8.6 (2024-06-14)

--- a/doc/theoretical_description_metrics.rst
+++ b/doc/theoretical_description_metrics.rst
@@ -195,7 +195,7 @@ and their corresponding labels :math:`y_i` and to compare its properties to that
 cumulative differences on sorted scores: 
 
 .. math::
-    C_k = \frac{1}{N}\sum_{i=1}^k (s_i - y_i)
+    C_k = \frac{1}{N}\sum_{i=1}^k (y_i - s_i)
 
 We also introduce a typical normalization scale :math:`\sigma`:
 


### PR DESCRIPTION
# Description

Change (y_i- s_i) instead of (s_i - y_i) in the definition of C_k

Fixes issue #369

# How Has This Been Tested?

No test for this change

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`