### PR TITLE
Import in the ts-changepoint notebook related to conformity scores is incorrect 

### DIFF
--- a/notebooks/regression/ts-changepoint.ipynb
+++ b/notebooks/regression/ts-changepoint.ipynb
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 425,
+   "execution_count": 629,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 426,
+   "execution_count": 630,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,8 @@
     "from mapie.metrics import regression_coverage_score, regression_mean_width_score, coverage_width_based\n",
     "from mapie.subsample import BlockBootstrap\n",
     "from mapie.time_series_regression import MapieTimeSeriesRegressor\n",
-    "from mapie.conformity_scores import ConformityScore\n",
+    "from mapie.conformity_scores.regression import BaseRegressionScore\n",
+    "from mapie.conformity_scores.regression import BaseConformityScore\n",
     "\n",
     "%reload_ext autoreload\n",
     "%autoreload 2\n",
@@ -83,7 +84,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 427,
+   "execution_count": 631,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 428,
+   "execution_count": 632,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 429,
+   "execution_count": 633,
    "metadata": {},
    "outputs": [
     {
@@ -141,7 +142,7 @@
        "Text(0, 0.5, 'Hourly demand (GW)')"
       ]
      },
-     "execution_count": 429,
+     "execution_count": 633,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -173,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 430,
+   "execution_count": 634,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +215,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 431,
+   "execution_count": 635,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 432,
+   "execution_count": 636,
    "metadata": {},
    "outputs": [
     {
@@ -271,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 433,
+   "execution_count": 637,
    "metadata": {},
    "outputs": [
     {
@@ -310,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 434,
+   "execution_count": 638,
    "metadata": {},
    "outputs": [
     {
@@ -357,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 435,
+   "execution_count": 639,
    "metadata": {},
    "outputs": [
     {
@@ -411,7 +412,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 436,
+   "execution_count": 640,
    "metadata": {},
    "outputs": [
     {
@@ -436,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 437,
+   "execution_count": 641,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +449,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 438,
+   "execution_count": 642,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +461,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 439,
+   "execution_count": 643,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 440,
+   "execution_count": 644,
    "metadata": {},
    "outputs": [
     {
@@ -515,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 441,
+   "execution_count": 645,
    "metadata": {},
    "outputs": [
     {
@@ -559,7 +560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 442,
+   "execution_count": 646,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 443,
+   "execution_count": 647,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,16 +590,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 444,
+   "execution_count": 648,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x184c64760>]"
+       "[<matplotlib.lines.Line2D at 0x186d0b730>]"
       ]
      },
-     "execution_count": 444,
+     "execution_count": 648,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -630,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 445,
+   "execution_count": 649,
    "metadata": {},
    "outputs": [
     {
@@ -660,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 446,
+   "execution_count": 650,
    "metadata": {},
    "outputs": [
     {
@@ -699,26 +700,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 447,
+   "execution_count": 651,
    "metadata": {},
    "outputs": [],
    "source": [
     "def compute_quantiles(conformity_scores, alpha_np):\n",
     "\n",
-    "    beta_np = ConformityScore._beta_optimize(\n",
+    "    beta_np = BaseRegressionScore._beta_optimize(\n",
     "                    alpha_np,\n",
     "                    conformity_scores.reshape(1, -1),\n",
     "                    conformity_scores.reshape(1, -1),\n",
     "                )\n",
     "    alpha_low, alpha_up = beta_np, 1 - alpha_np + beta_np\n",
     "\n",
-    "    lower_quantiles = ConformityScore.get_quantile(\n",
+    "    lower_quantiles = BaseConformityScore.get_quantile(\n",
     "    conformity_scores[..., np.newaxis],\n",
     "    alpha_low, axis=0, reversed=True,\n",
     "    unbounded=False\n",
     "    )\n",
     "\n",
-    "    higher_quantiles = ConformityScore.get_quantile(\n",
+    "    higher_quantiles = BaseConformityScore.get_quantile(\n",
     "        conformity_scores[..., np.newaxis],\n",
     "        alpha_up, axis=0,\n",
     "        unbounded=False\n",
@@ -729,7 +730,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 448,
+   "execution_count": 652,
    "metadata": {},
    "outputs": [
     {
@@ -786,7 +787,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 449,
+   "execution_count": 653,
    "metadata": {},
    "outputs": [
     {
@@ -864,7 +865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 458,
+   "execution_count": 654,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,7 +877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 459,
+   "execution_count": 655,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -890,7 +891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 460,
+   "execution_count": 656,
    "metadata": {},
    "outputs": [
     {
@@ -910,7 +911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 461,
+   "execution_count": 657,
    "metadata": {},
    "outputs": [
     {
@@ -930,7 +931,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 462,
+   "execution_count": 658,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -965,16 +966,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 463,
+   "execution_count": 659,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<matplotlib.lines.Line2D at 0x1854c75e0>]"
+       "[<matplotlib.lines.Line2D at 0x18672cd30>]"
       ]
      },
-     "execution_count": 463,
+     "execution_count": 659,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1012,16 +1013,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 464,
+   "execution_count": 660,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x18551cdf0>"
+       "<matplotlib.legend.Legend at 0x186665900>"
       ]
      },
-     "execution_count": 464,
+     "execution_count": 660,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1054,16 +1055,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 465,
+   "execution_count": 661,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x185621690>"
+       "<matplotlib.legend.Legend at 0x1854386a0>"
       ]
      },
-     "execution_count": 465,
+     "execution_count": 661,
      "metadata": {},
      "output_type": "execute_result"
     },


### PR DESCRIPTION
# Description

The import in the ts-changepoint notebook related to conformity scores has been incorrect since the merge of the Mapie Classifier refactor

Fixes #497 

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No unit test

# Checklist

- [ ] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully : `make lint`
- [ ] Typing passes successfully : `make type-check`
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`