### PR TITLE
Fix the set-up with pip for new contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ target/
 
 # ZIP files
 *.zip
+
+# Pyenv
+.python-version

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -50,11 +50,26 @@ Documenting your change
 
 If you're adding a class or a function, then you'll need to add a docstring with a doctest. We follow the `numpy docstring convention <https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html>`_, so please do too.
 Any estimator should follow the [scikit-learn API](https://scikit-learn.org/stable/developers/develop.html), so please follow these guidelines.
-In order to build the documentation locally, run :
+In order to build the documentation locally, you first need to install some dependencies :
+
+Create a dedicated virtual environment via `conda`:
 
 .. code:: sh
 
-    $ cd doc
+    $ conda env create -f environment.doc.yml
+    $ conda activate mapie-doc
+
+Alternatively, using `pip`, create a different virtual environment than the one used for development, and install the dependencies:
+
+.. code:: sh
+
+    $ pip install -r requirements.doc.txt
+    $ pip install -e .
+
+Finally, once dependencies are installed, you can build the documentation locally by running:
+
+.. code:: sh
+
     $ make clean-doc
     $ make doc
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.9.x (2024-xx-xx)
 ------------------
-
+* Fix (partially) the set-up with pip instead of conda for new contributors
 
 
 0.9.0 (2024-09-03)

--- a/requirements.ci.txt
+++ b/requirements.ci.txt
@@ -4,4 +4,5 @@ mypy
 pandas
 pytest
 pytest-cov
+scikit-learn
 typed-ast

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,8 +3,8 @@ flake8==4.0.1
 ipykernel==6.9.0
 jupyter==1.0.0
 mypy==1.7.1
-numpy==1.22.3
 numpydoc==1.1.0
+numpy==1.22.3
 pandas==1.3.5
 pytest==6.2.5
 pytest-cov==3.0.0
@@ -13,4 +13,4 @@ sphinx==4.3.2
 sphinx-gallery==0.10.1
 sphinx_rtd_theme==1.0.0
 twine==3.7.1
-wheel==0.38.1
+wheel==0.37.0

--- a/requirements.doc.txt
+++ b/requirements.doc.txt
@@ -1,8 +1,10 @@
-lightgbm==3.2.1
+lightgbm==4.4.0
 matplotlib==3.5.1
+numpy==1.22.3
 numpydoc==1.1.0
 pandas==1.3.5
-sphinx==4.3.2
+scikit-learn
+sphinx==5.3.0
 sphinx-gallery==0.10.1
 sphinx_rtd_theme==1.0.0
 typing_extensions==4.0.1


### PR DESCRIPTION
# Description

I ran into some errors when installing MAPIE for contribution purpose using pip.

In this PR, I updated the contribution guidelines and the requirements.txt files to make the pip setup work and to keep it as close as possible to the conda setup. I had to upgrade LightGBM version (pip setup only) to be able to install it on my Mac with an Apple Silicon chip.

Having different versions of LightGBM for conda and pip setups is not a good idea. Anyways, in the near future we'll have to re-asses which tool we use for distribution and thus what tools we officially support for contribution purpose (conda, pip, ...).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`