### PR TITLE
chore: bump wheel version to avoid known vulnerabilities

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,14 +2,17 @@
 History
 =======
 
+0.9.x (2024-xx-xx)
+------------------
+
+* Bump wheel version to avoid known security vulnerabilities
+
 0.9.1 (2024-09-13)
 ------------------
 
 * Fix issue 511 to access non-conformity scores with previous path
 * Update gitignore by including the documentation folder generated for Mondrian
 * Fix (partially) the set-up with pip instead of conda for new contributors
-
-
 
 0.9.0 (2024-09-03)
 ------------------

--- a/environment.dev.yml
+++ b/environment.dev.yml
@@ -19,4 +19,4 @@ dependencies:
     - sphinx-gallery=0.10.1
     - sphinx_rtd_theme=1.0.0
     - twine=3.7.1
-    - wheel=0.37.0
+    - wheel=0.38.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -13,4 +13,4 @@ sphinx==4.3.2
 sphinx-gallery==0.10.1
 sphinx_rtd_theme==1.0.0
 twine==3.7.1
-wheel==0.37.0
+wheel==0.38.1


### PR DESCRIPTION
# Description

Bump wheel version to avoid known vulnerabilities (identified by GitHub Dependabot)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`