### PR TITLE
Fixes #495 : Correct EnbPI Prediction Intervals centering

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,4 +44,5 @@ Contributors
 * Carl McBride Ellis <Carl-McBride-Ellis>
 * Baptiste Calot <baptiste.calot@capgemini.com>
 * Leonardo Garma <leonardo.garma@gmail.com>
+* Mohammed Jawhar <mohammedjawhar365@gmail.com>
 To be continued ...

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * Fix issue 525 in contribution guidelines with syntax errors in hyperlinks and other formatting issues.
 * Bump wheel version to avoid known security vulnerabilities
+* Fix issue 495 to center correctly the prediction intervals
 
 0.9.1 (2024-09-13)
 ------------------

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -565,12 +565,16 @@ class EnsembleRegressor(EnsembleEstimator):
             elif self.method == "plus":
                 y_pred_multi_low = y_pred_multi
                 y_pred_multi_up = y_pred_multi
-            else:
+            elif self.method != "enbpi":
                 y_pred_multi_low = y_pred[:, np.newaxis]
                 y_pred_multi_up = y_pred[:, np.newaxis]
 
             if ensemble:
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)
+
+            if self.method == "enbpi":
+                y_pred_multi_low = y_pred[:, np.newaxis]
+                y_pred_multi_up = y_pred[:, np.newaxis]
 
         if return_multi_pred:
             return y_pred, y_pred_multi_low, y_pred_multi_up

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -565,16 +565,16 @@ class EnsembleRegressor(EnsembleEstimator):
             elif self.method == "plus":
                 y_pred_multi_low = y_pred_multi
                 y_pred_multi_up = y_pred_multi
-            elif self.method != "enbpi":
+            elif self.method == "enbpi":
+                y_pred_aggregate = aggregate_all(self.agg_function, y_pred_multi)
+                y_pred_multi_low = y_pred_aggregate[:, np.newaxis]
+                y_pred_multi_up = y_pred_aggregate[:, np.newaxis]
+            else:
                 y_pred_multi_low = y_pred[:, np.newaxis]
                 y_pred_multi_up = y_pred[:, np.newaxis]
 
             if ensemble:
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)
-
-            if self.method == "enbpi":
-                y_pred_multi_low = y_pred[:, np.newaxis]
-                y_pred_multi_up = y_pred[:, np.newaxis]
 
         if return_multi_pred:
             return y_pred, y_pred_multi_low, y_pred_multi_up

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -566,7 +566,8 @@ class EnsembleRegressor(EnsembleEstimator):
                 y_pred_multi_low = y_pred_multi
                 y_pred_multi_up = y_pred_multi
             elif self.method == "enbpi":
-                y_pred_aggregate = aggregate_all(self.agg_function, y_pred_multi)
+                y_pred_aggregate = aggregate_all(
+                    self.agg_function, y_pred_multi)
                 y_pred_multi_low = y_pred_aggregate[:, np.newaxis]
                 y_pred_multi_up = y_pred_aggregate[:, np.newaxis]
             else:

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -94,9 +94,9 @@ STRATEGIES = {
 }
 
 WIDTHS = {
-    "blockbootstrap_enbpi_mean_wopt": 3.86,
+    "blockbootstrap_enbpi_mean_wopt": 3.89,
     "blockbootstrap_enbpi_median_wopt": 3.85,
-    "blockbootstrap_enbpi_mean": 3.86,
+    "blockbootstrap_enbpi_mean": 3.89,
     "blockbootstrap_enbpi_median": 3.85,
     "blockbootstrap_aci_mean": 3.96,
     "blockbootstrap_aci_median": 3.95,
@@ -104,10 +104,10 @@ WIDTHS = {
 }
 
 COVERAGES = {
-    "blockbootstrap_enbpi_mean_wopt": 0.952,
-    "blockbootstrap_enbpi_median_wopt": 0.946,
-    "blockbootstrap_enbpi_mean": 0.952,
-    "blockbootstrap_enbpi_median": 0.946,
+    "blockbootstrap_enbpi_mean_wopt": 0.956,
+    "blockbootstrap_enbpi_median_wopt": 0.956,
+    "blockbootstrap_enbpi_mean": 0.956,
+    "blockbootstrap_enbpi_median": 0.956,
     "blockbootstrap_aci_mean": 0.96,
     "blockbootstrap_aci_median": 0.96,
     "prefit": 0.97,


### PR DESCRIPTION
# Description

**Addresses the issue #495 concerning the prediction intervals generated by EnbPI.**

The intervals are now centered at the aggregation of `y_pred_multi` instead of the prediction of a single estimator, aligning with the pseudocode.

Fixes #495 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`