### PR TITLE
UPDATE:  MAPIEv1 Backend -  Split .fit into .fit_single_estimator and fit_multi_estimator

### DIFF
--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -426,6 +426,14 @@ class EnsembleRegressor(EnsembleEstimator):
         Out-of-fold conformity scores are stored under
         the ``conformity_scores_`` attribute.
 
+        Note
+        ----
+        This ``fit`` method is implemented because the class interface requires
+        it. However, it is not used directly. Instead, the fitting process is 
+        replaced by the ``fit_single_estimator`` and ``fit_multi_estimators`` 
+        methods, which should be utilized for single and multiple estimators, 
+        respectively.
+        
         Parameters
         ----------
         X: ArrayLike of shape (n_samples, n_features)

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -411,66 +411,6 @@ class EnsembleRegressor(EnsembleEstimator):
 
         return y_pred
 
-    def fit(
-        self,
-        X: ArrayLike,
-        y: ArrayLike,
-        sample_weight: Optional[ArrayLike] = None,
-        groups: Optional[ArrayLike] = None,
-        **fit_params
-    ) -> EnsembleRegressor:
-        """
-        Fit the base estimator under the ``single_estimator_`` attribute.
-        Fit all cross-validated estimator clones
-        and rearrange them into a list, the ``estimators_`` attribute.
-        Out-of-fold conformity scores are stored under
-        the ``conformity_scores_`` attribute.
-
-        Parameters
-        ----------
-        X: ArrayLike of shape (n_samples, n_features)
-            Input data.
-
-        y: ArrayLike of shape (n_samples,)
-            Input labels.
-
-        sample_weight: Optional[ArrayLike] of shape (n_samples,)
-            Sample weights. If None, then samples are equally weighted.
-
-            By default ``None``.
-
-        groups: Optional[ArrayLike] of shape (n_samples,)
-            Group labels for the samples used while splitting the dataset into
-            train/test set.
-
-            By default ``None``.
-
-        **fit_params : dict
-            Additional fit parameters.
-
-        Returns
-        -------
-        EnsembleRegressor
-            The estimator fitted.
-        """
-        self.fit_single_estimator(
-            X,
-            y,
-            sample_weight,
-            groups,
-            **fit_params
-        )
-
-        self.fit_multi_estimators(
-            X,
-            y,
-            sample_weight,
-            groups,
-            **fit_params
-        )
-
-        return self
-
     def fit_multi_estimators(
         self,
         X: ArrayLike,
@@ -519,7 +459,7 @@ class EnsembleRegressor(EnsembleEstimator):
 
         return self
 
-    def fit_single_estimator(
+    def fit(
         self,
         X: ArrayLike,
         y: ArrayLike,

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -481,7 +481,7 @@ class EnsembleRegressor(EnsembleEstimator):
     ) -> RegressorMixin:
 
         n_samples = _num_samples(y)
-        estimators: list[RegressorMixin] = []
+        estimators: List[RegressorMixin] = []
 
         if self.cv == "prefit":
 
@@ -533,11 +533,13 @@ class EnsembleRegressor(EnsembleEstimator):
         if self.cv == "prefit":
             self.single_estimator_ = self.estimator
         else:
+            cv = cast(BaseCrossValidator, self.cv)
+            train_indexes = [index for index, _ in cv.split(X, y, groups)][0]
+            full_indexes = np.arange(_num_samples(X))
             if self.use_split_method_:
-                cv = cast(BaseCrossValidator, self.cv)
-                indexes = [index for index, _ in cv.split(X, y, groups)][0]
+                indexes = train_indexes
             else:
-                indexes = np.arange(_num_samples(X))
+                indexes = full_indexes
 
             self.single_estimator_ = self._fit_oof_estimator(
                     clone(self.estimator),

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -411,6 +411,66 @@ class EnsembleRegressor(EnsembleEstimator):
 
         return y_pred
 
+    def fit(
+        self,
+        X: ArrayLike,
+        y: ArrayLike,
+        sample_weight: Optional[ArrayLike] = None,
+        groups: Optional[ArrayLike] = None,
+        **fit_params
+    ) -> EnsembleRegressor:
+        """
+        Fit the base estimator under the ``single_estimator_`` attribute.
+        Fit all cross-validated estimator clones
+        and rearrange them into a list, the ``estimators_`` attribute.
+        Out-of-fold conformity scores are stored under
+        the ``conformity_scores_`` attribute.
+
+        Parameters
+        ----------
+        X: ArrayLike of shape (n_samples, n_features)
+            Input data.
+
+        y: ArrayLike of shape (n_samples,)
+            Input labels.
+
+        sample_weight: Optional[ArrayLike] of shape (n_samples,)
+            Sample weights. If None, then samples are equally weighted.
+
+            By default ``None``.
+
+        groups: Optional[ArrayLike] of shape (n_samples,)
+            Group labels for the samples used while splitting the dataset into
+            train/test set.
+
+            By default ``None``.
+
+        **fit_params : dict
+            Additional fit parameters.
+
+        Returns
+        -------
+        EnsembleRegressor
+            The estimator fitted.
+        """
+        self.fit_single_estimator(
+            X,
+            y,
+            sample_weight,
+            groups,
+            **fit_params
+        )
+
+        self.fit_multi_estimators(
+            X,
+            y,
+            sample_weight,
+            groups,
+            **fit_params
+        )
+
+        return self
+
     def fit_multi_estimators(
         self,
         X: ArrayLike,
@@ -459,7 +519,7 @@ class EnsembleRegressor(EnsembleEstimator):
 
         return self
 
-    def fit(
+    def fit_single_estimator(
         self,
         X: ArrayLike,
         y: ArrayLike,

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -484,6 +484,9 @@ class EnsembleRegressor(EnsembleEstimator):
         estimators: list[RegressorMixin] = []
 
         if self.cv == "prefit":
+
+            # self.k_ is defined but not used
+            # Because it is among the fit attributes
             self.k_ = np.full(
                 shape=(n_samples, 1), fill_value=np.nan, dtype=float
             )

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -529,9 +529,10 @@ class EnsembleRegressor(EnsembleEstimator):
     ) -> RegressorMixin:
 
         self.use_split_method_ = check_no_agg_cv(X, self.cv, self.no_agg_cv_)
+        single_estimator_: RegressorMixin
 
         if self.cv == "prefit":
-            self.single_estimator_ = self.estimator
+            single_estimator_ = self.estimator
         else:
             cv = cast(BaseCrossValidator, self.cv)
             train_indexes = [index for index, _ in cv.split(X, y, groups)][0]
@@ -541,7 +542,7 @@ class EnsembleRegressor(EnsembleEstimator):
             else:
                 indexes = full_indexes
 
-            self.single_estimator_ = self._fit_oof_estimator(
+            single_estimator_ = self._fit_oof_estimator(
                     clone(self.estimator),
                     X,
                     y,
@@ -550,6 +551,7 @@ class EnsembleRegressor(EnsembleEstimator):
                     **fit_params
                 )
 
+        self.single_estimator_ = single_estimator_
         return self
 
     def predict(

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -485,16 +485,13 @@ class EnsembleRegressor(EnsembleEstimator):
     ) -> List[RegressorMixin]:
 
         n_samples = _num_samples(y)
-        self.use_split_method_ = check_no_agg_cv(X, self.cv, self.no_agg_cv_)
+        estimators: list[RegressorMixin] = []
 
         if self.cv == "prefit":
             self.k_ = np.full(
                 shape=(n_samples, 1), fill_value=np.nan, dtype=float
             )
-            estimators = []
-        elif self.cv == 'naive':
-            estimators = []
-        else:
+        if self.cv not in ["prefit", "naive"]:
             cv = cast(BaseCrossValidator, self.cv)
             self.k_ = np.full(
                 shape=(n_samples, cv.get_n_splits(X, y, groups)),
@@ -502,7 +499,10 @@ class EnsembleRegressor(EnsembleEstimator):
                 dtype=float,
             )
 
-            estimators = Parallel(self.n_jobs, verbose=self.verbose)(
+            estimators = Parallel(
+                self.n_jobs,
+                verbose=self.verbose
+            )(
                 delayed(self._fit_oof_estimator)(
                     clone(self.estimator),
                     X,

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -485,8 +485,8 @@ class EnsembleRegressor(EnsembleEstimator):
 
         if self.cv == "prefit":
 
-            # self.k_ is defined but not used
-            # Because it is among the fit attributes
+            # Create a placeholder attribute 'k_' filled with NaN values
+            # (This attribute is defined for consistency but is not used in prefit mode)
             self.k_ = np.full(
                 shape=(n_samples, 1), fill_value=np.nan, dtype=float
             )

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -478,7 +478,7 @@ class EnsembleRegressor(EnsembleEstimator):
         sample_weight: Optional[ArrayLike] = None,
         groups: Optional[ArrayLike] = None,
         **fit_params
-    ) -> RegressorMixin:
+    ) -> EnsembleRegressor:
 
         n_samples = _num_samples(y)
         estimators: List[RegressorMixin] = []
@@ -526,7 +526,7 @@ class EnsembleRegressor(EnsembleEstimator):
         sample_weight: Optional[ArrayLike] = None,
         groups: Optional[ArrayLike] = None,
         **fit_params
-    ) -> RegressorMixin:
+    ) -> EnsembleRegressor:
 
         self.use_split_method_ = check_no_agg_cv(X, self.cv, self.no_agg_cv_)
         single_estimator_: RegressorMixin

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -429,11 +429,11 @@ class EnsembleRegressor(EnsembleEstimator):
         Note
         ----
         This ``fit`` method is implemented because the class interface requires
-        it. However, it is not used directly. Instead, the fitting process is 
-        replaced by the ``fit_single_estimator`` and ``fit_multi_estimators`` 
-        methods, which should be utilized for single and multiple estimators, 
+        it. However, it is not used directly. Instead, the fitting process is
+        replaced by the ``fit_single_estimator`` and ``fit_multi_estimators``
+        methods, which should be utilized for single and multiple estimators,
         respectively.
-        
+
         Parameters
         ----------
         X: ArrayLike of shape (n_samples, n_features)

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -486,7 +486,8 @@ class EnsembleRegressor(EnsembleEstimator):
         if self.cv == "prefit":
 
             # Create a placeholder attribute 'k_' filled with NaN values
-            # (This attribute is defined for consistency but is not used in prefit mode)
+            # This attribute is defined for consistency but
+            # is not used in prefit mode
             self.k_ = np.full(
                 shape=(n_samples, 1), fill_value=np.nan, dtype=float
             )

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -454,7 +454,7 @@ class EnsembleRegressor(EnsembleEstimator):
             The estimator fitted.
         """
 
-        single_estimator_ = self.fit_single_estimator(
+        self.single_estimator_ = self.fit_single_estimator(
             X,
             y,
             sample_weight,
@@ -462,16 +462,13 @@ class EnsembleRegressor(EnsembleEstimator):
             **fit_params
         )
 
-        estimators_ = self.fit_multi_estimators(
+        self.estimators_ = self.fit_multi_estimators(
             X,
             y,
             sample_weight,
             groups,
             **fit_params
         )
-
-        self.single_estimator_ = single_estimator_
-        self.estimators_ = estimators_
 
         return self
 
@@ -531,7 +528,7 @@ class EnsembleRegressor(EnsembleEstimator):
             return self.estimator
         if self.use_split_method_:
             cv = cast(BaseCrossValidator, self.cv)
-            indexes = cv.split(X, y, groups)[0]
+            indexes = [index for index, _ in cv.split(X, y, groups)][0]
         else:
             indexes = np.arange(_num_samples(X))
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -520,7 +520,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         )
 
         # Fit the prediction function
-        self.fit_estimator(X, y, sample_weight, groups)
+        self.fit_single_estimator(X, y, sample_weight, groups)
 
         # Conformlize the model:
         self.conformlize(X, y, sample_weight, groups, **kwargs)
@@ -563,7 +563,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             X, y, sample_weight, groups
         )
 
-    def fit_estimator(
+    def fit_single_estimator(
         self,
         X: ArrayLike,
         y: ArrayLike,
@@ -571,7 +571,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         groups: Optional[ArrayLike] = None,
     ) -> MapieRegressor:
 
-        self.estimator_.fit_single_estimator(
+        self.estimator_.fit(
             X,
             y,
             sample_weight=sample_weight,

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -520,7 +520,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         )
 
         # Fit the prediction function
-        self.fit_single_estimator(X, y, sample_weight, groups)
+        self.fit_estimator(X, y, sample_weight, groups)
 
         # Conformlize the model:
         self.conformlize(X, y, sample_weight, groups, **kwargs)
@@ -563,7 +563,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             X, y, sample_weight, groups
         )
 
-    def fit_single_estimator(
+    def fit_estimator(
         self,
         X: ArrayLike,
         y: ArrayLike,
@@ -571,7 +571,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         groups: Optional[ArrayLike] = None,
     ) -> MapieRegressor:
 
-        self.estimator_.fit(
+        self.estimator_.fit_single_estimator(
             X,
             y,
             sample_weight=sample_weight,

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -515,7 +515,9 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         """
 
         # Initialize the estimator
-        self.init_fit(X, y, sample_weight, groups, **kwargs)
+        X, y, sample_weight, groups = self.init_fit(
+            X, y, sample_weight, groups, **kwargs
+        )
 
         # Fit the prediction function
         self.fit_estimator(X, y, sample_weight, groups)
@@ -555,6 +557,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             self.random_state,
             self.test_size,
             self.verbose
+        )
+
+        return (
+            X, y, sample_weight, groups
         )
 
     def fit_estimator(

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -534,7 +534,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         sample_weight: Optional[ArrayLike] = None,
         groups: Optional[ArrayLike] = None,
         **kwargs: Any
-    ) -> MapieRegressor:
+    ):
 
         self._fit_params = kwargs.pop('fit_params', {})
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -522,8 +522,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         # Fit the prediction function
         self.fit_estimator(X, y, sample_weight, groups)
 
-        # Conformlize the model:
-        self.conformlize(X, y, sample_weight, groups, **kwargs)
+        # conformalize the model:
+        self.conformalize(X, y, sample_weight, groups, **kwargs)
 
         return self
 
@@ -581,7 +581,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         return self
 
-    def conformlize(
+    def conformalize(
         self,
         X: ArrayLike,
         y: ArrayLike,

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -522,7 +522,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         # Fit the prediction function
         self.fit_estimator(X, y, sample_weight, groups)
 
-        # Conformalize the model:
+        # Conformlize the model:
         self.conformlize(X, y, sample_weight, groups, **kwargs)
 
         return self

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -579,6 +579,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             **self._fit_params
         )
 
+        return self
+
     def conformlize(
         self,
         X: ArrayLike,

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -514,15 +514,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             The model itself.
         """
 
-        # Initialize the estimator
         X, y, sample_weight, groups = self.init_fit(
             X, y, sample_weight, groups, **kwargs
         )
 
-        # Fit the prediction function
         self.fit_estimator(X, y, sample_weight, groups)
-
-        # conformalize the model:
         self.conformalize(X, y, sample_weight, groups, **kwargs)
 
         return self

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -1037,6 +1037,7 @@ def test_check_change_method_to_base(method: str, cv: str) -> None:
     mapie_reg.fit(X_val, y_val)
     assert mapie_reg.method == "base"
 
+
 @pytest.mark.parametrize("method", ["minmax", "naive", "plus", "base"])
 @pytest.mark.parametrize("cv", ["split", "prefit", 3])
 def test_check_fit_ensemble_estimators(method: str, cv: str) -> None:

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -1036,3 +1036,14 @@ def test_check_change_method_to_base(method: str, cv: str) -> None:
     )
     mapie_reg.fit(X_val, y_val)
     assert mapie_reg.method == "base"
+
+@pytest.mark.parametrize("method", ["minmax", "naive", "plus", "base"])
+@pytest.mark.parametrize("cv", ["split", "prefit", 3])
+def test_check_fit_ensemble_estimators(method: str, cv: str) -> None:
+    """Test the functionality of fitting ensemble estimators."""
+    mapie_reg = MapieRegressor()
+    mapie_reg.init_fit(X_toy, y_toy)
+    mapie_reg.estimator_.fit(X_toy, y_toy)
+
+    hasattr(mapie_reg.estimator_, "single_estimator_")
+    hasattr(mapie_reg.estimator_, "estimators_")

--- a/mapie_v1/conformity_scores/utils.py
+++ b/mapie_v1/conformity_scores/utils.py
@@ -31,4 +31,4 @@ def compute_alpha(
     """
     Compute alpha values from confidence levels.
     """
-    return [ 1 - level for level in confidence_levels]
+    return [1 - level for level in confidence_levels]

--- a/mapie_v1/conformity_scores/utils.py
+++ b/mapie_v1/conformity_scores/utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, List
 from mapie.conformity_scores import BaseRegressionScore
 from . import REGRESSION_CONFORMITY_SCORES_STRING_MAP
 
@@ -12,3 +12,23 @@ def check_and_select_split_conformity_score(
         return REGRESSION_CONFORMITY_SCORES_STRING_MAP[conformity_score]()
     else:
         raise ValueError("Invalid conformity_score type")
+
+
+def process_confidence_level(
+    self, confidence_level: Union[float, List[float]]
+) -> List[float]:
+    """
+    Ensure confidence_level is always a list of floats.
+    """
+    if isinstance(confidence_level, float):
+        return [confidence_level]
+    return confidence_level
+
+
+def compute_alpha(
+    self, confidence_levels: List[float]
+) -> List[float]:
+    """
+    Compute alpha values from confidence levels.
+    """
+    return [ 1 - level for level in confidence_levels]

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -402,7 +402,7 @@ class CrossConformalRegressor:
         Self
             The conformalized SplitConformalRegressor instance.
         """
-        self.mapie_regressor.conformlize(
+        self.mapie_regressor.conformalize(
             X,
             y,
             groups=groups,

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -400,7 +400,7 @@ class CrossConformalRegressor:
         Self
             The conformalized SplitConformalRegressor instance.
         """
-        self.mapie_regressor.conformalize(
+        self.mapie_regressor.conformlize(
             X,
             y,
             groups=groups,

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -10,8 +10,11 @@ from mapie._typing import ArrayLike, NDArray
 from mapie.conformity_scores import BaseRegressionScore
 from mapie.regression import MapieRegressor
 from mapie.utils import check_estimator_fit_predict
-from mapie_v1.conformity_scores.utils import \
-    check_and_select_split_conformity_score
+from mapie_v1.conformity_scores.utils import (
+    check_and_select_split_conformity_score,
+    process_confidence_level,
+    compute_alpha,
+)
 
 
 class SplitConformalRegressor:
@@ -101,10 +104,8 @@ class SplitConformalRegressor:
             random_state=random_state,
         )
 
-        if isinstance(confidence_level, float):
-            confidence_level = [confidence_level]
-
-        self.alpha = [1 - level for level in confidence_level]
+        self.confidence_level = process_confidence_level(confidence_level)
+        self.alpha = compute_alpha(self.confidence_level)
 
     def fit(
         self,
@@ -331,10 +332,8 @@ class CrossConformalRegressor:
             random_state=random_state,
         )
 
-        if isinstance(confidence_level, float):
-            confidence_level = [confidence_level]
-
-        self.alpha = [1 - level for level in confidence_level]
+        self.confidence_level = process_confidence_level(confidence_level)
+        self.alpha = compute_alpha(self.confidence_level)
 
     def fit(
         self,

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -365,7 +365,7 @@ class CrossConformalRegressor:
         X, y, sample_weight, groups = self.init_fit(
             X, y, fit_params=fit_params
         )
-        self.mapie_regressor.fit(X, y, sample_weight, groups)
+        self.mapie_regressor.fit_estimator(X, y, sample_weight, groups)
 
     def conformalize(
         self,

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -320,7 +320,7 @@ class CrossConformalRegressor:
         verbose: int = 0,
         random_state: Optional[Union[int, np.random.RandomState]] = None
     ) -> None:
- 
+
         self.mapie_regressor = MapieRegressor(
             estimator=self.estimator,
             method=method,
@@ -362,8 +362,10 @@ class CrossConformalRegressor:
         Self
             The fitted CrossConformalRegressor instance.
         """
-        self.mapie_regressor.init_fit(X, y, fit_params=fit_params)
-        self.mapie_regressor.fit_estimator(X, y)
+        X, y, sample_weight, groups = self.init_fit(
+            X, y, fit_params=fit_params
+        )
+        self.mapie_regressor.fit_estimator(X, y, sample_weight, groups)
 
     def conformalize(
         self,

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -365,7 +365,7 @@ class CrossConformalRegressor:
         X, y, sample_weight, groups = self.init_fit(
             X, y, fit_params=fit_params
         )
-        self.mapie_regressor.fit_estimator(X, y, sample_weight, groups)
+        self.mapie_regressor.fit(X, y, sample_weight, groups)
 
     def conformalize(
         self,

--- a/mapie_v1/regression.py
+++ b/mapie_v1/regression.py
@@ -320,7 +320,21 @@ class CrossConformalRegressor:
         verbose: int = 0,
         random_state: Optional[Union[int, np.random.RandomState]] = None
     ) -> None:
-        pass
+ 
+        self.mapie_regressor = MapieRegressor(
+            estimator=self.estimator,
+            method=method,
+            cv=cv,
+            n_jobs=n_jobs,
+            verbose=verbose,
+            conformity_score=self.conformity_score,
+            random_state=random_state,
+        )
+
+        if isinstance(confidence_level, float):
+            confidence_level = [confidence_level]
+
+        self.alpha = [1 - level for level in confidence_level]
 
     def fit(
         self,
@@ -348,7 +362,8 @@ class CrossConformalRegressor:
         Self
             The fitted CrossConformalRegressor instance.
         """
-        pass
+        self.mapie_regressor.init_fit(X, y, fit_params=fit_params)
+        self.mapie_regressor.fit_estimator(X, y)
 
     def conformalize(
         self,
@@ -385,7 +400,12 @@ class CrossConformalRegressor:
         Self
             The conformalized SplitConformalRegressor instance.
         """
-        pass
+        self.mapie_regressor.conformalize(
+            X,
+            y,
+            groups=groups,
+            predict_params=predict_params
+        )
 
     def predict_set(
         self,


### PR DESCRIPTION
…_multi_estimators

# Description

This PR refactors the `MAPIE` ibrary by splitting the `.fit` method in `EnsembleRegressor` into two distinct methods: `.fit_single_estimator` and `.fit_multi_estimators`. The goal is to enhance modularity, readability, and maintainability of the codebase.

This refactoring is part of an ongoing effort to align the `MAPIE` library with modern software engineering practices. It ensures better scalability, maintainability, and adaptability for future features or modifications. The changes also address the growing need to handle single and multi-estimator workflows distinctly in the library.

1. **Refactoring `.fit` Logic**:
   - The `.fit` method is now divided into:
     - **`.fit_single_estimator`**: Handles the fitting logic for a single estimator.
     - **`.fit_multi_estimators`**: Handles the fitting logic for multiple estimators in an ensemble.

2. **Reorganization of `v0` and `v1` Components**:
   - **`v0` **:
     - `v0.conformlize`:
       Combines logic for `fit_multi_estimators` and calibration-based prediction (`predict_calib`).
     - `v0.fit`:
       Combines `fit_single_estimator` and `conformlize` to handle the full fitting process.
   - **`v1`**:
     - `v1.fit`:
       Only includes `fit_single_estimator`, streamlining the single-estimator fitting process.
     - `v1.conformlize`:
       Retains the structure of `v0.conformlize`, combining multi-estimator fitting and prediction calibration.

## Type of change

- New feature Non-breaking change which adds functionality

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully and without warnings : `make doc`