### PR TITLE
Fix: 547 wrong warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ History
 * Fix documentation build warnings
 * Fix issue 528 to correct broken ENS image in the documentation
 * Fix issue 548 to correct labels generated in tutorial
+* Fix issue 547 to fix wrong warning
 
 0.9.1 (2024-09-13)
 ------------------

--- a/mapie/metrics.py
+++ b/mapie/metrics.py
@@ -8,11 +8,10 @@ from sklearn.utils.validation import check_array, column_or_1d
 from ._machine_precision import EPSILON
 from ._typing import ArrayLike, NDArray
 from .utils import (calc_bins, check_alpha, check_array_inf, check_array_nan,
-                    check_array_shape_classification,
+                    check_array_shape_classification, check_split_strategy,
                     check_array_shape_regression, check_arrays_length,
-                    check_binary_zero_one, check_lower_upper_bounds,
-                    check_nb_intervals_sizes, check_nb_sets_sizes,
-                    check_number_bins, check_split_strategy)
+                    check_binary_zero_one, check_nb_intervals_sizes,
+                    check_nb_sets_sizes, check_number_bins)
 
 
 def regression_coverage_score(
@@ -55,7 +54,6 @@ def regression_coverage_score(
     y_pred_up = cast(NDArray, column_or_1d(y_pred_up))
 
     check_arrays_length(y_true, y_pred_low, y_pred_up)
-    check_lower_upper_bounds(y_true, y_pred_low, y_pred_up)
     check_array_nan(y_true)
     check_array_inf(y_true)
     check_array_nan(y_pred_low)


### PR DESCRIPTION
# Description

Fix issue #547  Wrong warning in regression_coverage_score 

Fixes #(issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully and without warnings : `make doc`