### PR TITLE
CHORE: fix sklearn version in documentation requirements to avoid a bug with latest sklearn version

### DIFF
--- a/environment.doc.yml
+++ b/environment.doc.yml
@@ -7,7 +7,7 @@ dependencies:
     - numpydoc=1.1.0
     - pandas=1.3.5
     - python=3.10
-    - scikit-learn
+    - scikit-learn=1.5.2
     - sphinx=5.3.0
     - sphinx-gallery=0.10.1
     - sphinx_rtd_theme=1.0.0

--- a/requirements.doc.txt
+++ b/requirements.doc.txt
@@ -3,7 +3,7 @@ matplotlib==3.5.1
 numpy==1.22.3
 numpydoc==1.1.0
 pandas==1.3.5
-scikit-learn
+scikit-learn==1.5.2
 sphinx==5.3.0
 sphinx-gallery==0.10.1
 sphinx_rtd_theme==1.0.0


### PR DESCRIPTION
# Description
When building the documentation for a new MAPIE contributor, errors would be raised because of the latest sklearn version.
We fix the sklearn version in the documentation requirements to avoid this bug.
This fix is temporary, and a proper dev/doc/ci dependencies defined when we release v1.