### PR TITLE
Remove enbpi warning

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,7 @@ History
 * Fix issue 547 to fix wrong warning
 * Fix issue 480 (correct display of mathematical equations in generated notebooks)
 * Refactor MapieRegressor, EnsembleRegressor, and MapieQuantileRegressor, to prepare for the release of v1.0.0
+* Remove optimize_beta usage warning when using for methods other than EnbPI
 
 0.9.1 (2024-09-13)
 ------------------

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Any, Iterable, Optional, Tuple, Union, cast
 
 import numpy as np
@@ -694,13 +693,6 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             return np.array(y_pred)
 
         else:
-            if optimize_beta and self.method != 'enbpi':
-                warnings.warn(
-                    "WARNING: Beta optimisation should only be used for "
-                    "method='enbpi'.",
-                    UserWarning
-                )
-
             # Check alpha and the number of effective calibration samples
             alpha_np = cast(NDArray, alpha)
             if not allow_infinite_bounds:

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -864,19 +864,6 @@ def test_return_multi_pred(ensemble: bool) -> None:
     assert len(output) == 3
 
 
-def test_beta_optimize_user_warning() -> None:
-    """
-    Test that a UserWarning is displayed when optimize_beta is used.
-    """
-    mapie_reg = MapieRegressor(
-        conformity_score=AbsoluteConformityScore(sym=False)
-    ).fit(X, y)
-    with pytest.warns(
-        UserWarning, match=r"Beta optimisation should only be used for*",
-    ):
-        mapie_reg.predict(X, alpha=0.05, optimize_beta=True)
-
-
 def test_fit_parameters_passing() -> None:
     """
     Test passing fit parameters, here early stopping at iteration 3.


### PR DESCRIPTION
# Description

ENH: remove optimize_beta warning in back-end (optimize_beta has been introduced only for ENBPI in the scientific literature, but it works for all regression methods, so we can support it)