### PR TITLE
ENH: MapieQuantileRegressor - remove warning about alpha and correct docstring

### DIFF
--- a/mapie/regression/quantile_regression.py
+++ b/mapie/regression/quantile_regression.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import Iterable, List, Optional, Tuple, Union, cast, Any
 
 import numpy as np
@@ -26,8 +25,6 @@ class MapieQuantileRegressor(MapieRegressor):
     """
     This class implements the conformalized quantile regression strategy
     as proposed by Romano et al. (2019) to make conformal predictions.
-    The only valid ``method`` is ``"quantile"`` and the only valid
-    ``cv`` is ``"split"``.
 
     Parameters
     ----------
@@ -197,12 +194,6 @@ class MapieQuantileRegressor(MapieRegressor):
         ValueError
             If the value of ``alpha`` is not between ``0.0`` and ``1.0``.
         """
-        if self.cv == "prefit":
-            warnings.warn(
-                "WARNING: The alpha that is set needs to be the same"
-                + " as the alpha of your prefitted model in the following"
-                " order [alpha/2, 1 - alpha/2, 0.5]"
-            )
         if isinstance(alpha, float):
             if np.any(np.logical_or(alpha <= 0, alpha >= 1.0)):
                 raise ValueError(

--- a/mapie/tests/test_quantile_regression.py
+++ b/mapie/tests/test_quantile_regression.py
@@ -589,30 +589,6 @@ def test_non_trained_estimator() -> None:
         )
 
 
-def test_warning_alpha_prefit() -> None:
-    """
-    Check that the user is warned that the alphas need to be correctly set.
-    """
-    with pytest.warns(
-        UserWarning,
-        match=r".*WARNING: The alpha that is set needs to be the same*"
-    ):
-        gb_trained1, gb_trained2, gb_trained3 = clone(gb), clone(gb), clone(gb)
-        gb_trained1.fit(X_train, y_train)
-        gb_trained2.fit(X_train, y_train)
-        gb_trained3.fit(X_train, y_train)
-        list_estimators = [gb_trained1, gb_trained2, gb_trained3]
-        mapie_reg = MapieQuantileRegressor(
-            estimator=list_estimators,
-            cv="prefit",
-            alpha=0.3
-        )
-        mapie_reg.fit(
-            X_calib,
-            y_calib
-        )
-
-
 @pytest.mark.parametrize("alpha", [0.05, 0.1, 0.2, 0.3])
 def test_prefit_and_non_prefit_equal(alpha: float) -> None:
     """


### PR DESCRIPTION
A warning was triggered at every call of the `.fit` method in a prefit setting.

Using warnings as documentation is not a good practice, so we remove it.

Documentation will be clearer in v1 anyways.