### PR TITLE
REFACTO: in split setting, remove checking NaNs to avoid inevitable warning, and remove useless aggregation to avoid dependency to agg_function

### DIFF
--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -402,9 +402,12 @@ class EnsembleRegressor:
                         predictions[i], dtype=float
                     )
                     self.k_[ind, i] = 1
-                check_nan_in_aposteriori_prediction(pred_matrix)
 
-                y_pred = aggregate_all(self.agg_function, pred_matrix)
+                if self.cv == "split":
+                    y_pred = pred_matrix.flatten()
+                else:
+                    check_nan_in_aposteriori_prediction(pred_matrix)
+                    y_pred = aggregate_all(self.agg_function, pred_matrix)
 
         return y_pred
 

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Union, cast
 import numpy as np
 from joblib import Parallel, delayed
 from sklearn.base import RegressorMixin, clone
-from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
+from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils import _safe_indexing, deprecated
 from sklearn.utils.validation import _num_samples, check_is_fitted
 

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -403,10 +403,7 @@ class EnsembleRegressor:
                     )
                     self.k_[ind, i] = 1
 
-                if (
-                    isinstance(self.cv, BaseShuffleSplit) and
-                    self.cv.n_splits == 1
-                ):
+                if self.use_split_method_:
                     y_pred = pred_matrix.flatten()
                 else:
                     check_nan_in_aposteriori_prediction(pred_matrix)

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Union, cast
 import numpy as np
 from joblib import Parallel, delayed
 from sklearn.base import RegressorMixin, clone
-from sklearn.model_selection import BaseCrossValidator
+from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
 from sklearn.utils import _safe_indexing, deprecated
 from sklearn.utils.validation import _num_samples, check_is_fitted
 
@@ -403,7 +403,10 @@ class EnsembleRegressor:
                     )
                     self.k_[ind, i] = 1
 
-                if self.cv == "split":
+                if (
+                    isinstance(self.cv, BaseShuffleSplit) and
+                    self.cv.n_splits == 1
+                ):
                     y_pred = pred_matrix.flatten()
                 else:
                     check_nan_in_aposteriori_prediction(pred_matrix)

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -701,7 +701,7 @@ def test_not_enough_resamplings() -> None:
     """
     with pytest.warns(UserWarning, match=r"WARNING: at least one point of*"):
         mapie_reg = MapieRegressor(
-            cv=Subsample(n_resamplings=1), agg_function="mean"
+            cv=Subsample(n_resamplings=2, random_state=0), agg_function="mean"
         )
         mapie_reg.fit(X, y)
 

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -318,7 +318,8 @@ def test_not_enough_resamplings() -> None:
         match=r"WARNING: at least one point of*"
     ):
         mapie_ts_reg = MapieTimeSeriesRegressor(
-            cv=BlockBootstrap(n_resamplings=1, n_blocks=1), agg_function="mean"
+            cv=BlockBootstrap(n_resamplings=2, n_blocks=1, random_state=0),
+            agg_function="mean"
         )
         mapie_ts_reg.fit(X, y)
 


### PR DESCRIPTION
Currently, during calibration, the same logic is used in the split setting and in the cross setting.

Specifically, at some point we call `check_nan_in_aposteriori_prediction` and `aggregate_all` in both settings.

It works in the split setting because `check_nan_in_aposteriori_prediction` does basically nothing except checking NaNs, and `aggregate_all` simply flattens the prediction matrix to a prediction array, from shape `(n_samples, 1)` to shape `(n_samples,)`.

However, calling those 2 functions brings 2 issues:
1. `check_nan_in_aposteriori_prediction` will always trigger a warning because by definition the train samples are not used for calibration.
2. `aggregate_all` also triggers warning in the split setting. Moreover, aggregating is not needed anyways in the split setting during calibration, and the dependency on `agg_function` could be removed entirely in further refactoring

In this PR, we check if we are in a split setting, and if yes simplify the code by simply flattening the array. It is not an ideal solution because we add an extra condition to the existing logic, but it fixes the first issue in a pragmatic way, and prepares the code for further refactoring.