### PR TITLE
DOC: fix typo

### DIFF
--- a/doc/theoretical_description_classification.rst
+++ b/doc/theoretical_description_classification.rst
@@ -159,14 +159,14 @@ By analogy with the CV+ method for regression, estimating the prediction sets is
 
 - We split the training set into *K* disjoint subsets :math:`S_1, S_2, ..., S_K` of equal size. 
   
-- *K* regression functions :math:`\hat{\mu}_{-S_k}` are fitted on the training set with the 
+- *K* classification functions :math:`\hat{\mu}_{-S_k}` are fitted on the training set with the 
   corresponding :math:`k^{th}` fold removed.
 
 - The corresponding *out-of-fold* conformity score is computed for each :math:`i^{th}` point 
 
 - Compare the conformity scores of training instances with the scores of each label for each new test point in order to
   decide whether or not the label should be included in the prediction set. 
-  For the APS method, the prediction set is constructed as follows (see equation 11 of [3]) : 
+  For the APS method, the prediction set is constructed as follows (see equation 11 of [2]) : 
 
 .. math:: 
     C_{n, \alpha}(X_{n+1}) = 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fix 2 typos on theoretical_description_classification
Fixes #616 

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- No test.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully: `make lint`
- [ ] Typing passes successfully: `make type-check`
- [ ] Unit tests pass successfully: `make tests`
- [ ] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`