### PR TITLE
DOC: fix readme and write precisions on contributing.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ The typical workflow for contributing to `mapie` is:
 Local setup
 -----------
 
-We encourage you to use a virtual environment, with Python > `3.6`. You'll want to activate it every time you want to work on `mapie`.
+We encourage you to use a virtual environment, with Python `3.7`, `3.8`, `3.9` or `3.10`. You'll want to activate it every time you want to work on `mapie`.
 
 You can create a virtual environment via ``conda``:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ The typical workflow for contributing to `mapie` is:
 Local setup
 -----------
 
-We encourage you to use a virtual environment, with Python `3.7`, `3.8`, `3.9` or `3.10`. You'll want to activate it every time you want to work on `mapie`.
+We encourage you to use a virtual environment, with Python `3.9` or `3.10`. You'll want to activate it every time you want to work on `mapie`.
 
 You can create a virtual environment via ``conda``:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,7 +23,7 @@ The typical workflow for contributing to `mapie` is:
 Local setup
 -----------
 
-We encourage you to use a virtual environment. You'll want to activate it every time you want to work on `mapie`.
+We encourage you to use a virtual environment, with Python > `3.6`. You'll want to activate it every time you want to work on `mapie`.
 
 You can create a virtual environment via ``conda``:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -38,7 +38,13 @@ Alternatively, using ``pip``, create a virtual environment and install dependenc
 
     $ pip install -r requirements.dev.txt
 
-Finally, install `mapie` in development mode:
+If you work on Mac, you may have to install libomp manually in order to install LightGBM:
+
+.. code-block:: sh
+
+    $ brew install libomp
+
+Finally, install ``mapie`` in development mode:
 
 .. code-block:: sh
 

--- a/README.rst
+++ b/README.rst
@@ -160,7 +160,7 @@ The full documentation can be found `on this link <https://mapie.readthedocs.io/
 You are welcome to propose and contribute new ideas.
 We encourage you to `open an issue <https://github.com/scikit-learn-contrib/MAPIE/issues>`_ so that we can align on the work to be done.
 It is generally a good idea to have a quick discussion before opening a pull request that is potentially out-of-scope.
-For more information on the contribution process, please go `here <CONTRIBUTING.rst>`_.
+For more information on the contribution process, please go `here <https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst>`_.
 
 
 🤝  Affiliations


### PR DESCRIPTION
# Description

- Fix the contributing guide URL in the readme.
- Add precision in contributing.rst

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Release checklist done.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`