### PR TITLE
DOC: Migrate quickstart/plot_prefit.py to v1

### DIFF
--- a/examples/regression/1-quickstart/plot_prefit.py
+++ b/examples/regression/1-quickstart/plot_prefit.py
@@ -62,12 +62,15 @@ X_train_conformalize, X_test, y_train_conformalize, y_test = train_test_split(
     X, y, test_size=1 / 10, random_state=RANDOM_STATE
 )
 X_train, X_conformalize, y_train, y_conformalize = train_test_split(
-    X_train_conformalize, y_train_conformalize, test_size=1 / 9, random_state=RANDOM_STATE
+    X_train_conformalize, y_train_conformalize,
+    test_size=1 / 9, random_state=RANDOM_STATE
 )
 
 
 ##############################################################################
-# 2. Pre-train a neural network
+# 2. Use a neural network
+# -----------------------------------------------------------------------------
+# 2.1 Pre-train a neural network
 # -----------------------------------------------------------------------------
 #
 # For this example, we will train a
@@ -81,7 +84,7 @@ est_mlp.fit(X_train.reshape(-1, 1), y_train)
 
 
 ##############################################################################
-# 3. Using MAPIE to conformalize the models
+# 2.2 Use MAPIE to conformalize the models
 # -----------------------------------------------------------------------------
 #
 # We will now proceed to conformalize the models using MAPIE. To this aim, we set
@@ -90,7 +93,9 @@ est_mlp.fit(X_train.reshape(-1, 1), y_train)
 
 
 # Conformalize uncertainties on calibration set
-mapie = SplitConformalRegressor(estimator=est_mlp, confidence_level=confidence_level, prefit=True)
+mapie = SplitConformalRegressor(
+    estimator=est_mlp, confidence_level=confidence_level, prefit=True
+)
 mapie.conformalize(X_conformalize.reshape(-1, 1), y_conformalize)
 
 # Evaluate prediction and coverage level on testing set
@@ -99,10 +104,10 @@ coverage = regression_coverage_score(y_test, y_pis[:, 0, 0], y_pis[:, 1, 0])
 
 
 ##############################################################################
-# 4. Plot results
+# 2.3 Plot results
 # -----------------------------------------------------------------------------
 #
-# In order to view the results, we will plot the predictions of the 
+# In order to view the results, we will plot the predictions of the
 # the multi-layer perceptron (MLP) with their prediction intervals calculated with
 # :class:`~mapie.regression.SplitConformalRegressor`.
 
@@ -164,7 +169,9 @@ plt.show()
 
 
 ##############################################################################
-# 5. Pre-train LGBM models
+# 3. Use LGBM models
+# -----------------------------------------------------------------------------
+# 3.1 Pre-train LGBM models
 # -----------------------------------------------------------------------------
 #
 # For this example, we will train multiple LGBMRegressor with a
@@ -185,7 +192,7 @@ for alpha_ in [(1 - confidence_level) / 2, (1 + confidence_level) / 2, 0.5]:
     list_estimators_cqr.append(estimator_)
 
 ##############################################################################
-# 6. Using MAPIE to conformalize the models
+# 3.2 Use MAPIE to conformalize the models
 # -----------------------------------------------------------------------------
 #
 # We will now proceed to conformalize the models using MAPIE. To this aim, we set
@@ -193,7 +200,9 @@ for alpha_ in [(1 - confidence_level) / 2, (1 + confidence_level) / 2, 0.5]:
 # We then predict using the test set and evaluate its coverage.
 
 # Conformalize uncertainties on conformalize set
-mapie_cqr = ConformalizedQuantileRegressor(list_estimators_cqr, confidence_level=0.9, prefit=True)
+mapie_cqr = ConformalizedQuantileRegressor(
+    list_estimators_cqr, confidence_level=0.9, prefit=True
+)
 mapie_cqr.conformalize(X_conformalize.reshape(-1, 1), y_conformalize)
 
 # Evaluate prediction and coverage level on testing set
@@ -206,7 +215,7 @@ coverage_cqr = regression_coverage_score(
 
 
 ##############################################################################
-# 7. Plot results
+# 3.3 Plot results
 # -----------------------------------------------------------------------------
 #
 # As fdor the MLP predictions, we plot the predictions of the LGBMRegressor

--- a/examples/regression/1-quickstart/plot_prefit.py
+++ b/examples/regression/1-quickstart/plot_prefit.py
@@ -92,7 +92,7 @@ est_mlp.fit(X_train.reshape(-1, 1), y_train)
 # We then predict using the test set and evaluate its coverage.
 
 
-# Conformalize uncertainties on calibration set
+# Conformalize uncertainties on conformalize set
 mapie = SplitConformalRegressor(
     estimator=est_mlp, confidence_level=confidence_level, prefit=True
 )

--- a/examples/regression/1-quickstart/plot_prefit.py
+++ b/examples/regression/1-quickstart/plot_prefit.py
@@ -1,21 +1,20 @@
 """
 ==========================================================================================================
-[Pre-v1] Example use of the prefit parameter with neural networks and LGBM Regressor
+Example use of the prefit parameter with neural networks and LGBM Regressor
 ==========================================================================================================
 **Note: we recently released MAPIE v1.0.0, which introduces breaking API changes.**
-**This notebook hasn't been updated to the new API yet.**
 
-:class:`~mapie.regression.MapieRegressor` and
-:class:`~mapie.quantile_regression.MapieQuantileRegressor`
-are used to calibrate uncertainties for large models for
+:class:`~mapie.regression.SplitConformalRegressor` and
+:class:`~mapie.regression.ConformalizedQuantileRegressor`
+are used to conformalize uncertainties for large models for
 which the cost of cross-validation is too high. Typically,
 neural networks rely on a single validation set.
 
 In this example, we first fit a neural network on the training set. We
-then compute residuals on a validation set with the `cv="prefit"` parameter.
+then compute residuals on a validation set with the `prefit=True` parameter.
 Finally, we evaluate the model with prediction intervals on a testing set.
-We will also show how to use the prefit method in the conformalized quantile
-regressor.
+In a second part, we will also show how to use the prefit method in the
+conformalized quantile regressor.
 """
 
 
@@ -30,11 +29,12 @@ from sklearn.neural_network import MLPRegressor
 
 from mapie._typing import NDArray
 from mapie.metrics import regression_coverage_score
-from mapie.regression import MapieQuantileRegressor, MapieRegressor
+from mapie_v1.regression import SplitConformalRegressor, ConformalizedQuantileRegressor
 
 warnings.filterwarnings("ignore")
 
-alpha = 0.1
+RANDOM_STATE = 1
+confidence_level = 0.9
 
 ##############################################################################
 # 1. Generate dataset
@@ -42,7 +42,7 @@ alpha = 0.1
 #
 # We start by defining a function that we will use to generate data. We then
 # add random noise to the y values. Then we split the dataset to have
-# a training, calibration and test set.
+# a training, conformalize and test set.
 
 
 def f(x: NDArray) -> NDArray:
@@ -51,90 +51,63 @@ def f(x: NDArray) -> NDArray:
 
 
 # Generate data
+rng = np.random.default_rng(59)
 sigma = 0.1
 n_samples = 10000
 X = np.linspace(0, 1, n_samples)
-y = f(X) + np.random.normal(0, sigma, n_samples)
+y = f(X) + rng.normal(0, sigma, n_samples)
 
 # Train/validation/test split
-X_train_cal, X_test, y_train_cal, y_test = train_test_split(
-    X, y, test_size=1 / 10
+X_train_conformalize, X_test, y_train_conformalize, y_test = train_test_split(
+    X, y, test_size=1 / 10, random_state=RANDOM_STATE
 )
-X_train, X_cal, y_train, y_cal = train_test_split(
-    X_train_cal, y_train_cal, test_size=1 / 9
+X_train, X_conformalize, y_train, y_conformalize = train_test_split(
+    X_train_conformalize, y_train_conformalize, test_size=1 / 9, random_state=RANDOM_STATE
 )
 
 
 ##############################################################################
-# 2. Pre-train models
+# 2. Pre-train a neural network
 # -----------------------------------------------------------------------------
 #
 # For this example, we will train a
 # :class:`~sklearn.neural_network.MLPRegressor` for
-# :class:`~mapie.regression.MapieRegressor` and multiple LGBMRegressor with a
-# quantile objective as this is a requirement to perform conformalized
-# quantile regression using
-# :class:`~mapie.quanitle_regression.MapieQuantileRegressor`. Note that the
-# three estimators need to be trained at quantile values of
-# ``(α/2, 1-(α/2), 0.5)``.
+# :class:`~mapie.regression.SplitConformalRegressor`.
 
 
-# Train a MLPRegressor for MapieRegressor
-est_mlp = MLPRegressor(activation="relu", random_state=1)
+# Train a MLPRegressor for SplitConformalRegressor
+est_mlp = MLPRegressor(activation="relu", random_state=RANDOM_STATE)
 est_mlp.fit(X_train.reshape(-1, 1), y_train)
 
-# Train LGBMRegressor models for MapieQuantileRegressor
-list_estimators_cqr = []
-for alpha_ in [alpha / 2, (1 - (alpha / 2)), 0.5]:
-    estimator_ = LGBMRegressor(
-        objective='quantile',
-        alpha=alpha_,
-    )
-    estimator_.fit(X_train.reshape(-1, 1), y_train)
-    list_estimators_cqr.append(estimator_)
-
 
 ##############################################################################
-# 3. Using MAPIE to calibrate the models
+# 3. Using MAPIE to conformalize the models
 # -----------------------------------------------------------------------------
 #
-# We will now proceed to calibrate the models using MAPIE. To this aim, we set
-# `cv="prefit"` so that we use the models that we already trained prior.
-# We then precict using the test set and evaluate its coverage.
+# We will now proceed to conformalize the models using MAPIE. To this aim, we set
+# `prefit=True` so that we use the model that we already trained prior.
+# We then predict using the test set and evaluate its coverage.
 
 
-# Calibrate uncertainties on calibration set
-mapie = MapieRegressor(est_mlp, cv="prefit")
-mapie.fit(X_cal.reshape(-1, 1), y_cal)
+# Conformalize uncertainties on calibration set
+mapie = SplitConformalRegressor(estimator=est_mlp, confidence_level=confidence_level, prefit=True)
+mapie.conformalize(X_conformalize.reshape(-1, 1), y_conformalize)
 
 # Evaluate prediction and coverage level on testing set
-y_pred, y_pis = mapie.predict(X_test.reshape(-1, 1), alpha=alpha)
+y_pred, y_pis = mapie.predict_interval(X_test.reshape(-1, 1))
 coverage = regression_coverage_score(y_test, y_pis[:, 0, 0], y_pis[:, 1, 0])
 
-# Calibrate uncertainties on calibration set
-mapie_cqr = MapieQuantileRegressor(list_estimators_cqr, cv="prefit")
-mapie_cqr.fit(X_cal.reshape(-1, 1), y_cal)
-
-# Evaluate prediction and coverage level on testing set
-y_pred_cqr, y_pis_cqr = mapie_cqr.predict(X_test.reshape(-1, 1))
-coverage_cqr = regression_coverage_score(
-    y_test,
-    y_pis_cqr[:, 0, 0],
-    y_pis_cqr[:, 1, 0]
-)
-
 
 ##############################################################################
-# 4. Plots
+# 4. Plot results
 # -----------------------------------------------------------------------------
 #
-# In order to view the results shown above, we will plot each other predictions
-# with their prediction interval. The multi-layer perceptron (MLP) with
-# :class:`~mapie.regression.MapieRegressor` and LGBMRegressor with
-# :class:`~mapie.quantile_regression.MapieQuantileRegressor`.
+# In order to view the results, we will plot the predictions of the 
+# the multi-layer perceptron (MLP) with their prediction intervals calculated with
+# :class:`~mapie.regression.SplitConformalRegressor`.
 
 # Plot obtained prediction intervals on testing set
-theoretical_semi_width = scipy.stats.norm.ppf(1 - alpha) * sigma
+theoretical_semi_width = scipy.stats.norm.ppf(1 - confidence_level) * sigma
 y_test_theoretical = f(X_test)
 order = np.argsort(X_test)
 
@@ -150,9 +123,103 @@ plt.fill_between(
     y_pis[:, 0, 0][order],
     y_pis[:, 1, 0][order],
     alpha=0.4,
-    label="prediction intervals MP",
+    label="prediction intervals SCR",
     color="green"
 )
+
+plt.title(
+    f"Target and effective coverages for:\n "
+    f"MLP with SplitConformalRegressor, confidence_level={confidence_level}: "
+    + f"(coverage is {coverage:.3f})\n"
+)
+plt.scatter(X_test, y_test, color="red", alpha=0.7, label="testing", s=2)
+plt.plot(
+    X_test[order],
+    y_test_theoretical[order],
+    color="gray",
+    label="True confidence intervals",
+)
+plt.plot(
+    X_test[order],
+    y_test_theoretical[order] - theoretical_semi_width,
+    color="gray",
+    ls="--",
+)
+plt.plot(
+    X_test[order],
+    y_test_theoretical[order] + theoretical_semi_width,
+    color="gray",
+    ls="--",
+)
+plt.xlabel("x")
+plt.ylabel("y")
+plt.legend(
+    loc='upper center',
+    bbox_to_anchor=(0.5, -0.05),
+    fancybox=True,
+    shadow=True,
+    ncol=3
+)
+plt.show()
+
+
+##############################################################################
+# 5. Pre-train LGBM models
+# -----------------------------------------------------------------------------
+#
+# For this example, we will train multiple LGBMRegressor with a
+# quantile objective as this is a requirement to perform conformalized
+# quantile regression using
+# :class:`~mapie.regression.ConformalizedQuantileRegressor`. Note that the
+# three estimators need to be trained at quantile values of
+# ``(1+confidence_level)/2, (1-confidence_level)/2, 0.5)``.
+
+# Train LGBMRegressor models for MapieQuantileRegressor
+list_estimators_cqr = []
+for alpha_ in [(1 - confidence_level) / 2, (1 + confidence_level) / 2, 0.5]:
+    estimator_ = LGBMRegressor(
+        objective='quantile',
+        alpha=alpha_,
+    )
+    estimator_.fit(X_train.reshape(-1, 1), y_train)
+    list_estimators_cqr.append(estimator_)
+
+##############################################################################
+# 6. Using MAPIE to conformalize the models
+# -----------------------------------------------------------------------------
+#
+# We will now proceed to conformalize the models using MAPIE. To this aim, we set
+# `prefit=True` so that we use the models that we already trained prior.
+# We then predict using the test set and evaluate its coverage.
+
+# Conformalize uncertainties on conformalize set
+mapie_cqr = ConformalizedQuantileRegressor(list_estimators_cqr, confidence_level=0.9, prefit=True)
+mapie_cqr.conformalize(X_conformalize.reshape(-1, 1), y_conformalize)
+
+# Evaluate prediction and coverage level on testing set
+y_pred_cqr, y_pis_cqr = mapie_cqr.predict_interval(X_test.reshape(-1, 1))
+coverage_cqr = regression_coverage_score(
+    y_test,
+    y_pis_cqr[:, 0, 0],
+    y_pis_cqr[:, 1, 0]
+)
+
+
+##############################################################################
+# 7. Plot results
+# -----------------------------------------------------------------------------
+#
+# As fdor the MLP predictions, we plot the predictions of the LGBMRegressor
+# with their prediction intervals calculated with
+# :class:`~mapie.regression.ConformalizedQuantileRegressor`.
+
+# Plot obtained prediction intervals on testing set
+theoretical_semi_width = scipy.stats.norm.ppf(1 - confidence_level) * sigma
+y_test_theoretical = f(X_test)
+order = np.argsort(X_test)
+
+plt.figure(figsize=(8, 8))
+
 plt.plot(
     X_test[order],
     y_pred_cqr[order],
@@ -164,15 +231,13 @@ plt.fill_between(
     y_pis_cqr[:, 0, 0][order],
     y_pis_cqr[:, 1, 0][order],
     alpha=0.4,
-    label="prediction intervals MQP",
+    label="prediction intervals CQR",
     color="blue"
 )
 plt.title(
     f"Target and effective coverages for:\n "
-    f"MLP with MapieRegressor alpha={alpha}: "
-    + f"({1 - alpha:.3f}, {coverage:.3f})\n"
-    f"LGBM with MapieQuantileRegressor alpha={alpha}: "
-    + f"({1 - alpha:.3f}, {coverage_cqr:.3f})"
+    f"LGBM with ConformalizedQuantileRegressor, confidence_level={confidence_level}: "
+    + f"(coverage is {coverage_cqr:.3f})"
 )
 plt.scatter(X_test, y_test, color="red", alpha=0.7, label="testing", s=2)
 plt.plot(


### PR DESCRIPTION
# Description

Migrate quickstart/plot_prefit.py to v1

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

- Passed every step of the release checklist.

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`