### PR TITLE
ENH & TEST & MTN: implement guardrails to avoid method being called in incorrect order. Add related functional tests. Unrelated: simplify existing functional test, add and use transform_confidence_level_to_alpha in ConformalizedQuantileRegressor

### DIFF
--- a/mapie_v1/_utils.py
+++ b/mapie_v1/_utils.py
@@ -14,14 +14,21 @@ def transform_confidence_level_to_alpha_list(
         confidence_levels = confidence_level
     else:
         confidence_levels = [confidence_level]
+    return [
+        transform_confidence_level_to_alpha(confidence_level)
+        for confidence_level in confidence_levels
+    ]
 
+
+def transform_confidence_level_to_alpha(
+    confidence_level: float,
+) -> float:
     # Using decimals to avoid weird-looking float approximations
     # when computing alpha = 1 - confidence_level
     # Such approximations arise even with simple confidence levels like 0.9
-    confidence_levels_d = [Decimal(str(conf_level)) for conf_level in confidence_levels]
-    alphas_d = [Decimal("1") - conf_level_d for conf_level_d in confidence_levels_d]
-
-    return [float(alpha_d) for alpha_d in alphas_d]
+    confidence_level_decimal = Decimal(str(confidence_level))
+    alpha_decimal = Decimal("1") - confidence_level_decimal
+    return float(alpha_decimal)
 
 
 def check_if_param_in_allowed_values(
@@ -63,3 +70,36 @@ def prepare_fit_params_and_sample_weight(
     fit_params_ = prepare_params(fit_params)
     sample_weight = fit_params_.pop("sample_weight", None)
     return fit_params_, sample_weight
+
+
+def raise_error_if_previous_method_not_called(
+    current_method_name: str,
+    previous_method_name: str,
+    was_previous_method_called: bool,
+) -> None:
+    if not was_previous_method_called:
+        raise ValueError(
+            f"Incorrect method order: call {previous_method_name} "
+            f"before calling {current_method_name}."
+        )
+
+
+def raise_error_if_method_already_called(
+    method_name: str,
+    was_method_called: bool,
+) -> None:
+    if was_method_called:
+        raise ValueError(
+            f"{method_name} method already called. "
+            f"MAPIE does not currently support calling {method_name} several times."
+        )
+
+
+def raise_error_if_fit_called_in_prefit_mode(
+    is_mode_prefit: bool,
+) -> None:
+    if is_mode_prefit:
+        raise ValueError(
+            "The fit method must be skipped when the prefit parameter is set to True. "
+            "Use the conformalize method directly after instanciation."
+        )

--- a/tests_v1/tests/test_regression.py
+++ b/tests_v1/tests/test_regression.py
@@ -1,9 +1,14 @@
 import numpy as np
 import pytest
 from sklearn.datasets import make_regression
-from sklearn.linear_model import LinearRegression
+from sklearn.linear_model import LinearRegression, QuantileRegressor
+from sklearn.dummy import DummyRegressor
 from sklearn.model_selection import train_test_split
-from mapie_v1.regression import SplitConformalRegressor
+from mapie_v1.regression import (
+    SplitConformalRegressor,
+    CrossConformalRegressor,
+    ConformalizedQuantileRegressor, JackknifeAfterBootstrapRegressor,
+)
 
 RANDOM_STATE = 1
 
@@ -22,35 +27,110 @@ def dataset():
     return X_train, X_conformalize, X_test, y_train, y_conformalize, y_test
 
 
-@pytest.fixture
-def predictions_scr_prefit(dataset):
+def test_scr_same_predictions_prefit_not_prefit(dataset) -> None:
     X_train, X_conformalize, X_test, y_train, y_conformalize, y_test = dataset
     regressor = LinearRegression()
     regressor.fit(X_train, y_train)
     scr_prefit = SplitConformalRegressor(estimator=regressor, prefit=True)
     scr_prefit.conformalize(X_conformalize, y_conformalize)
-    return scr_prefit.predict_interval(X_test)
+    predictions_scr_prefit = scr_prefit.predict_interval(X_test)
 
-
-@pytest.fixture
-def predictions_scr_not_prefit(dataset):
-    X_train, X_conformalize, X_test, y_train, y_conformalize, y_test = dataset
     scr_not_prefit = SplitConformalRegressor(estimator=LinearRegression(), prefit=False)
     scr_not_prefit.fit(X_train, y_train).conformalize(X_conformalize, y_conformalize)
-    return scr_not_prefit.predict_interval(X_test)
-
-
-def test_scr_same_intervals_prefit_not_prefit(
-    predictions_scr_prefit, predictions_scr_not_prefit
-) -> None:
-    intervals_scr_prefit = predictions_scr_prefit[1]
-    intervals_scr_not_prefit = predictions_scr_not_prefit[1]
-    np.testing.assert_equal(intervals_scr_prefit, intervals_scr_not_prefit)
-
-
-def test_scr_same_predictions_prefit_not_prefit(
-    predictions_scr_prefit, predictions_scr_not_prefit
-) -> None:
-    predictions_scr_prefit = predictions_scr_prefit[0]
-    predictions_scr_not_prefit = predictions_scr_not_prefit[0]
+    predictions_scr_not_prefit = scr_not_prefit.predict_interval(X_test)
     np.testing.assert_equal(predictions_scr_prefit, predictions_scr_not_prefit)
+
+
+class TestWrongMethodsOrderRaisesError:
+    @pytest.mark.parametrize(
+        "split_technique",
+        [SplitConformalRegressor, ConformalizedQuantileRegressor]
+    )
+    def test_split_technique_with_prefit_false(self, split_technique, dataset):
+        X_train, X_conformalize, X_test, y_train, y_conformalize, y_test = dataset
+        if split_technique == ConformalizedQuantileRegressor:
+            estimator = QuantileRegressor()
+        else:
+            estimator = DummyRegressor()
+        technique = split_technique(estimator=estimator, prefit=False)
+
+        with pytest.raises(ValueError, match=r"call fit before calling conformalize"):
+            technique.conformalize(
+                X_conformalize,
+                y_conformalize
+            )
+
+        technique.fit(X_train, y_train)
+
+        with pytest.raises(ValueError, match=r"fit method already called"):
+            technique.fit(X_train, y_train)
+        with pytest.raises(
+            ValueError,
+            match=r"call conformalize before calling predict"
+        ):
+            technique.predict(X_test)
+        with pytest.raises(
+            ValueError,
+            match=r"call conformalize before calling predict_interval"
+        ):
+            technique.predict_interval(X_test)
+
+        technique.conformalize(X_conformalize, y_conformalize)
+
+        with pytest.raises(ValueError, match=r"conformalize method already called"):
+            technique.conformalize(X_conformalize, y_conformalize)
+
+    @pytest.mark.parametrize(
+        "split_technique",
+        [SplitConformalRegressor, ConformalizedQuantileRegressor]
+    )
+    def test_split_technique_with_prefit_true(self, split_technique, dataset):
+        X_train, X_conformalize, X_test, y_train, y_conformalize, y_test = dataset
+        estimator = DummyRegressor()
+        estimator.fit(X_train, y_train)
+        if split_technique == ConformalizedQuantileRegressor:
+            technique = split_technique(estimator=[estimator] * 3, prefit=True)
+        else:
+            technique = split_technique(estimator=estimator, prefit=True)
+
+        with pytest.raises(ValueError, match=r"The fit method must be skipped"):
+            technique.fit(X_train, y_train)
+        with pytest.raises(
+            ValueError,
+            match=r"call conformalize before calling predict"
+        ):
+            technique.predict(X_test)
+        with pytest.raises(
+            ValueError,
+            match=r"call conformalize before calling predict_interval"
+        ):
+            technique.predict_interval(X_test)
+
+        technique.conformalize(X_conformalize, y_conformalize)
+
+        with pytest.raises(ValueError, match=r"conformalize method already called"):
+            technique.conformalize(X_conformalize, y_conformalize)
+
+    @pytest.mark.parametrize(
+        "cross_technique",
+        [CrossConformalRegressor, JackknifeAfterBootstrapRegressor]
+    )
+    def test_cross_technique_with_prefit_false(self, cross_technique, dataset):
+        X_train, X_conformalize, X_test, y_train, y_conformalize, y_test = dataset
+        technique = cross_technique(estimator=DummyRegressor())
+
+        with pytest.raises(
+            ValueError,
+            match=r"call fit_conformalize before calling predict"
+        ):
+            technique.predict(X_test)
+        with pytest.raises(
+            ValueError,
+            match=r"call fit_conformalize before calling predict_interval"
+        ):
+            technique.predict_interval(X_test)
+
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+
+        with pytest.raises(ValueError, match=r"fit_conformalize method already called"):
+            technique.fit_conformalize(X_conformalize, y_conformalize)


### PR DESCRIPTION
See title