### PR TITLE
FIX: use both terms `confidence_level` and `alpha` in error messages

### DIFF
--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -316,20 +316,20 @@ def check_alpha(
         alpha_np = np.array(alpha)
     else:
         raise ValueError(
-            "Invalid confidence_level. Allowed values are float or Iterable."
+            "Invalid confidence_level or alpha. Allowed values are float or Iterable."
         )
     if len(alpha_np.shape) != 1:
         raise ValueError(
-            "Invalid confidence_level."
+            "Invalid confidence_level or alpha."
             "Please provide a one-dimensional list of values."
         )
     if alpha_np.dtype.type not in [np.float64, np.float32]:
         raise ValueError(
-            "Invalid confidence_level. Allowed values are Iterable of floats."
+            "Invalid confidence_level or alpha. Allowed values are Iterable of floats."
         )
     if np.any(np.logical_or(alpha_np < 0, alpha_np > 1)):
         raise ValueError(
-            "Invalid confidence_level. Allowed values are between 0 and 1."
+            "Invalid confidence_level or alpha. Allowed values are between 0 and 1."
         )
     return alpha_np
 

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -320,7 +320,7 @@ def check_alpha(
         )
     if len(alpha_np.shape) != 1:
         raise ValueError(
-            "Invalid confidence_level or alpha."
+            "Invalid confidence_level or alpha. "
             "Please provide a one-dimensional list of values."
         )
     if alpha_np.dtype.type not in [np.float64, np.float32]:


### PR DESCRIPTION
 These errors can happen in several MAPIE use cases, and:
  - For regression and classification, the parameter alpha is replaced by confidence_level in MAPIE v1
  - For risk control and time series, out of MAPIE v1 scope, the term alpha is still used in the API and the doc
