### PR TITLE
DOC: fix typo errors in documentation

### DIFF
--- a/doc/theoretical_description_mondrian.rst
+++ b/doc/theoretical_description_mondrian.rst
@@ -15,9 +15,8 @@ coverage guarantee.  The coverage guarantee is given by:
 where :math:`G_{n+1}` is the group of the new test point :math:`X_{n+1}` and :math:`g`
 is a group in the set of groups :math:`\mathcal{G}`.
 
-MCP can be used with any split conformal predictor and can be particularly useful when one have a prior 
-knowledge about existing groups wheter the information is directly included in the features
-of the data or not.
+MCP can be used with any split conformal predictor and can be particularly useful when one have a prior
+knowledge about existing groups whether the information is directly included in the features of the data or not.
 In a classifcation setting, the groups can be defined as the predicted classes of the data. Doing so,
 one can ensure that, for each predicted class, the coverage guarantee is satisfied.
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fix minor typos.

Fixes #649 

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully: `make lint`
- [ ] Typing passes successfully: `make type-check`
- [ ] Unit tests pass successfully: `make tests`
- [ ] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`