### PR TITLE
DOC: fix minor typo errors in documentation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -47,4 +47,5 @@ Contributors
 * Mohammed Jawhar <mohammedjawhar365@gmail.com>
 * Syed Affan <saffand03@gmail.com>
 * Cyprien Bertran <cbertrandebalanda@yahoo.fr>
+* Brijesh Thummar <brijeshthummar02@gmail.com>
 To be continued ...

--- a/doc/choosing_the_right_algorithm.rst
+++ b/doc/choosing_the_right_algorithm.rst
@@ -2,7 +2,7 @@
 Choosing the right algorithm
 ############################################
 
-Following is a simple decision tree to help you you getting started quickly with MAPIE.
+Following is a simple decision tree to help you getting started quickly with MAPIE.
 
 Reality is of course a bit more complex, so feel free to browse the documentation for nuanced explanations.
 

--- a/doc/theoretical_description_mondrian.rst
+++ b/doc/theoretical_description_mondrian.rst
@@ -22,9 +22,8 @@ coverage guarantee.  The coverage guarantee is given by:
 where :math:`G_{n+1}` is the group of the new test point :math:`X_{n+1}` and :math:`g`
 is a group in the set of groups :math:`\mathcal{G}`.
 
-MCP can be used with any split conformal predictor and can be particularly useful when one have a prior 
-knowledge about existing groups wheter the information is directly included in the features
-of the data or not.
+MCP can be used with any split conformal predictor and can be particularly useful when one have a prior
+knowledge about existing groups whether the information is directly included in the features of the data or not.
 In a classifcation setting, the groups can be defined as the predicted classes of the data. Doing so,
 one can ensure that, for each predicted class, the coverage guarantee is satisfied.
 

--- a/doc/theoretical_description_mondrian.rst
+++ b/doc/theoretical_description_mondrian.rst
@@ -24,7 +24,7 @@ is a group in the set of groups :math:`\mathcal{G}`.
 
 MCP can be used with any split conformal predictor and can be particularly useful when one have a prior
 knowledge about existing groups whether the information is directly included in the features of the data or not.
-In a classifcation setting, the groups can be defined as the predicted classes of the data. Doing so,
+In a classification setting, the groups can be defined as the predicted classes of the data. Doing so,
 one can ensure that, for each predicted class, the coverage guarantee is satisfied.
 
 In order to achieve the group-conditional coverage guarantee, MCP simply classifies the data


### PR DESCRIPTION
# Description

Fix minor typos.

Fixes #649 , Closes PR #652 

## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`