### PR TITLE
Fix incorrect import paths in `aps.py` and `raps.py`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -48,4 +48,5 @@ Contributors
 * Syed Affan <saffand03@gmail.com>
 * Cyprien Bertran <cbertrandebalanda@yahoo.fr>
 * Faustin Pulvéric <faustin.pulveric@gmail.com>
+* Chaoqi Zhang <prncoprs@163.com>
 To be continued ...

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,7 @@ History
 ------------------
 
 * Fix issue  512 to replace setup.py by pyproject.toml, bump twine and wheel dependencies to latest
+* Fix issue  670 to correct the import path which cause ModuleNotFoundError
 
 0.9.2 (2025-15-01)
 ------------------

--- a/mapie/conformity_scores/sets/aps.py
+++ b/mapie/conformity_scores/sets/aps.py
@@ -1,8 +1,8 @@
 from typing import Optional, Tuple, Union, cast
 
 import numpy as np
-from sklearn.dummy import check_random_state
-from sklearn.calibration import label_binarize
+from sklearn.utils import check_random_state
+from sklearn.preprocessing import label_binarize
 
 from mapie.conformity_scores.sets.naive import NaiveConformityScore
 from mapie.conformity_scores.sets.utils import (

--- a/mapie/conformity_scores/sets/raps.py
+++ b/mapie/conformity_scores/sets/raps.py
@@ -1,7 +1,7 @@
 from typing import Optional, Tuple, Union, cast
 
 import numpy as np
-from sklearn.calibration import LabelEncoder
+from sklearn.preprocessing import LabelEncoder
 from sklearn.model_selection import StratifiedShuffleSplit
 from sklearn.utils import _safe_indexing
 from sklearn.utils.validation import _num_samples

--- a/mapie/tests/test_quantile_regression.py
+++ b/mapie/tests/test_quantile_regression.py
@@ -97,7 +97,7 @@ class NotFitPredictEstimator:
         self.alpha = alpha
 
 
-class NoLossPamameterEstimator(BaseEstimator):
+class NoLossParameterEstimator(BaseEstimator):
     def __init__(self, alpha):
         self.alpha = alpha
 
@@ -108,7 +108,7 @@ class NoLossPamameterEstimator(BaseEstimator):
         """Dummy predict."""
 
 
-class NoAlphaPamameterEstimator(BaseEstimator):
+class NoAlphaParameterEstimator(BaseEstimator):
     def __init__(self, alpha, loss):
         self.alpha = alpha
         self.loss = loss
@@ -176,12 +176,12 @@ def test_no_para_loss_estimator() -> None:
     ):
         mapie_reg = MapieQuantileRegressor()
         mapie_reg.quantile_estimator_params[
-            "NoLossPamameterEstimator"
+            "NoLossParameterEstimator"
         ] = {
             "loss_name": "noloss",
             "alpha_name": "alpha"
         }
-        mapie_reg.estimator = NoLossPamameterEstimator(
+        mapie_reg.estimator = NoLossParameterEstimator(
             alpha=0.2
             )
         mapie_reg.fit(
@@ -200,12 +200,12 @@ def test_no_para_alpha_estimator() -> None:
     ):
         mapie_reg = MapieQuantileRegressor()
         mapie_reg.quantile_estimator_params[
-            "NoAlphaPamameterEstimator"
+            "NoAlphaParameterEstimator"
         ] = {
             "loss_name": "loss",
             "alpha_name": "noalpha"
         }
-        mapie_reg.estimator = NoAlphaPamameterEstimator(
+        mapie_reg.estimator = NoAlphaParameterEstimator(
             alpha=0.2,
             loss="quantile"
             )


### PR DESCRIPTION
# Description

This PR fixes incorrect import paths in `mapie/conformity_scores/sets/aps.py` and `raps.py`, which were causing `ModuleNotFoundError` during import of `MapieRegressor` and `MapieClassifier`.

The following changes were made:
- `check_random_state` is now correctly imported from `sklearn.utils` instead of `sklearn.dummy`.
- `label_binarize` is now correctly imported from `sklearn.preprocessing` instead of `sklearn.calibration`.
- `LabelEncoder` is now correctly imported from `sklearn.preprocessing` instead of `sklearn.calibration`.

This fixes the issue reported in #670 .


## Type of change

Please remove options that are irrelevant.

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Successfully imported `MapieRegressor` and `MapieClassifier` after the fixes.
- [x] Ran basic example code to validate that MAPIE functionalities now work without `ModuleNotFoundError`.
- [x] Manual verification by reproducing the previous error and ensuring it no longer occurs after this fix.

Test configuration:
- Ubuntu 22.04
- Python 3.10
- mapie==0.9.2
- scikit-learn==1.5.2

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`