### PR TITLE
Fix naming error in test_quantile_regression.py

### DIFF
--- a/mapie/tests/test_quantile_regression.py
+++ b/mapie/tests/test_quantile_regression.py
@@ -97,7 +97,7 @@ class NotFitPredictEstimator:
         self.alpha = alpha
 
 
-class NoLossPamameterEstimator(BaseEstimator):
+class NoLossParameterEstimator(BaseEstimator):
     def __init__(self, alpha):
         self.alpha = alpha
 
@@ -108,7 +108,7 @@ class NoLossPamameterEstimator(BaseEstimator):
         """Dummy predict."""
 
 
-class NoAlphaPamameterEstimator(BaseEstimator):
+class NoAlphaParameterEstimator(BaseEstimator):
     def __init__(self, alpha, loss):
         self.alpha = alpha
         self.loss = loss
@@ -176,12 +176,12 @@ def test_no_para_loss_estimator() -> None:
     ):
         mapie_reg = MapieQuantileRegressor()
         mapie_reg.quantile_estimator_params[
-            "NoLossPamameterEstimator"
+            "NoLossParameterEstimator"
         ] = {
             "loss_name": "noloss",
             "alpha_name": "alpha"
         }
-        mapie_reg.estimator = NoLossPamameterEstimator(
+        mapie_reg.estimator = NoLossParameterEstimator(
             alpha=0.2
             )
         mapie_reg.fit(
@@ -200,12 +200,12 @@ def test_no_para_alpha_estimator() -> None:
     ):
         mapie_reg = MapieQuantileRegressor()
         mapie_reg.quantile_estimator_params[
-            "NoAlphaPamameterEstimator"
+            "NoAlphaParameterEstimator"
         ] = {
             "loss_name": "loss",
             "alpha_name": "noalpha"
         }
-        mapie_reg.estimator = NoAlphaPamameterEstimator(
+        mapie_reg.estimator = NoAlphaParameterEstimator(
             alpha=0.2,
             loss="quantile"
             )


### PR DESCRIPTION
# Description

Replaced:
- NoLossPamameterEstimator -> NoLossParameterEstimator
- NoAlphaPamameterEstimator -> NoAlphaParameterEstimator

Fixes #658 

## Type of change

- Fixed typo in the code

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`