### PR TITLE
FIX: avoid double inference when predicting in split conformal classification

### DIFF
--- a/mapie/conformity_scores/sets/lac.py
+++ b/mapie/conformity_scores/sets/lac.py
@@ -1,10 +1,9 @@
-from typing import Optional, cast
+from typing import Optional, cast, Union
 
 import numpy as np
 
 from mapie.conformity_scores.classification import BaseClassificationScore
-from mapie.conformity_scores.sets.utils import check_proba_normalized
-from mapie.estimator.classifier import EnsembleClassifier
+from sklearn.model_selection import BaseCrossValidator
 
 from mapie._machine_precision import EPSILON
 from numpy.typing import NDArray
@@ -80,24 +79,28 @@ class LACConformityScore(BaseClassificationScore):
         self,
         X: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        y_pred_proba: NDArray,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         agg_scores: Optional[str] = "mean",
         **kwargs
     ) -> NDArray:
         """
-        Get predictions from an EnsembleClassifier.
+        Just processes the passed y_pred_proba.
 
         Parameters
         -----------
         X: NDArray of shape (n_samples, n_features)
-            Observed feature values.
+            Observed feature values (not used since predictions are passed).
 
         alpha_np: NDArray of shape (n_alpha,)
             NDArray of floats between ``0`` and ``1``, represents the
             uncertainty of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        y_pred_proba: NDArray
+            Predicted probabilities from the estimator.
+
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator.
 
         agg_scores: Optional[str]
             Method to aggregate the scores from the base estimators.
@@ -111,8 +114,6 @@ class LACConformityScore(BaseClassificationScore):
         NDArray
             Array of predictions.
         """
-        y_pred_proba = estimator.predict(X, agg_scores)
-        y_pred_proba = check_proba_normalized(y_pred_proba, axis=1)
         if agg_scores != "crossval":
             y_pred_proba = np.repeat(
                 y_pred_proba[:, :, np.newaxis], len(alpha_np), axis=2
@@ -124,7 +125,7 @@ class LACConformityScore(BaseClassificationScore):
         self,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         agg_scores: Optional[str] = "mean",
         **kwargs
     ) -> NDArray:
@@ -140,8 +141,8 @@ class LACConformityScore(BaseClassificationScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator.
 
         agg_scores: Optional[str]
             Method to aggregate the scores from the base estimators.
@@ -157,7 +158,7 @@ class LACConformityScore(BaseClassificationScore):
         """
         n = len(conformity_scores)
 
-        if estimator.cv == "prefit" or agg_scores in ["mean"]:
+        if cv == "prefit" or agg_scores in ["mean"]:
             quantiles_ = _compute_quantiles(
                 conformity_scores,
                 alpha_np
@@ -172,7 +173,7 @@ class LACConformityScore(BaseClassificationScore):
         y_pred_proba: NDArray,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         agg_scores: Optional[str] = "mean",
         **kwargs
     ) -> NDArray:
@@ -192,8 +193,8 @@ class LACConformityScore(BaseClassificationScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator.
 
         agg_scores: Optional[str]
             Method to aggregate the scores from the base estimators.
@@ -209,7 +210,7 @@ class LACConformityScore(BaseClassificationScore):
         """
         n = len(conformity_scores)
 
-        if (estimator.cv == "prefit") or (agg_scores == "mean"):
+        if (cv == "prefit") or (agg_scores == "mean"):
             prediction_sets = np.less_equal(
                 (1 - y_pred_proba) - self.quantiles_, EPSILON
             )

--- a/mapie/conformity_scores/sets/naive.py
+++ b/mapie/conformity_scores/sets/naive.py
@@ -1,12 +1,12 @@
-from typing import Tuple, Union
+from typing import Tuple, Union, Optional
 
 import numpy as np
 
 from mapie.conformity_scores.classification import BaseClassificationScore
 from mapie.conformity_scores.sets.utils import (
-    check_proba_normalized, get_last_index_included
+    get_last_index_included
 )
-from mapie.estimator.classifier import EnsembleClassifier
+from sklearn.model_selection import BaseCrossValidator
 
 from mapie._machine_precision import EPSILON
 from numpy.typing import NDArray
@@ -61,31 +61,33 @@ class NaiveConformityScore(BaseClassificationScore):
         self,
         X: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        y_pred_proba: NDArray,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         **kwargs
     ) -> NDArray:
         """
-        Get predictions from an EnsembleClassifier.
+        Just processes the passed y_pred_proba.
 
         Parameters
         -----------
         X: NDArray of shape (n_samples, n_features)
-            Observed feature values.
+            Observed feature values (not used since predictions are passed).
 
         alpha_np: NDArray of shape (n_alpha,)
             NDArray of floats between ``0`` and ``1``, represents the
             uncertainty of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        y_pred_proba: NDArray
+            Predicted probabilities from the estimator.
+
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         Returns
         --------
         NDArray
             Array of predictions.
         """
-        y_pred_proba = estimator.predict(X, agg_scores='mean')
-        y_pred_proba = check_proba_normalized(y_pred_proba, axis=1)
         y_pred_proba = np.repeat(
             y_pred_proba[:, :, np.newaxis], len(alpha_np), axis=2
         )
@@ -95,7 +97,7 @@ class NaiveConformityScore(BaseClassificationScore):
         self,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         **kwargs
     ) -> NDArray:
         """
@@ -110,8 +112,8 @@ class NaiveConformityScore(BaseClassificationScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         Returns
         --------
@@ -234,7 +236,7 @@ class NaiveConformityScore(BaseClassificationScore):
         y_pred_proba: NDArray,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         **kwargs
     ) -> NDArray:
         """
@@ -253,8 +255,8 @@ class NaiveConformityScore(BaseClassificationScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         Returns
         --------

--- a/mapie/conformity_scores/sets/raps.py
+++ b/mapie/conformity_scores/sets/raps.py
@@ -2,13 +2,12 @@ from typing import Optional, Tuple, Union, cast
 
 import numpy as np
 from sklearn.preprocessing import LabelEncoder
-from sklearn.model_selection import StratifiedShuffleSplit
+from sklearn.model_selection import StratifiedShuffleSplit, BaseCrossValidator
 from sklearn.utils import _safe_indexing
 from sklearn.utils.validation import _num_samples
 
 from mapie.conformity_scores.sets.aps import APSConformityScore
 from mapie.conformity_scores.sets.utils import get_true_label_position
-from mapie.estimator.classifier import EnsembleClassifier
 
 from mapie._machine_precision import EPSILON
 from numpy.typing import NDArray
@@ -377,7 +376,7 @@ class RAPSConformityScore(APSConformityScore):
         self,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         agg_scores: Optional[str] = "mean",
         include_last_label: Optional[Union[bool, str]] = True,
         **kwargs
@@ -394,8 +393,8 @@ class RAPSConformityScore(APSConformityScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         agg_scores: Optional[str]
             Method to aggregate the scores from the base estimators.

--- a/mapie/conformity_scores/sets/topk.py
+++ b/mapie/conformity_scores/sets/topk.py
@@ -1,12 +1,12 @@
-from typing import Optional, cast
+from typing import Optional, cast, Union
 
 import numpy as np
 
 from mapie.conformity_scores.classification import BaseClassificationScore
 from mapie.conformity_scores.sets.utils import (
-    check_proba_normalized, get_true_label_position
+    get_true_label_position
 )
-from mapie.estimator.classifier import EnsembleClassifier
+from sklearn.model_selection import BaseCrossValidator
 
 from mapie._machine_precision import EPSILON
 from numpy.typing import NDArray
@@ -84,33 +84,35 @@ class TopKConformityScore(BaseClassificationScore):
         self,
         X: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        y_pred_proba: NDArray,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         **kwargs
     ) -> NDArray:
         """
-        Get predictions from an EnsembleClassifier.
+        Just processes the passed y_pred_proba.
 
         This method should be implemented by any subclass of the current class.
 
         Parameters
         -----------
         X: NDArray of shape (n_samples, n_features)
-            Observed feature values.
+            Observed feature values (not used since predictions are passed).
 
         alpha_np: NDArray of shape (n_alpha,)
             NDArray of floats between ``0`` and ``1``, represents the
             uncertainty of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        y_pred_proba: NDArray
+            Predicted probabilities from the estimator.
+
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         Returns
         --------
         NDArray
             Array of predictions.
         """
-        y_pred_proba = estimator.predict(X, agg_scores="mean")
-        y_pred_proba = check_proba_normalized(y_pred_proba, axis=1)
         y_pred_proba = np.repeat(
             y_pred_proba[:, :, np.newaxis], len(alpha_np), axis=2
         )
@@ -120,7 +122,7 @@ class TopKConformityScore(BaseClassificationScore):
         self,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         **kwargs
     ) -> NDArray:
         """
@@ -135,8 +137,8 @@ class TopKConformityScore(BaseClassificationScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         Returns
         --------
@@ -150,7 +152,7 @@ class TopKConformityScore(BaseClassificationScore):
         y_pred_proba: NDArray,
         conformity_scores: NDArray,
         alpha_np: NDArray,
-        estimator: EnsembleClassifier,
+        cv: Optional[Union[int, str, BaseCrossValidator]],
         **kwargs
     ) -> NDArray:
         """
@@ -169,8 +171,8 @@ class TopKConformityScore(BaseClassificationScore):
             NDArray of floats between 0 and 1, representing the uncertainty
             of the confidence interval.
 
-        estimator: EnsembleClassifier
-            Estimator that is fitted to predict y from X.
+        cv: Optional[Union[int, str, BaseCrossValidator]]
+            Cross-validation strategy used by the estimator (not used here).
 
         Returns
         --------

--- a/mapie/conformity_scores/sets/utils.py
+++ b/mapie/conformity_scores/sets/utils.py
@@ -77,38 +77,6 @@ def check_include_last_label(
         return include_last_label
 
 
-def check_proba_normalized(
-    y_pred_proba: NDArray,
-    axis: int = 1
-) -> NDArray:
-    """
-    Check if for all the samples the sum of the probabilities is equal to one.
-
-    Parameters
-    ----------
-    y_pred_proba: NDArray of shape (n_samples, n_classes) or
-    (n_samples, n_train_samples, n_classes)
-        Softmax output of a model.
-
-    Returns
-    -------
-    ArrayLike of shape (n_samples, n_classes)
-        Softmax output of a model if the scores all sum to one.
-
-    Raises
-    ------
-    ValueError
-        If the sum of the scores is not equal to one.
-    """
-    np.testing.assert_allclose(
-        np.sum(y_pred_proba, axis=axis),
-        1,
-        err_msg="The sum of the scores is not equal to one.",
-        rtol=1e-5
-    )
-    return y_pred_proba.astype(np.float64)
-
-
 def get_last_index_included(
     y_pred_proba_cumsum: NDArray,
     threshold: NDArray,

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -445,11 +445,6 @@ class CustomGradientBoostingClassifier(GradientBoostingClassifier):
         else:
             return super().predict_proba(X)
 
-    def predict(self, X, check_predict_params=False):
-        if check_predict_params:
-            return np.zeros(X.shape[0])
-        return super().predict(X)
-
 
 def early_stopping_monitor(i, est, locals):
     """Returns True on the 3rd iteration."""
@@ -839,9 +834,6 @@ class CumulatedScoreClassifier:
         self.fitted_ = True
         return self
 
-    def predict(self, X: ArrayLike) -> NDArray:
-        return np.array([1, 2, 1])
-
     def predict_proba(self, X: ArrayLike) -> NDArray:
         if np.max(X) <= 2:
             return np.array(
@@ -871,9 +863,6 @@ class ImageClassifier:
         self.fitted_ = True
         return self
 
-    def predict(self, *args: Any) -> NDArray:
-        return np.array([1, 2, 1])
-
     def predict_proba(self, X: ArrayLike) -> NDArray:
         if np.max(X) == 0:
             return np.array(
@@ -898,12 +887,6 @@ class WrongOutputModel:
     def predict_proba(self, *args: Any) -> NDArray:
         return self.proba_out
 
-    def predict(self, *args: Any) -> NDArray:
-        pred = (
-            self.proba_out == self.proba_out.max(axis=1)[:, None]
-        ).astype(int)
-        return pred
-
 
 class Float32OuputModel:
 
@@ -919,9 +902,6 @@ class Float32OuputModel:
         probas = np.array([[.9, .05, .05]])
         proba_out = np.repeat(probas, len(X), axis=0).astype(np.float32)
         return proba_out
-
-    def predict(self, X: NDArray, *args: Any) -> NDArray:
-        return np.repeat(1, len(X))
 
     def get_params(self, *args: Any, **kwargs: Any):
         return {"prefit": False}

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -33,7 +33,7 @@ from mapie.conformity_scores import (
     TopKConformityScore,
     NaiveConformityScore,
 )
-from mapie.conformity_scores.sets.utils import check_proba_normalized
+from mapie.utils import check_proba_normalized
 from mapie.metrics.classification import classification_coverage_score
 
 random_state = 42
@@ -439,7 +439,9 @@ class CustomGradientBoostingClassifier(GradientBoostingClassifier):
         if check_predict_params:
             n_samples = X.shape[0]
             n_classes = len(self.classes_)
-            return np.zeros((n_samples, n_classes))
+            probas = np.zeros((n_samples, n_classes))
+            probas[:, 0] = 1.0
+            return probas
         else:
             return super().predict_proba(X)
 
@@ -1921,7 +1923,7 @@ def test_fit_parameters_passing() -> None:
 def test_predict_parameters_passing() -> None:
     """
     Test passing predict parameters.
-    Checks that conformity_scores from train are 0, y_pred from test are 0.
+    Checks that y_pred from test are 0.
     """
     X_train, X_test, y_train, y_test = (
         train_test_split(X, y, test_size=0.2, random_state=random_state)
@@ -1935,10 +1937,7 @@ def test_predict_parameters_passing() -> None:
         X_train, y_train, predict_params=predict_params
     )
 
-    expected_conformity_scores = np.ones((X_train.shape[0], 1))
     y_pred = mapie_model.predict(X_test, agg_scores="mean", **predict_params)
-    np.testing.assert_equal(mapie_model.conformity_scores_,
-                            expected_conformity_scores)
     np.testing.assert_equal(y_pred, 0)
 
 
@@ -1988,7 +1987,7 @@ def test_predict_params_expected_behavior_unaffected_by_fit_params() -> None:
     """
     We want to verify that there are no interferences
     with fit_params on the expected behavior of predict_params
-    Checks that conformity_scores from train and y_pred from test are 0.
+    Checks that y_pred from test are 0.
     """
     X_train, X_test, y_train, y_test = (
         train_test_split(X, y, test_size=0.2, random_state=random_state)
@@ -2005,10 +2004,6 @@ def test_predict_params_expected_behavior_unaffected_by_fit_params() -> None:
     )
     y_pred = mapie_model.predict(X_test, agg_scores="mean", **predict_params)
 
-    expected_conformity_scores = np.ones((X_train.shape[0], 1))
-
-    np.testing.assert_equal(mapie_model.conformity_scores_,
-                            expected_conformity_scores)
     np.testing.assert_equal(y_pred, 0)
 
 

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1033,6 +1033,38 @@ def _check_estimator_classification(
     return estimator
 
 
+def check_proba_normalized(
+    y_pred_proba: NDArray,
+    axis: int = 1
+) -> NDArray:
+    """
+    Check if for all the samples the sum of the probabilities is equal to one.
+
+    Parameters
+    ----------
+    y_pred_proba: NDArray of shape (n_samples, n_classes) or
+    (n_samples, n_train_samples, n_classes)
+        Softmax output of a model.
+
+    Returns
+    -------
+    ArrayLike of shape (n_samples, n_classes)
+        Softmax output of a model if the scores all sum to one.
+
+    Raises
+    ------
+    ValueError
+        If the sum of the scores is not equal to one.
+    """
+    np.testing.assert_allclose(
+        np.sum(y_pred_proba, axis=axis),
+        1,
+        err_msg="The sum of the scores is not equal to one.",
+        rtol=1e-5
+    )
+    return y_pred_proba.astype(np.float64)
+
+
 def _get_binning_groups(
     y_score: NDArray,
     num_bins: int,

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1035,7 +1035,7 @@ def _check_estimator_classification(
 
 def check_proba_normalized(
     y_pred_proba: NDArray,
-    axis: int = 1
+    axis: int = -1
 ) -> NDArray:
     """
     Check if for all the samples the sum of the probabilities is equal to one.


### PR DESCRIPTION
PR content:
 - move probabilities prediction to the main class instead of conformity scores classes
 - use those probabilities to compute y_pred
 - change EnsembleClassifier .predict function to .predict_agg_proba
 - modify tests to reflect changes

Remark: we're not using the provided classifier `predict` method anymore to predict labels. This _may_ cause output format change with exotic classifiers. But MAPIE is a wrapper on top of estimators, so MAPIE `predict` outputs should be consistent across estimators.