### PR TITLE
FIX: prefit=True by default in split methods docstrings

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,7 @@ History
 * Fix double inference when using `predict_set` function in split conformal classification
 * Add FAQ entry in the documentation about ongoing works to extend MAPIE for LLM control
 * MAPIE now supports Python versions up to the latest release (currently 3.13)
+* Change `prefit` default value to `True` in split methods' docstrings to remain consistent with the implementation
 
 1.0.1 (2025-05-22)
 ------------------

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -79,7 +79,7 @@ class SplitConformalClassifier:
 
         See :ref:`theoretical_description_classification`.
 
-    prefit : bool, default=False
+    prefit : bool, default=True
         If True, the base classifier must be fitted, and the ``fit``
         method must be skipped.
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -72,7 +72,7 @@ class SplitConformalRegressor:
         be provided.
 
         See :ref:`theoretical_description_conformity_scores`.
-    prefit : bool, default=False
+    prefit : bool, default=True
         If True, the base regressor must be fitted, and the ``fit``
         method must be skipped.
 


### PR DESCRIPTION
There was an inconsistency in the default value of the ``prefit`` parameter in split methods (regression and classification) between the implementations and the docstrings.
The ``prefit`` parameter is now set to ``True`` by default in both.