### PR TITLE
DOC: correct default split_size to 0.25

### DIFF
--- a/mapie/conformity_scores/bounds/residuals.py
+++ b/mapie/conformity_scores/bounds/residuals.py
@@ -51,7 +51,7 @@ class ResidualNormalisedScore(BaseRegressionScore):
     split_size: Optional[Union[int, float]]
         The proportion of data that is used to fit the ``residual_estimator``.
         By default it is the default value of
-        ``sklearn.model_selection.train_test_split`` ie 0.2.
+        ``sklearn.model_selection.train_test_split`` ie 0.25.
 
     random_state: Optional[Union[int, np.random.RandomState]]
         Pseudo random number used for random sampling.


### PR DESCRIPTION
# Description

This PR corrects the default value cited in the docstring for the `split_size` parameter within the `ResidualNormalisedScore` class.

The documentation incorrectly stated that the default value, derived from `sklearn.model_selection.train_test_split`, is `0.2`. However, according to the official scikit-learn source code, the `test_size` defaults to `0.25` when both `train_size` and `test_size` are `None`.

https://github.com/scikit-learn/scikit-learn/blob/be6bce6c629e1ed2f50336e2fe89867c9ef848cd/sklearn/model_selection/_split.py#L2793-L2798

This commit aligns the `mapie` docstring with the actual behavior of its scikit-learn dependency, ensuring documentation accuracy and preventing potential user confusion.

## Type of change

- Bug fix (non-breaking change which fixes an issue)