### PR TITLE
chore: remove get-latest-python job and simplify Python version setup…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - master
   pull_request:
 
+jobs:
   build:
-    needs: get-latest-python
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,10 +21,13 @@ on:
             scipy-version: "==1.10.*"
           # latest stable dependencies
           - os: ubuntu-latest
+            python-version: "3.x"
             use-pinned-deps: false
           - os: windows-latest
+            python-version: "3.x"
             use-pinned-deps: false
           - os: macos-latest
+            python-version: "3.x"
             use-pinned-deps: false
     defaults:
       run:
@@ -36,7 +39,7 @@ on:
       - name: Set up Python
         uses: actions/setup-python@v5.6.0
         with:
-          python-version: "3.x"
+          python-version: ${{ matrix.python-version }}
           check-latest: true
       - name: Install minimum dependency constraints
         if: ${{ matrix.use-pinned-deps }}


### PR DESCRIPTION
# Description
Get latest version of python for CI tests. Right now it was getting the version currently already available, hence, not testing the latest python version.

## Type of change

Please remove options that are irrelevant.
- Bug fix (non-breaking change which fixes an issue)

# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`

## Contribution Documentation
- [ ] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files

## LLM Usage
- [ ] I used a Large Language Model (LLM) for this contribution.
- [ ] I carefully reviewed and verified all LLM-generated content.

If you used an LLM, please provide the following details:

- **LLM used**: (e.g., Mistral, Claude, GPT, Gemini, etc.)
- **Purpose**: (e.g., code generation, documentation, test writing, refactoring, etc.)
