### PR TITLE
docs: fix segmentation example

### DIFF
--- a/examples/risk_control/2-advanced-analysis/plot_semantic_segmentation_precision_control.py
+++ b/examples/risk_control/2-advanced-analysis/plot_semantic_segmentation_precision_control.py
@@ -166,7 +166,7 @@ def denormalize_image(tensor_image: torch.Tensor) -> np.ndarray:
 
 # Select random test images
 NUM_EXAMPLES = 4
-np.random.seed(42)
+np.random.seed(0)
 
 # Get indices of images with masks
 indices_with_masks = []

--- a/examples/risk_control/2-advanced-analysis/plot_semantic_segmentation_recall_control.py
+++ b/examples/risk_control/2-advanced-analysis/plot_semantic_segmentation_recall_control.py
@@ -165,7 +165,7 @@ def denormalize_image(tensor_image: torch.Tensor) -> np.ndarray:
 
 # Select random test images
 NUM_EXAMPLES = 4
-np.random.seed(42)
+np.random.seed(0)
 
 # Get indices of images with masks
 indices_with_masks = []


### PR DESCRIPTION
now the images chosen in the precision control and recall control for semantic segmentation are better