### PR TITLE
chore: add deepwiki badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@
 .. |Release| image:: https://img.shields.io/github/v/release/scikit-learn-contrib/mapie
     :target: https://github.com/scikit-learn-contrib/MAPIE/releases
 
-.. |Commits| image:: https://img.shields.io/github/commits-since/scikit-learn-contrib/mapie/latest/master
+.. |Commits| image:: https://img.shields.io/github/commits-since/scikit-learn-contrib/mapie/latest
     :target: https://github.com/scikit-learn-contrib/MAPIE/commits/master
 
 .. |Ask DeepWiki| image:: https://deepwiki.com/badge.svg


### PR DESCRIPTION
add a deepwiki badge, which should trigger a weekly refresh of the deepwiki.

fix the " commits since "  badge which did not work previously