### PR TITLE
fix: mypy warn return any and add type casting to fix new type issues

### DIFF
--- a/mapie/conformity_scores/bounds/residuals.py
+++ b/mapie/conformity_scores/bounds/residuals.py
@@ -166,13 +166,15 @@ class ResidualNormalisedScore(BaseRegressionScore):
         X: NDArray,
         y: NDArray,
         y_pred: NDArray,
-    ) -> Tuple[NDArray, NDArray]:
+    ) -> RegressorMixin:
         """
-        Fit the residual estimator and returns the indexes used for the
-        training of the base estimator and those needed for the conformalization.
+        Fit the residual estimator and return the fitted estimator.
 
         Parameters
         ----------
+        residual_estimator_: RegressorMixin
+            The residual estimator to fit.
+
         X: NDArray
             All the observed values used in the general fit.
 
@@ -185,7 +187,7 @@ class ResidualNormalisedScore(BaseRegressionScore):
         Returns
         -------
         RegressorMixin
-            Fitted residual estimator
+            Fitted residual estimator.
         """
         residuals = np.abs(np.subtract(y, y_pred))
         targets = np.log(np.maximum(residuals, np.full(residuals.shape, self.eps)))

--- a/mapie/metrics/calibration.py
+++ b/mapie/metrics/calibration.py
@@ -16,7 +16,7 @@ from mapie.utils import (
 from sklearn.utils.validation import column_or_1d
 
 
-from typing import Tuple, cast, Optional, Union
+from typing import Optional, Tuple, Union, cast
 
 
 def _get_binning_groups(
@@ -154,8 +154,9 @@ def expected_calibration_error(
         y_true_, y_score, num_bins, split_strategy
     )
 
-    return np.divide(
-        np.sum(bin_sizes * np.abs(bin_accs - bin_confs)), np.sum(bin_sizes)
+    return cast(
+        float,
+        np.divide(np.sum(bin_sizes * np.abs(bin_accs - bin_confs)), np.sum(bin_sizes)),
     )
 
 
@@ -429,7 +430,7 @@ def length_scale(s: NDArray) -> float:
     """
     n = len(s)
     length_scale = np.sqrt(np.sum(s * (1 - s))) / n
-    return length_scale
+    return cast(float, length_scale)
 
 
 def kolmogorov_smirnov_statistic(y_true: NDArray, y_score: NDArray) -> float:
@@ -808,7 +809,7 @@ def spiegelhalter_statistic(y_true: NDArray, y_score: NDArray) -> float:
     numerator: float = np.sum((y_true - y_score) * (1 - 2 * y_score))
     denominator = np.sqrt(np.sum((1 - 2 * y_score) ** 2 * y_score * (1 - y_score)))
     sp_stat = numerator / denominator
-    return sp_stat
+    return cast(float, sp_stat)
 
 
 def spiegelhalter_p_value(y_true: NDArray, y_score: NDArray) -> float:
@@ -856,4 +857,4 @@ def spiegelhalter_p_value(y_true: NDArray, y_score: NDArray) -> float:
     _check_array_inf(y_score)
     sp_stat = spiegelhalter_statistic(y_true, y_score)
     sp_p_value = 1 - scipy.stats.norm.cdf(sp_stat)
-    return sp_p_value
+    return cast(float, sp_p_value)

--- a/mapie/metrics/classification.py
+++ b/mapie/metrics/classification.py
@@ -48,7 +48,7 @@ def classification_mean_width_score(y_pred_set: ArrayLike) -> float:
     _check_array_inf(y_pred_set)
     width = y_pred_set.sum(axis=1)
     mean_width = width.mean(axis=0)
-    return mean_width
+    return cast(float, mean_width)
 
 
 def classification_coverage_score(y_true: NDArray, y_pred_set: NDArray) -> NDArray:

--- a/mapie/metrics/regression.py
+++ b/mapie/metrics/regression.py
@@ -545,4 +545,4 @@ def regression_mwi_score(
     error_below: float = np.sum((y_pred_low - y_true)[y_true < y_pred_low])
     total_error = error_above + error_below
     mwi = (width + total_error * 2 / (1 - confidence_level)) / len(y_true)
-    return mwi
+    return cast(float, mwi)

--- a/mapie/risk_control/fwer_control.py
+++ b/mapie/risk_control/fwer_control.py
@@ -1,6 +1,6 @@
 import warnings
 from abc import ABC, abstractmethod
-from typing import Literal, Union
+from typing import Literal, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -168,7 +168,7 @@ class FWERBonferroniHolm(FWERProcedure):
         active_indices = np.flatnonzero(self.active_hypotheses)
         if len(active_indices) == 0:
             return None
-        return active_indices[np.argmin(p_values[active_indices])]
+        return cast(int, active_indices[np.argmin(p_values[active_indices])])
 
     def _local_significance_levels(self) -> NDArray:
         remaining = self.active_hypotheses.sum()

--- a/mapie/risk_control/methods.py
+++ b/mapie/risk_control/methods.py
@@ -158,7 +158,7 @@ def _is_increasing_risk(r_hat_plus: NDArray) -> bool:
     bool
         True if array is increasing, False otherwise
     """
-    return r_hat_plus[0] < r_hat_plus[-1]
+    return cast(bool, r_hat_plus[0] < r_hat_plus[-1])
 
 
 def find_best_predict_param(

--- a/mapie/tests/long_tests/test_theoretical_validity.py
+++ b/mapie/tests/long_tests/test_theoretical_validity.py
@@ -7,6 +7,7 @@ theoretical validity checks) as pytest tests.
 
 import warnings
 from itertools import product
+from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -125,7 +126,7 @@ def precision_logistic_classifier(scale: float, threshold: float) -> float:
     )
     TP_plus_FP = (3 - decision_threshold) / 6
 
-    return TP / TP_plus_FP
+    return cast(float, TP / TP_plus_FP)
 
 
 def accuracy_logistic_classifier(scale: float, threshold: float) -> float:
@@ -156,7 +157,7 @@ def accuracy_logistic_classifier(scale: float, threshold: float) -> float:
     )
     FN_plus_TN = (3 + decision_threshold) / 6
     TN = FN_plus_TN - FN
-    return TP + TN
+    return cast(float, TP + TN)
 
 
 def recall_logistic_classifier(scale: float, threshold: float) -> float:
@@ -185,7 +186,7 @@ def recall_logistic_classifier(scale: float, threshold: float) -> float:
             - np.log(1 + np.exp(-3 * scale))
         )
     )
-    return TP / (TP + FN)
+    return cast(float, TP / (TP + FN))
 
 
 def run_one_experiment_with_random_classifier(

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -417,7 +417,7 @@ def _check_no_agg_cv(
     elif isinstance(cv, int):
         return cv == 1
     elif hasattr(cv, "get_n_splits"):
-        return cv.get_n_splits(X, y, groups) == 1
+        return cast(bool, cv.get_n_splits(X, y, groups) == 1)
     else:
         raise ValueError(
             "Invalid cv argument. "

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.9
 ignore_missing_imports = True
+warn_return_any = True
 
 [mypy-sklearn.*]
 ignore_errors = True


### PR DESCRIPTION
Fixes #816

* Updated return statements in classification, regression, and calibration metrics to include type casting for improved type safety.
* Adjusted return types in risk control methods and utility functions to ensure consistent boolean and float returns.
* Enhanced the residuals class method to clarify the return type as a fitted estimator.

## LLM Usage
- [x] I used a Large Language Model (LLM) for this contribution.
- [x] I carefully reviewed and verified all LLM-generated content.

If you used an LLM, please provide the following details:

- **LLM used**: Cursor
- **Purpose**: code generation