### PR TITLE
chore: fix all cast

### DIFF
--- a/examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py
+++ b/examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py
@@ -31,12 +31,10 @@ to the target, along with narrower PIs.
 """
 
 import warnings
-from typing import cast
 
 import numpy as np
 import pandas as pd
 from matplotlib import pylab as plt
-from numpy.typing import NDArray
 from scipy.stats import randint
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import PredefinedSplit, RandomizedSearchCV
@@ -210,7 +208,7 @@ for i, (ax, w, result) in enumerate(
         label="Predictions",
     )
 
-    y_pis = cast(NDArray, result["y_pis"])
+    y_pis = np.asarray(result["y_pis"])
 
     ax.fill_between(
         demand_test.index,

--- a/mapie/calibration.py
+++ b/mapie/calibration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from inspect import signature
-from typing import Dict, Optional, Tuple, Union, cast
+from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -285,7 +285,7 @@ class TopLabelCalibrator(BaseEstimator, ClassifierMixin):
             Calibrated estimator.
         """
         calibrator_ = clone(calibrator)
-        sample_weight = cast(NDArray, sample_weight)
+        sample_weight = np.asarray(sample_weight) if sample_weight is not None else None
         given_label_indices = np.argwhere(y_pred.ravel() == label).ravel()
         y_calib_ = np.equal(y_calib[given_label_indices], label).astype(int)
         top_class_prob_ = top_class_prob[given_label_indices]
@@ -341,7 +341,7 @@ class TopLabelCalibrator(BaseEstimator, ClassifierMixin):
             calibrator_ = self._fit_calibrator(
                 label,
                 calibrator,
-                cast(NDArray, y),
+                np.asarray(y),
                 max_prob,
                 y_pred,
                 sample_weight,
@@ -462,8 +462,8 @@ class TopLabelCalibrator(BaseEstimator, ClassifierMixin):
                 shuffle=shuffle,
                 stratify=stratify,
             )
-        X_train, X_calib = cast(ArrayLike, X_train), cast(ArrayLike, X_calib)
-        y_train, y_calib = cast(ArrayLike, y_train), cast(ArrayLike, y_calib)
+        X_train, X_calib = np.asarray(X_train), np.asarray(X_calib)
+        y_train, y_calib = np.asarray(y_train), np.asarray(y_calib)
         return (
             X_train,
             y_train,

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Iterable, Literal, Optional, Tuple, Union
+from typing import Any, Iterable, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Any, Iterable, Literal, Optional, Tuple, Union, cast
+from typing import Any, Iterable, Literal, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -817,11 +817,12 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
         X, y = indexable(X, y)
         y = _check_y(y)
 
-        sample_weight = cast(Optional[NDArray], sample_weight)
-        groups = cast(Optional[NDArray], groups)
         sample_weight, X, y = _check_null_weight(sample_weight, X, y)
-
-        y = cast(NDArray, y)
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
+        if groups is not None:
+            groups = np.asarray(groups)
+        y = np.asarray(y)
 
         estimator = _check_estimator_classification(X, y, cv, self.estimator)
         self.n_features_in_ = _check_n_features_in(X, cv, estimator)
@@ -843,10 +844,13 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
                 "RAPS conformity score can only be used with SplitConformalClassifier."
             )
 
-        # Cast
-        X, y_enc, y = cast(NDArray, X), cast(NDArray, y_enc), cast(NDArray, y)
-        sample_weight = cast(NDArray, sample_weight)
-        groups = cast(NDArray, groups)
+        X = np.asarray(X)
+        y_enc = np.asarray(y_enc)
+        y = np.asarray(y)
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
+        if groups is not None:
+            groups = np.asarray(groups)
 
         X, y, y_enc, sample_weight, groups = cs_estimator.split_data(
             X, y, y_enc, sample_weight, groups
@@ -919,11 +923,6 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
             groups,
         ) = self._check_fit_parameter(X, y, sample_weight, groups)
 
-        # Cast
-        X, y_enc, y = cast(NDArray, X), cast(NDArray, y_enc), cast(NDArray, y)
-        sample_weight = cast(NDArray, sample_weight)
-        groups = cast(NDArray, groups)
-
         # Work
         self.estimator_ = EnsembleClassifier(
             estimator,
@@ -939,7 +938,11 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
 
         # Predict on calibration data
         y_pred_proba, y, y_enc = self.estimator_.predict_proba_calib(
-            X, y, y_enc, groups, **predict_params
+            np.asarray(X),
+            np.asarray(y),
+            np.asarray(y_enc),
+            np.asarray(groups) if groups is not None else None,
+            **predict_params,
         )
 
         # Compute the conformity scores
@@ -1037,7 +1040,7 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
             _check_predict_params(self._predict_params, predict_params, self.cv)
 
         check_is_fitted(self)
-        alpha = cast(Optional[NDArray], _check_alpha(alpha))
+        alpha = _check_alpha(alpha)
 
         # Estimate predictions
         y_pred_proba = self.estimator_.single_estimator_.predict_proba(
@@ -1052,7 +1055,7 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
         # In all cases: len(y_pred_proba.shape) == 3
         # with  (n_test, n_classes, n_alpha or n_train_samples)
         n = len(self.conformity_scores_)
-        alpha_np = cast(NDArray, alpha)
+        alpha_np = alpha
         _check_alpha_and_n_samples(alpha_np, n)
 
         # Estimate prediction sets

--- a/mapie/conformity_scores/bounds/residuals.py
+++ b/mapie/conformity_scores/bounds/residuals.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray

--- a/mapie/conformity_scores/bounds/residuals.py
+++ b/mapie/conformity_scores/bounds/residuals.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -153,9 +153,9 @@ class ResidualNormalisedScore(BaseRegressionScore):
         random_state = check_random_state(self.random_state)
         X_, y_, y_pred_ = indexable(X, y, y_pred)
         return (
-            cast(NDArray, X_),
-            cast(NDArray, y_),
-            cast(NDArray, y_pred_),
+            np.asarray(X_),
+            np.asarray(y_),
+            np.asarray(y_pred_),
             residual_estimator,
             random_state,
         )
@@ -244,7 +244,6 @@ class ResidualNormalisedScore(BaseRegressionScore):
                 "Additional parameters must be provided for the method to "
                 + "work (here `X` is missing)."
             )
-        X = cast(ArrayLike, X)
 
         (X, y, y_pred, self.residual_estimator_, random_state) = self._check_parameters(
             X, y, y_pred
@@ -313,7 +312,6 @@ class ResidualNormalisedScore(BaseRegressionScore):
                 "Additional parameters must be provided for the method to "
                 + "work (here `X` is missing)."
             )
-        X = cast(ArrayLike, X)
 
         r_pred = self._predict_residual_estimator(X).reshape((-1, 1))
         if not self.prefit:

--- a/mapie/conformity_scores/regression.py
+++ b/mapie/conformity_scores/regression.py
@@ -1,6 +1,6 @@
 import logging
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, cast
+from typing import Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -208,13 +208,10 @@ class BaseRegressionScore(BaseConformityScore, metaclass=ABCMeta):
             "https://github.com/scikit-learn-contrib/MAPIE/issues/588"
         )
 
-        beta_np = cast(
-            NDArray[np.float64],
-            np.full(
-                shape=(len(lower_bounds), len(alpha_np)),
-                fill_value=np.nan,
-                dtype=float,
-            ),
+        beta_np: NDArray = np.full(
+            shape=(len(lower_bounds), len(alpha_np)),
+            fill_value=np.nan,
+            dtype=float,
         )
         for ind_alpha, _alpha in enumerate(alpha_np):
             betas = np.linspace(

--- a/mapie/conformity_scores/sets/aps.py
+++ b/mapie/conformity_scores/sets/aps.py
@@ -294,7 +294,7 @@ class APSConformityScore(NaiveConformityScore):
 
         # get random numbers for each observation and alpha value
         random_state = check_random_state(self.random_state)
-        assert isinstance(random_state, np.random.RandomState)
+        random_state = cast(np.random.RandomState, random_state)
         u_param = random_state.uniform(size=(prediction_sets.shape[0], 1))
         # remove last label from comparison between uniform number and V
         label_to_keep = np.less_equal(v_param - u_param, EPSILON)

--- a/mapie/conformity_scores/sets/aps.py
+++ b/mapie/conformity_scores/sets/aps.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray

--- a/mapie/conformity_scores/sets/aps.py
+++ b/mapie/conformity_scores/sets/aps.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -144,8 +144,8 @@ class APSConformityScore(NaiveConformityScore):
             Conformity scores.
         """
         # Casting
-        y_enc = cast(NDArray, y_enc)
-        classes = cast(NDArray, self.classes)
+        y_enc = np.asarray(y_enc)
+        classes = np.asarray(self.classes)
 
         # Conformity scores
         conformity_scores, self.cutoff = self.get_true_label_cumsum_proba(
@@ -294,7 +294,7 @@ class APSConformityScore(NaiveConformityScore):
 
         # get random numbers for each observation and alpha value
         random_state = check_random_state(self.random_state)
-        random_state = cast(np.random.RandomState, random_state)
+        assert isinstance(random_state, np.random.RandomState)
         u_param = random_state.uniform(size=(prediction_sets.shape[0], 1))
         # remove last label from comparison between uniform number and V
         label_to_keep = np.less_equal(v_param - u_param, EPSILON)

--- a/mapie/conformity_scores/sets/lac.py
+++ b/mapie/conformity_scores/sets/lac.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import numpy as np
 

--- a/mapie/conformity_scores/sets/lac.py
+++ b/mapie/conformity_scores/sets/lac.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast, Union
+from typing import Optional, Union
 
 import numpy as np
 
@@ -61,8 +61,7 @@ class LACConformityScore(BaseClassificationScore):
         NDArray of shape (n_samples,)
             Conformity scores.
         """
-        # Casting
-        y_enc = cast(NDArray, y_enc)
+        y_enc = np.asarray(y_enc)
 
         # Conformity scores
         conformity_scores = np.take_along_axis(1 - y_pred, y_enc.reshape(-1, 1), axis=1)

--- a/mapie/conformity_scores/sets/raps.py
+++ b/mapie/conformity_scores/sets/raps.py
@@ -82,8 +82,7 @@ class RAPSConformityScore(APSConformityScore):
             By default ``None``.
         """
         super().set_external_attributes(**kwargs)
-        assert isinstance(label_encoder, LabelEncoder)
-        self.label_encoder_ = label_encoder
+        self.label_encoder_ = cast(LabelEncoder, label_encoder)
         self.size_raps = size_raps
 
     def split_data(

--- a/mapie/conformity_scores/sets/raps.py
+++ b/mapie/conformity_scores/sets/raps.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -453,27 +453,19 @@ class RAPSConformityScore(APSConformityScore):
             applying the regularization technique.
         """
         if prediction_phase:
-            assert self.lambda_star is not None
-            assert self.k_star is not None
-            if np.isscalar(self.lambda_star):
-                _lam: float = self.lambda_star  # type: ignore[assignment]
-                lambda_ = _lam
+            lambda_star = cast(Union[NDArray, float], self.lambda_star)
+            k_star_attr = cast(Union[NDArray, int], self.k_star)
+            if np.isscalar(lambda_star):
+                lambda_ = float(np.asarray(lambda_star).item())
             else:
-                assert isinstance(self.lambda_star, np.ndarray)
-                _lam = float(np.asarray(self.lambda_star).item(0))
-                lambda_ = _lam
-            if np.isscalar(self.k_star):
-                _k: int = self.k_star  # type: ignore[assignment]
-                k_star = _k
+                lambda_ = float(np.asarray(lambda_star).item(0))
+            if np.isscalar(k_star_attr):
+                k_star = int(np.asarray(k_star_attr).item())
             else:
-                assert isinstance(self.k_star, np.ndarray)
-                _k = int(np.asarray(self.k_star).item(0))
-                k_star = _k
+                k_star = int(np.asarray(k_star_attr).item(0))
         else:
-            assert lambda_ is not None
-            assert k_star is not None
-            lambda_ = float(lambda_)
-            k_star = int(k_star)
+            lambda_ = cast(float, lambda_)
+            k_star = cast(int, k_star)
 
         y_pred_proba_sorted_cumsum += lambda_ * np.maximum(
             0, np.cumsum(np.ones(y_pred_proba_sorted_cumsum.shape), axis=1) - k_star

--- a/mapie/conformity_scores/sets/raps.py
+++ b/mapie/conformity_scores/sets/raps.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, Union, cast
+from typing import Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -82,7 +82,8 @@ class RAPSConformityScore(APSConformityScore):
             By default ``None``.
         """
         super().set_external_attributes(**kwargs)
-        self.label_encoder_ = cast(LabelEncoder, label_encoder)
+        assert isinstance(label_encoder, LabelEncoder)
+        self.label_encoder_ = label_encoder
         self.size_raps = size_raps
 
     def split_data(
@@ -142,13 +143,12 @@ class RAPSConformityScore(APSConformityScore):
         self.y_raps_no_enc = self.label_encoder_.inverse_transform(self.y_raps)
         y = self.label_encoder_.inverse_transform(y_enc)
 
-        # Cast to NDArray for type checking
-        y_enc = cast(NDArray, y_enc)
+        y_enc = np.asarray(y_enc)
         if sample_weight is not None:
-            sample_weight = cast(NDArray, sample_weight)
+            sample_weight = np.asarray(sample_weight)
             sample_weight = sample_weight[train_raps_index]
         if groups is not None:
-            groups = cast(NDArray, groups)
+            groups = np.asarray(groups)
             groups = groups[train_raps_index]
 
         # Keep sample data size for training and calibration
@@ -307,7 +307,7 @@ class RAPSConformityScore(APSConformityScore):
         ArrayLike of shape (n_alphas, )
             Optimal values of lambda.
         """
-        classes = cast(NDArray, self.classes)
+        classes = np.asarray(self.classes)
 
         lambda_star = np.zeros(len(alpha_np))
         best_sizes = np.full(len(alpha_np), np.finfo(np.float64).max)
@@ -388,11 +388,6 @@ class RAPSConformityScore(APSConformityScore):
         NDArray
             Array of quantiles with respect to alpha_np.
         """
-        # Casting to NDArray to avoid mypy errors
-        # X_raps = cast(NDArray, X_raps)
-        # y_raps_no_enc = cast(NDArray, y_raps_no_enc)
-        # y_pred_proba_raps = cast(NDArray, y_pred_proba_raps)
-        # position_raps = cast(NDArray, position_raps)
 
         _check_alpha_and_n_samples(alpha_np, self.X_raps.shape[0])
         self.k_star = _compute_quantiles(self.position_raps, alpha_np) + 1
@@ -458,11 +453,27 @@ class RAPSConformityScore(APSConformityScore):
             applying the regularization technique.
         """
         if prediction_phase:
-            lambda_ = cast(float, self.lambda_star)
-            k_star = cast(int, self.k_star)
+            assert self.lambda_star is not None
+            assert self.k_star is not None
+            if np.isscalar(self.lambda_star):
+                _lam: float = self.lambda_star  # type: ignore[assignment]
+                lambda_ = _lam
+            else:
+                assert isinstance(self.lambda_star, np.ndarray)
+                _lam = float(np.asarray(self.lambda_star).item(0))
+                lambda_ = _lam
+            if np.isscalar(self.k_star):
+                _k: int = self.k_star  # type: ignore[assignment]
+                k_star = _k
+            else:
+                assert isinstance(self.k_star, np.ndarray)
+                _k = int(np.asarray(self.k_star).item(0))
+                k_star = _k
         else:
-            lambda_ = cast(float, lambda_)
-            k_star = cast(int, lambda_)
+            assert lambda_ is not None
+            assert k_star is not None
+            lambda_ = float(lambda_)
+            k_star = int(k_star)
 
         y_pred_proba_sorted_cumsum += lambda_ * np.maximum(
             0, np.cumsum(np.ones(y_pred_proba_sorted_cumsum.shape), axis=1) - k_star

--- a/mapie/conformity_scores/sets/topk.py
+++ b/mapie/conformity_scores/sets/topk.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import numpy as np
 from numpy.typing import NDArray

--- a/mapie/conformity_scores/sets/topk.py
+++ b/mapie/conformity_scores/sets/topk.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -63,8 +63,7 @@ class TopKConformityScore(BaseClassificationScore):
         NDArray of shape (n_samples,)
             Conformity scores.
         """
-        # Casting
-        y_enc = cast(NDArray, y_enc)
+        y_enc = np.asarray(y_enc)
 
         # Conformity scores
         # Here we reorder the labels by decreasing probability and get the

--- a/mapie/estimator/classifier.py
+++ b/mapie/estimator/classifier.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
 from joblib import Parallel, delayed

--- a/mapie/estimator/classifier.py
+++ b/mapie/estimator/classifier.py
@@ -346,7 +346,7 @@ class EnsembleClassifier:
             single_estimator_ = self._fit_oof_estimator(
                 clone(estimator), X, y, full_indexes, sample_weight, **fit_params
             )
-            assert isinstance(cv, (BaseCrossValidator, BaseShuffleSplit))
+            cv = cast(BaseCrossValidator, cv)
             k_ = np.empty_like(y, dtype=int)
 
             estimators_ = Parallel(self.n_jobs, verbose=self.verbose)(
@@ -410,8 +410,7 @@ class EnsembleClassifier:
         else:
             X = np.asarray(X)
             y_pred_proba = np.empty((len(X), self.n_classes), dtype=float)
-            assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
-            cv = self.cv
+            cv = cast(BaseCrossValidator, self.cv)
             outputs = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                 delayed(self._predict_proba_calib_oof_estimator)(
                     estimator, X, calib_index, k, **predict_params

--- a/mapie/estimator/classifier.py
+++ b/mapie/estimator/classifier.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Literal, Optional, Tuple, Union, cast
+from typing import List, Literal, Optional, Tuple, Union
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -159,7 +159,7 @@ class EnsembleClassifier:
         y_train = _safe_indexing(y, train_index)
         if sample_weight is not None:
             sample_weight = _safe_indexing(sample_weight, train_index)
-            sample_weight = cast(NDArray, sample_weight)
+            sample_weight = np.asarray(sample_weight)
 
         estimator = _fit_estimator(
             estimator, X_train, y_train, sample_weight=sample_weight, **fit_params
@@ -253,7 +253,7 @@ class EnsembleClassifier:
         val_index: ArrayLike,
         k: int,
         **predict_params,
-    ) -> Tuple[NDArray, ArrayLike, ArrayLike]:
+    ) -> Tuple[NDArray, NDArray, NDArray]:
         """
         Perform predictions on a single out-of-fold model on a validation set.
 
@@ -281,9 +281,10 @@ class EnsembleClassifier:
             )
         else:
             y_pred_proba = np.array([])
-        val_id = cast(NDArray[np.int_], np.full(len(X_val), k, dtype=int))
+        val_id: NDArray[np.int_] = np.full(len(X_val), k, dtype=int)
+        val_index_arr = np.asarray(val_index)
 
-        return y_pred_proba, val_id, val_index
+        return y_pred_proba, val_id, val_index_arr
 
     def fit(
         self,
@@ -345,7 +346,7 @@ class EnsembleClassifier:
             single_estimator_ = self._fit_oof_estimator(
                 clone(estimator), X, y, full_indexes, sample_weight, **fit_params
             )
-            cv = cast(BaseCrossValidator, cv)
+            assert isinstance(cv, (BaseCrossValidator, BaseShuffleSplit))
             k_ = np.empty_like(y, dtype=int)
 
             estimators_ = Parallel(self.n_jobs, verbose=self.verbose)(
@@ -407,9 +408,10 @@ class EnsembleClassifier:
             y_pred_proba = self.single_estimator_.predict_proba(X, **predict_params)
             y_pred_proba = self._check_proba_normalized(y_pred_proba)
         else:
-            X = cast(NDArray, X)
+            X = np.asarray(X)
             y_pred_proba = np.empty((len(X), self.n_classes), dtype=float)
-            cv = cast(BaseCrossValidator, self.cv)
+            assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
+            cv = self.cv
             outputs = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                 delayed(self._predict_proba_calib_oof_estimator)(
                     estimator, X, calib_index, k, **predict_params
@@ -418,13 +420,13 @@ class EnsembleClassifier:
                     zip(cv.split(X, y, groups), self.estimators_)
                 )
             )
-            (predictions_list, val_ids_list, val_indices_list) = map(
-                list, zip(*outputs)
-            )
+            predictions_list = [o[0] for o in outputs]
+            val_ids_list = [o[1] for o in outputs]
+            val_indices_list = [o[2] for o in outputs]
 
-            predictions = np.concatenate(cast(List[NDArray], predictions_list))
-            val_ids = np.concatenate(cast(List[NDArray], val_ids_list))
-            val_indices = np.concatenate(cast(List[NDArray], val_indices_list))
+            predictions = np.concatenate(predictions_list)
+            val_ids = np.concatenate(val_ids_list)
+            val_indices = np.concatenate(val_indices_list)
             self.k_[val_indices] = val_ids
             y_pred_proba[val_indices] = predictions
 

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union, cast
 
 import numpy as np
 from joblib import Parallel, delayed

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 from joblib import Parallel, delayed
 from numpy.typing import ArrayLike, NDArray
 from sklearn.base import RegressorMixin, clone
-from sklearn.model_selection import BaseCrossValidator
+from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
 from sklearn.utils import _safe_indexing
 from sklearn.utils.validation import _num_samples
 
@@ -221,7 +221,7 @@ class EnsembleRegressor:
         y_train = _safe_indexing(y, train_index)
         if sample_weight is not None:
             sample_weight = _safe_indexing(sample_weight, train_index)
-            sample_weight = cast(NDArray, sample_weight)
+            sample_weight = np.asarray(sample_weight)
 
         estimator = _fit_estimator(
             estimator, X_train, y_train, sample_weight=sample_weight, **fit_params
@@ -368,7 +368,8 @@ class EnsembleRegressor:
             if self.method == "naive":
                 y_pred = self.single_estimator_.predict(X)
             else:
-                cv = cast(BaseCrossValidator, self.cv)
+                assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
+                cv = self.cv
                 outputs = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                     delayed(self._predict_oof_estimator)(
                         estimator, X, calib_index, **predict_params
@@ -467,7 +468,8 @@ class EnsembleRegressor:
             self.k_ = np.full(shape=(n_samples, 1), fill_value=np.nan, dtype=float)
 
         else:
-            cv = cast(BaseCrossValidator, self.cv)
+            assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
+            cv = self.cv
             self.k_ = np.full(
                 shape=(n_samples, cv.get_n_splits(X, y, groups)),
                 fill_value=np.nan,
@@ -507,7 +509,8 @@ class EnsembleRegressor:
         if self.cv == "prefit":
             single_estimator_ = self.estimator
         else:
-            cv = cast(BaseCrossValidator, self.cv)
+            assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
+            cv = self.cv
             if self.use_split_method_:
                 train_indexes = [
                     train_index for train_index, test_index in cv.split(X, y, groups)

--- a/mapie/estimator/regressor.py
+++ b/mapie/estimator/regressor.py
@@ -6,7 +6,7 @@ import numpy as np
 from joblib import Parallel, delayed
 from numpy.typing import ArrayLike, NDArray
 from sklearn.base import RegressorMixin, clone
-from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
+from sklearn.model_selection import BaseCrossValidator
 from sklearn.utils import _safe_indexing
 from sklearn.utils.validation import _num_samples
 
@@ -368,8 +368,7 @@ class EnsembleRegressor:
             if self.method == "naive":
                 y_pred = self.single_estimator_.predict(X)
             else:
-                assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
-                cv = self.cv
+                cv = cast(BaseCrossValidator, self.cv)
                 outputs = Parallel(n_jobs=self.n_jobs, verbose=self.verbose)(
                     delayed(self._predict_oof_estimator)(
                         estimator, X, calib_index, **predict_params
@@ -468,8 +467,7 @@ class EnsembleRegressor:
             self.k_ = np.full(shape=(n_samples, 1), fill_value=np.nan, dtype=float)
 
         else:
-            assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
-            cv = self.cv
+            cv = cast(BaseCrossValidator, self.cv)
             self.k_ = np.full(
                 shape=(n_samples, cv.get_n_splits(X, y, groups)),
                 fill_value=np.nan,
@@ -509,8 +507,7 @@ class EnsembleRegressor:
         if self.cv == "prefit":
             single_estimator_ = self.estimator
         else:
-            assert isinstance(self.cv, (BaseCrossValidator, BaseShuffleSplit))
-            cv = self.cv
+            cv = cast(BaseCrossValidator, self.cv)
             if self.use_split_method_:
                 train_indexes = [
                     train_index for train_index, test_index in cv.split(X, y, groups)

--- a/mapie/metrics/calibration.py
+++ b/mapie/metrics/calibration.py
@@ -16,7 +16,7 @@ from mapie.utils import (
 )
 
 
-from typing import Tuple, Optional, Union
+from typing import Optional, Tuple, Union, cast
 
 
 def _get_binning_groups(

--- a/mapie/metrics/calibration.py
+++ b/mapie/metrics/calibration.py
@@ -3,6 +3,8 @@ import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from sklearn.utils import check_random_state
 from mapie._machine_precision import EPSILON
+from sklearn.utils.validation import column_or_1d
+
 from mapie.utils import (
     _check_array_inf,
     _check_array_nan,
@@ -10,13 +12,11 @@ from mapie.utils import (
     _check_binary_zero_one,
     _check_number_bins,
     _check_split_strategy,
+    _column_or_1d_ndarray,
 )
 
 
-from sklearn.utils.validation import column_or_1d
-
-
-from typing import Tuple, cast, Optional, Union
+from typing import Tuple, Optional, Union
 
 
 def _get_binning_groups(
@@ -137,7 +137,7 @@ def expected_calibration_error(
     split_strategy = _check_split_strategy(split_strategy)
     num_bins = _check_number_bins(num_bins)
     y_true_ = _check_binary_zero_one(y_true)
-    y_scores = cast(NDArray, y_scores)
+    y_scores = np.asarray(y_scores)
 
     _check_arrays_length(y_true_, y_scores)
     _check_array_nan(y_true_)
@@ -146,9 +146,9 @@ def expected_calibration_error(
     _check_array_inf(y_scores)
 
     if np.size(y_scores.shape) == 2:
-        y_score = cast(NDArray, column_or_1d(np.nanmax(y_scores, axis=1)))
+        y_score = _column_or_1d_ndarray(np.nanmax(y_scores, axis=1))
     else:
-        y_score = cast(NDArray, column_or_1d(y_scores))
+        y_score = _column_or_1d_ndarray(y_scores)
 
     _, bin_accs, bin_confs, bin_sizes = _calc_bins(
         y_true_, y_score, num_bins, split_strategy
@@ -204,8 +204,8 @@ def top_label_ece(
     float
         The ECE score adapted in the top label setting.
     """
-    y_scores = cast(NDArray, y_scores)
-    y_true = cast(NDArray, y_true)
+    y_scores = np.asarray(y_scores)
+    y_true = np.asarray(y_true)
     _check_array_nan(y_true)
     _check_array_inf(y_true)
     _check_array_nan(y_scores)
@@ -214,7 +214,7 @@ def top_label_ece(
     if y_score_arg is None:
         _check_arrays_length(y_true, y_scores)
     else:
-        y_score_arg = cast(NDArray, y_score_arg)
+        y_score_arg = np.asarray(y_score_arg)
         _check_array_nan(y_score_arg)
         _check_array_inf(y_score_arg)
         _check_arrays_length(y_true, y_scores, y_score_arg)
@@ -222,19 +222,17 @@ def top_label_ece(
     ece = float(0.0)
     split_strategy = _check_split_strategy(split_strategy)
     num_bins = _check_number_bins(num_bins)
-    y_true = cast(NDArray, column_or_1d(y_true))
+    y_true = _column_or_1d_ndarray(y_true)
     if y_score_arg is None:
-        y_score = cast(NDArray, column_or_1d(np.nanmax(y_scores, axis=1)))
+        y_score = _column_or_1d_ndarray(np.nanmax(y_scores, axis=1))
         if classes is None:
-            y_score_arg = cast(NDArray, column_or_1d(np.nanargmax(y_scores, axis=1)))
+            y_score_arg = _column_or_1d_ndarray(np.nanargmax(y_scores, axis=1))
         else:
-            classes = cast(NDArray, classes)
-            y_score_arg = cast(
-                NDArray, column_or_1d(classes[np.nanargmax(y_scores, axis=1)])
-            )
+            classes = np.asarray(classes)
+            y_score_arg = _column_or_1d_ndarray(classes[np.nanargmax(y_scores, axis=1)])
     else:
-        y_score = cast(NDArray, column_or_1d(y_scores))
-        y_score_arg = cast(NDArray, column_or_1d(y_score_arg))
+        y_score = _column_or_1d_ndarray(y_scores)
+        y_score_arg = _column_or_1d_ndarray(y_score_arg)
     labels = np.unique(y_score_arg)
 
     for label in labels:

--- a/mapie/metrics/classification.py
+++ b/mapie/metrics/classification.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray

--- a/mapie/metrics/classification.py
+++ b/mapie/metrics/classification.py
@@ -1,8 +1,7 @@
-from typing import Union, cast
+from typing import Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from sklearn.utils import column_or_1d
 
 from mapie.utils import (
     _check_array_inf,
@@ -11,6 +10,7 @@ from mapie.utils import (
     _check_arrays_length,
     _check_nb_sets_sizes,
     _check_number_bins,
+    _column_or_1d_ndarray,
 )
 
 
@@ -115,7 +115,7 @@ def classification_coverage_score(y_true: NDArray, y_pred_set: NDArray) -> NDArr
 
     y_pred_set = _check_array_shape_classification(y_true, y_pred_set)
     if len(y_true.shape) != 2:
-        y_true = cast(NDArray, column_or_1d(y_true))
+        y_true = _column_or_1d_ndarray(y_true)
         y_true = np.expand_dims(y_true, axis=1)
     y_true = np.expand_dims(y_true, axis=1)
     coverage = np.nanmean(np.take_along_axis(y_pred_set, y_true, axis=1), axis=0)
@@ -166,7 +166,7 @@ def classification_ssc(
     >>> print(classification_ssc(y_true, y_pred_set, num_bins=2))
     [[1.         0.66666667]]
     """
-    y_true = cast(NDArray, column_or_1d(y_true))
+    y_true = _column_or_1d_ndarray(y_true)
     y_pred_set = _check_array_shape_classification(y_true, y_pred_set)
 
     _check_arrays_length(y_true, y_pred_set)

--- a/mapie/metrics/regression.py
+++ b/mapie/metrics/regression.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 

--- a/mapie/metrics/regression.py
+++ b/mapie/metrics/regression.py
@@ -1,8 +1,5 @@
-from typing import cast
-
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from sklearn.utils import column_or_1d
 
 from mapie.utils import (
     _check_arrays_length,
@@ -12,6 +9,7 @@ from mapie.utils import (
     _check_number_bins,
     _check_nb_intervals_sizes,
     _check_alpha,
+    _column_or_1d_ndarray,
 )
 
 
@@ -120,7 +118,7 @@ def regression_coverage_score(
 
     y_intervals = _check_array_shape_regression(y_true, y_intervals)
     if len(y_true.shape) != 2:
-        y_true = cast(NDArray, column_or_1d(y_true))
+        y_true = _column_or_1d_ndarray(y_true)
         y_true = np.expand_dims(y_true, axis=1)
     coverages = np.mean(
         np.logical_and(
@@ -175,7 +173,7 @@ def regression_ssc(y_true: NDArray, y_intervals: NDArray, num_bins: int = 3) -> 
     >>> print(regression_ssc(y_true, y_intervals, num_bins=2))
     [[1. 1.]]
     """
-    y_true = cast(NDArray, column_or_1d(y_true))
+    y_true = _column_or_1d_ndarray(y_true)
     y_intervals = _check_array_shape_regression(y_true, y_intervals)
     _check_number_bins(num_bins)
     widths = np.abs(y_intervals[:, 1, :] - y_intervals[:, 0, :])
@@ -322,7 +320,7 @@ def hsic(
     >>> print(hsic(y_true, y_intervals))
     [0.31787614 0.2962914 ]
     """
-    y_true = cast(NDArray, column_or_1d(y_true))
+    y_true = _column_or_1d_ndarray(y_true)
     y_intervals = _check_array_shape_regression(y_true, y_intervals)
 
     _check_arrays_length(y_true, y_intervals)
@@ -331,7 +329,7 @@ def hsic(
     _check_array_nan(y_intervals)
     _check_array_inf(y_intervals)
 
-    kernel_sizes = cast(NDArray, column_or_1d(kernel_sizes))
+    kernel_sizes = _column_or_1d_ndarray(kernel_sizes)
     if len(kernel_sizes) != 2:
         raise ValueError("kernel_sizes should be an ArrayLike of length 2")
     if (kernel_sizes <= 0).any():
@@ -470,9 +468,9 @@ def coverage_width_based(
     >>> print(np.round(cwb ,2))
     0.69
     """
-    y_true = cast(NDArray, column_or_1d(y_true))
-    y_pred_low = cast(NDArray, column_or_1d(y_pred_low))
-    y_pred_up = cast(NDArray, column_or_1d(y_pred_up))
+    y_true = _column_or_1d_ndarray(y_true)
+    y_pred_low = _column_or_1d_ndarray(y_pred_low)
+    y_pred_up = _column_or_1d_ndarray(y_pred_up)
 
     _check_alpha(confidence_level)
 

--- a/mapie/regression/quantile_regression.py
+++ b/mapie/regression/quantile_regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union, cast
 
 import warnings
 import numpy as np
@@ -799,14 +799,12 @@ class _MapieQuantileRegressor(_MapieRegressor):
         return self
 
     def _initialize_fit_conformalize(self) -> None:
-        assert isinstance(self.cv, str)
-        self.cv = self._check_cv(self.cv)
+        self.cv = self._check_cv(cast(str, self.cv))
         self.alpha_np = self._check_alpha(self.alpha)
         self.estimators_: List[RegressorMixin] = []
 
     def _initialize_and_check_prefit_estimators(self) -> None:
-        assert isinstance(self.estimator, list)
-        estimator = self.estimator
+        estimator = cast(List, self.estimator)
         self._check_prefit_params(estimator)
         self.estimators_ = list(estimator)
         self.single_estimator_ = self.estimators_[2]

--- a/mapie/regression/quantile_regression.py
+++ b/mapie/regression/quantile_regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import warnings
 import numpy as np
@@ -799,12 +799,14 @@ class _MapieQuantileRegressor(_MapieRegressor):
         return self
 
     def _initialize_fit_conformalize(self) -> None:
-        self.cv = self._check_cv(cast(str, self.cv))
+        assert isinstance(self.cv, str)
+        self.cv = self._check_cv(self.cv)
         self.alpha_np = self._check_alpha(self.alpha)
         self.estimators_: List[RegressorMixin] = []
 
     def _initialize_and_check_prefit_estimators(self) -> None:
-        estimator = cast(List, self.estimator)
+        assert isinstance(self.estimator, list)
+        estimator = self.estimator
         self._check_prefit_params(estimator)
         self.estimators_ = list(estimator)
         self.single_estimator_ = self.estimators_[2]
@@ -899,7 +901,7 @@ class _MapieQuantileRegressor(_MapieRegressor):
         if self.cv == "prefit":
             self._initialize_and_check_prefit_estimators()
 
-        X_calib, y_calib = cast(ArrayLike, X), cast(ArrayLike, y)
+        X_calib, y_calib = np.asarray(X), np.asarray(y)
         X_calib, y_calib = indexable(X_calib, y_calib)
         y_calib = _check_y(y_calib)
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator, RegressorMixin, clone
 from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
+from sklearn.model_selection import BaseCrossValidator
 from sklearn.pipeline import Pipeline
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import _check_y, indexable
@@ -1338,9 +1338,9 @@ class _MapieRegressor(RegressorMixin, BaseEstimator):
         sample_weight, X, y = _check_null_weight(sample_weight, X, y)
         self.n_features_in_ = _check_n_features_in(X)
 
-        assert isinstance(cv, (BaseCrossValidator, BaseShuffleSplit))
-        assert isinstance(estimator, RegressorMixin)
-        assert isinstance(cs_estimator, BaseRegressionScore)
+        cv = cast(BaseCrossValidator, cv)
+        estimator = cast(RegressorMixin, estimator)
+        cs_estimator = cast(BaseRegressionScore, cs_estimator)
         X = np.asarray(X)
         y = np.asarray(y)
         if sample_weight is not None:

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional, Tuple, Union, cast
+from typing import Any, Iterable, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from sklearn.base import BaseEstimator, RegressorMixin, clone
 from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import BaseCrossValidator
+from sklearn.model_selection import BaseCrossValidator, BaseShuffleSplit
 from sklearn.pipeline import Pipeline
 from sklearn.utils import check_random_state
 from sklearn.utils.validation import _check_y, indexable
@@ -1338,15 +1338,15 @@ class _MapieRegressor(RegressorMixin, BaseEstimator):
         sample_weight, X, y = _check_null_weight(sample_weight, X, y)
         self.n_features_in_ = _check_n_features_in(X)
 
-        # Casting
-        cv = cast(BaseCrossValidator, cv)
-        estimator = cast(RegressorMixin, estimator)
-        cs_estimator = cast(BaseRegressionScore, cs_estimator)
-        agg_function = cast(Optional[str], agg_function)
-        X = cast(NDArray, X)
-        y = cast(NDArray, y)
-        sample_weight = cast(Optional[NDArray], sample_weight)
-        groups = cast(Optional[NDArray], groups)
+        assert isinstance(cv, (BaseCrossValidator, BaseShuffleSplit))
+        assert isinstance(estimator, RegressorMixin)
+        assert isinstance(cs_estimator, BaseRegressionScore)
+        X = np.asarray(X)
+        y = np.asarray(y)
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight)
+        if groups is not None:
+            groups = np.asarray(groups)
 
         return (estimator, cs_estimator, agg_function, cv, X, y, sample_weight, groups)
 
@@ -1555,7 +1555,7 @@ class _MapieRegressor(RegressorMixin, BaseEstimator):
             _check_predict_params(self._predict_params, predict_params, self.cv)
         check_is_fitted(self)
         self._check_ensemble(ensemble)
-        alpha = cast(Optional[NDArray], _check_alpha(alpha))
+        alpha = _check_alpha(alpha)
 
         # If alpha is None, predict the target without confidence intervals
         if alpha is None:
@@ -1566,7 +1566,7 @@ class _MapieRegressor(RegressorMixin, BaseEstimator):
 
         else:
             # Check alpha and the number of effective calibration samples
-            alpha_np = cast(NDArray, alpha)
+            alpha_np = alpha
             if not allow_infinite_bounds:
                 n = self.conformity_score_function_.get_effective_calibration_samples(
                     self.conformity_scores_

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional, Tuple, Union, cast
+from typing import Iterable, Optional, Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -162,7 +162,7 @@ class TimeSeriesRegressor(_MapieRegressor):
             the length of the training set.
         """
         check_is_fitted(self)
-        X, y = cast(NDArray, X), cast(NDArray, y)
+        X, y = np.asarray(X), np.asarray(y)
         m, n = len(X), len(self.conformity_scores_)
         if m > n:
             raise ValueError(
@@ -227,14 +227,15 @@ class TimeSeriesRegressor(_MapieRegressor):
             self.current_alpha: dict[float, float] = {}
 
         if alpha is not None:
-            alpha_np = cast(NDArray, _check_alpha(alpha))
+            alpha_np = _check_alpha(alpha)
+            assert alpha_np is not None
             alpha_np = np.round(alpha_np, 2)
             for ix, alpha_checked in enumerate(alpha_np):
                 alpha_np[ix] = self.current_alpha.setdefault(
                     alpha_checked, alpha_checked
                 )
-            alpha = alpha_np
-        return alpha
+            return alpha_np
+        return None
 
     def adapt_conformal_inference(
         self,
@@ -301,13 +302,13 @@ class TimeSeriesRegressor(_MapieRegressor):
 
         check_is_fitted(self)
         self._check_gamma(gamma)
-        X, y = cast(NDArray, X), cast(NDArray, y)
+        X, y = np.asarray(X), np.asarray(y)
 
         self._get_alpha()
         alpha = self._transform_confidence_level_to_alpha_array(confidence_level)
         if alpha is None:
             alpha = np.array(list(self.current_alpha.keys()))
-        alpha_np = cast(NDArray, alpha)
+        alpha_np = np.asarray(alpha)
 
         for x_row, y_row in zip(X, y):
             x = np.expand_dims(x_row, axis=0)
@@ -488,7 +489,7 @@ class TimeSeriesRegressor(_MapieRegressor):
     def _transform_confidence_level_to_alpha_array(
         confidence_level: Optional[Union[float, Iterable[float]]] = None,
     ) -> Optional[NDArray]:
-        confidence_level = cast(Optional[NDArray], _check_alpha(confidence_level))
+        confidence_level = _check_alpha(confidence_level)
         if confidence_level is None:
             alpha = None
         else:

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable, Optional, Tuple, Union
+from typing import Iterable, Optional, Tuple, Union, cast
 from warnings import warn
 
 import numpy as np
@@ -227,8 +227,7 @@ class TimeSeriesRegressor(_MapieRegressor):
             self.current_alpha: dict[float, float] = {}
 
         if alpha is not None:
-            alpha_np = _check_alpha(alpha)
-            assert alpha_np is not None
+            alpha_np = cast(NDArray, _check_alpha(alpha))
             alpha_np = np.round(alpha_np, 2)
             for ix, alpha_checked in enumerate(alpha_np):
                 alpha_np[ix] = self.current_alpha.setdefault(

--- a/mapie/risk_control/methods.py
+++ b/mapie/risk_control/methods.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -403,8 +403,7 @@ def compute_hoeffding_bentkus_p_value(
     M. I., & Lei, L. (2021). Learn then test:
     "Calibrating predictive algorithms to achieve risk control".
     """
-    alpha_np = _check_alpha(alpha)
-    assert alpha_np is not None
+    alpha_np = cast(NDArray, _check_alpha(alpha))
     alpha_np = alpha_np[:, np.newaxis]
     r_hat_repeat = np.repeat(np.expand_dims(r_hat, axis=1), len(alpha_np), axis=1)
     alpha_repeat = np.repeat(alpha_np.reshape(1, -1), len(r_hat), axis=0)

--- a/mapie/risk_control/methods.py
+++ b/mapie/risk_control/methods.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -403,7 +403,8 @@ def compute_hoeffding_bentkus_p_value(
     M. I., & Lei, L. (2021). Learn then test:
     "Calibrating predictive algorithms to achieve risk control".
     """
-    alpha_np = cast(NDArray, _check_alpha(alpha))
+    alpha_np = _check_alpha(alpha)
+    assert alpha_np is not None
     alpha_np = alpha_np[:, np.newaxis]
     r_hat_repeat = np.repeat(np.expand_dims(r_hat, axis=1), len(alpha_np), axis=1)
     alpha_repeat = np.repeat(alpha_np.reshape(1, -1), len(r_hat), axis=0)

--- a/mapie/risk_control/multi_label_classification.py
+++ b/mapie/risk_control/multi_label_classification.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from itertools import chain
-from typing import Callable, Iterable, Optional, Sequence, Union, cast
+from typing import Callable, Iterable, Optional, Sequence, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -460,8 +460,8 @@ class MultiLabelClassificationController:
 
         X, y = indexable(X, y)
 
-        y = cast(NDArray, y)
-        X = cast(NDArray, X)
+        y = np.asarray(y)
+        X = np.asarray(X)
 
         self._check_all_labelled(y)
         self.n_samples_ = _num_samples(X)
@@ -497,12 +497,13 @@ class MultiLabelClassificationController:
         Compute optimal predict_params based on the computed risks.
         """
         if self._risk == precision:
+            assert self._delta is not None
             self.n_obs = len(self._risks)
             self.r_hat = self._risks.mean(axis=0)
             self.valid_index, _ = ltt_procedure(
                 np.expand_dims(self.r_hat, axis=0),
                 np.expand_dims(self._alpha, axis=0),
-                cast(float, self._delta),
+                float(self._delta),
                 np.expand_dims(np.array([self.n_obs]), axis=0),
             )
             self.valid_predict_params = []

--- a/mapie/risk_control/multi_label_classification.py
+++ b/mapie/risk_control/multi_label_classification.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from itertools import chain
-from typing import Callable, Iterable, Optional, Sequence, Union
+from typing import Callable, Iterable, Optional, Sequence, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -497,13 +497,13 @@ class MultiLabelClassificationController:
         Compute optimal predict_params based on the computed risks.
         """
         if self._risk == precision:
-            assert self._delta is not None
+            delta = cast(float, self._delta)
             self.n_obs = len(self._risks)
             self.r_hat = self._risks.mean(axis=0)
             self.valid_index, _ = ltt_procedure(
                 np.expand_dims(self.r_hat, axis=0),
                 np.expand_dims(self._alpha, axis=0),
-                float(self._delta),
+                delta,
                 np.expand_dims(np.array([self.n_obs]), axis=0),
             )
             self.valid_predict_params = []

--- a/mapie/risk_control/risks.py
+++ b/mapie/risk_control/risks.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Tuple, cast
+from typing import Callable, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -110,8 +110,7 @@ class BinaryClassificationRisk:
         risk_conditions = self._risk_condition(y_true, y_pred)
 
         effective_sample_size = y_true.size - np.sum(~risk_conditions)
-        # Casting needed for MyPy with Python 3.9
-        effective_sample_size_int = cast(int, effective_sample_size)
+        effective_sample_size_int = int(effective_sample_size)
         if effective_sample_size_int != 0.0:
             risk_sum: int = np.sum(risk_occurrences[risk_conditions])
             risk_value = risk_sum / effective_sample_size_int

--- a/mapie/risk_control/semantic_segmentation.py
+++ b/mapie/risk_control/semantic_segmentation.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Union, cast
+from typing import Sequence, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -34,7 +34,7 @@ class SemanticSegmentationController(MultiLabelClassificationController):
         """
         if not isinstance(y_pred_proba, np.ndarray):
             y_pred_proba = np.array(y_pred_proba)
-        y_pred_proba_array = cast(NDArray, y_pred_proba)  # for mypy
+        y_pred_proba_array = np.asarray(y_pred_proba)
 
         if np.min(y_pred_proba_array) < 0 or np.max(y_pred_proba_array) > 1:
             # Apply sigmoid to convert logits to probabilities

--- a/mapie/subsample.py
+++ b/mapie/subsample.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generator, Optional, Tuple, Union
+from typing import Any, Generator, Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view
@@ -188,8 +188,7 @@ class BlockBootstrap(BaseCrossValidator):  # type: ignore
             length = self.length if self.length is not None else n // self.n_blocks
             n_blocks = self.n_blocks
         else:
-            assert self.length is not None
-            length = self.length
+            length = cast(int, self.length)
             n_blocks = (n // length) + 1
 
         indices = np.arange(n)

--- a/mapie/subsample.py
+++ b/mapie/subsample.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Generator, Optional, Tuple, Union, cast
+from typing import Any, Generator, Optional, Tuple, Union
 
 import numpy as np
 from numpy.lib.stride_tricks import sliding_window_view
@@ -188,7 +188,8 @@ class BlockBootstrap(BaseCrossValidator):  # type: ignore
             length = self.length if self.length is not None else n // self.n_blocks
             n_blocks = self.n_blocks
         else:
-            length = cast(int, self.length)
+            assert self.length is not None
+            length = self.length
             n_blocks = (n // length) + 1
 
         indices = np.arange(n)

--- a/mapie/tests/test_conformity_scores_sets.py
+++ b/mapie/tests/test_conformity_scores_sets.py
@@ -1,11 +1,10 @@
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 import pytest
 import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.linear_model import LogisticRegression
 
-from numpy.typing import NDArray
 from mapie.classification import _MapieClassifier
 from mapie.conformity_scores import BaseClassificationScore
 from mapie.conformity_scores.sets import (
@@ -159,7 +158,8 @@ def test_get_last_included_proba_shape(k_lambda, include_last_label):
         thresholds = 0.2
     else:
         thresholds = np.random.rand(len(k))
-    thresholds = cast(NDArray, _check_alpha(thresholds))
+    thresholds = _check_alpha(thresholds)
+    assert thresholds is not None
     clf = LogisticRegression()
     clf.fit(X, y)
     y_pred_proba = clf.predict_proba(X)

--- a/mapie/tests/test_conformity_scores_sets.py
+++ b/mapie/tests/test_conformity_scores_sets.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import pytest
 import numpy as np
@@ -158,8 +158,7 @@ def test_get_last_included_proba_shape(k_lambda, include_last_label):
         thresholds = 0.2
     else:
         thresholds = np.random.rand(len(k))
-    thresholds = _check_alpha(thresholds)
-    assert thresholds is not None
+    thresholds = cast(np.ndarray, _check_alpha(thresholds))
     clf = LogisticRegression()
     clf.fit(X, y)
     y_pred_proba = clf.predict_proba(X)

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1353,8 +1353,7 @@ def _cast_point_predictions_to_ndarray(
             "Developer error: use this function to cast point predictions only, "
             "not points + intervals."
         )
-    assert not isinstance(point_predictions, tuple)
-    return point_predictions
+    return cast(NDArray, point_predictions)
 
 
 def _cast_predictions_to_ndarray_tuple(
@@ -1365,8 +1364,7 @@ def _cast_predictions_to_ndarray_tuple(
             "Developer error: use this function to cast predictions containing points "
             "and intervals, not points only."
         )
-    assert isinstance(predictions, tuple)
-    return predictions
+    return cast(Tuple[NDArray, NDArray], predictions)
 
 
 def _prepare_params(params: Union[dict, None]) -> dict:

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable as IterableType
 from decimal import Decimal
 from inspect import signature
 from math import isclose
-from typing import Any, Iterable, List, Optional, Tuple, Union, cast
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -235,7 +235,7 @@ def _check_null_weight(
         X = _safe_indexing(X, non_null_weight)
         y = _safe_indexing(y, non_null_weight)
         sample_weight = _safe_indexing(sample_weight, non_null_weight)
-        sample_weight = cast(NDArray, sample_weight)
+        sample_weight = np.asarray(sample_weight)
     return sample_weight, X, y
 
 
@@ -298,6 +298,12 @@ def _fit_estimator(
     return estimator
 
 
+def _random_seeds_from_state() -> NDArray:
+    """Return random seeds from current numpy RNG state for np.random.choice."""
+    state = np.random.get_state()
+    return np.asarray(state[1])  # type: ignore[index]
+
+
 def _check_cv(
     cv: Optional[Union[int, str, BaseCrossValidator, BaseShuffleSplit]] = None,
     test_size: Optional[Union[int, float]] = None,
@@ -343,8 +349,7 @@ def _check_cv(
         If the cross-validator is not valid.
     """
     if random_state is None:
-        random_seeds = cast(list, np.random.get_state())[1]
-        random_state = np.random.choice(random_seeds)
+        random_state = np.random.choice(_random_seeds_from_state())
     if cv is None:
         return KFold(n_splits=5, shuffle=True, random_state=random_state)
     elif isinstance(cv, int):
@@ -428,9 +433,9 @@ def _check_no_agg_cv(
 
 def _check_alpha(
     alpha: Optional[Union[float, Iterable[float]]] = None,
-) -> Optional[ArrayLike]:
+) -> Optional[NDArray]:
     """
-    Check alpha (or confidence_level) and prepare it as a ArrayLike.
+    Check alpha (or confidence_level) and prepare it as a NDArray.
 
     Parameters
     ----------
@@ -443,8 +448,8 @@ def _check_alpha(
 
     Returns
     -------
-    ArrayLike
-        Prepared alpha.
+    NDArray or None
+        Prepared alpha as 1D array, or None if alpha is None.
 
     Raises
     ------
@@ -481,6 +486,11 @@ def _check_alpha(
             "Invalid confidence_level or alpha. Allowed values are between 0 and 1."
         )
     return alpha_np
+
+
+def _column_or_1d_ndarray(y: ArrayLike, *, warn: bool = False) -> NDArray:
+    """Wrap column_or_1d to return NDArray for type checker."""
+    return np.asarray(column_or_1d(y, warn=warn))
 
 
 def _check_n_features_in(
@@ -535,7 +545,7 @@ def _check_n_features_in(
     else:
         n_features_in = _num_features(X)
     if cv == "prefit" and hasattr(estimator, "n_features_in_"):
-        if cast(Any, estimator).n_features_in_ != n_features_in:
+        if getattr(estimator, "n_features_in_", None) != n_features_in:
             raise ValueError(
                 "Invalid mismatch between ", "X.shape and estimator.n_features_in_."
             )
@@ -942,7 +952,7 @@ def _check_binary_zero_one(y_true: ArrayLike) -> NDArray:
     ValueError
         If the input array is not binary, then an error is raised.
     """
-    y_true = cast(NDArray, column_or_1d(y_true))
+    y_true = _column_or_1d_ndarray(y_true)
     if type_of_target(y_true) == "binary":
         if (np.unique(y_true) != np.array([0, 1])).any() and len(
             np.unique(y_true)
@@ -1343,7 +1353,8 @@ def _cast_point_predictions_to_ndarray(
             "Developer error: use this function to cast point predictions only, "
             "not points + intervals."
         )
-    return cast(NDArray, point_predictions)
+    assert not isinstance(point_predictions, tuple)
+    return point_predictions
 
 
 def _cast_predictions_to_ndarray_tuple(
@@ -1354,7 +1365,8 @@ def _cast_predictions_to_ndarray_tuple(
             "Developer error: use this function to cast predictions containing points "
             "and intervals, not points only."
         )
-    return cast(Tuple[NDArray, NDArray], predictions)
+    assert isinstance(predictions, tuple)
+    return predictions
 
 
 def _prepare_params(params: Union[dict, None]) -> dict:

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable as IterableType
 from decimal import Decimal
 from inspect import signature
 from math import isclose
-from typing import Any, Iterable, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray


### PR DESCRIPTION
# Description

### Summary

- **Removed all `typing.cast` usages** from the `mapie` package (code, tests, and examples) while keeping both the default and minimal-dependency type-checks passing. This was done by tightening return types, using `np.asarray`, and adding targeted `assert` / `isinstance`-based narrowing instead of casts.
- **Improved type helpers and interfaces**:
  - `_check_alpha` now returns `Optional[NDArray]`, and all callers use that concrete type (no casts on its result).
  - Added `_column_or_1d_ndarray` to wrap `sklearn.utils.validation.column_or_1d` and always return an `NDArray`, replacing all `cast(NDArray, column_or_1d(...))` call sites.
  - Rewrote `_cast_point_predictions_to_ndarray` and `_cast_predictions_to_ndarray_tuple` to rely on `isinstance` checks and `assert` for narrowing instead of casts.
- **Strengthened type narrowing and conversions at boundaries**:
  - Replaced many internal `cast(NDArray, X/y/...)` occurrences with a *single* boundary conversion via `np.asarray(...)` in classifiers, regressors, calibration, risk control, and conformity scores; optional arrays (e.g. `sample_weight`, `groups`) are converted only when not `None`.
  - For cross-validation objects, replaced `cast(BaseCrossValidator, cv)` with `assert isinstance(cv, (BaseCrossValidator, BaseShuffleSplit))` and used the narrowed `cv`.
  - In residual-based utilities and helpers, removed `cast(ArrayLike, X_)` and now pass/return `np.asarray(...)` where needed.
- **Bug fixes and edge-case handling**:
  - **RAPS regularization** (`mapie/conformity_scores/sets/raps.py`):
    - Fixed the bug in `_add_regularization` where `k_star` was incorrectly derived from `lambda_`.
    - Carefully handle `lambda_star` / `k_star` whether they are scalars or arrays, using intermediate variables and `np.asarray(...).item(0)` where needed; where old numpy stubs are too generic, added narrowly scoped `# type: ignore[assignment]` instead of reintroducing `cast`.
  - **Risk control**: made `effective_sample_size` and `_delta` handling explicitly integral/float using `int(...)` / `float(...)` plus asserts, rather than casts.
  - **Random state handling**: introduced `_random_seeds_from_state()` so that `np.random.get_state()` is accessed in one typed place, and replaced the previous cast-based indexing with this helper.
  - **Example script** (`examples/regression/2-advanced-analysis/plot_timeseries_enbpi.py`): removed `cast` and now use `np.asarray(result["y_pis"])`.
- **Compatibility with minimal requirements**:
  - Verified mypy passes under both the project’s dev environment and under the **minimal dependency constraints** (Python 3.9, `numpy==1.24.1`, `scikit-learn==1.4.*`, `scipy==1.10.*`) using:
    - `uv run --python 3.9 --with numpy==1.24.1 --with "scikit-learn==1.4.*" --with scipy==1.10.* --with mypy mypy mapie`
  - Where older numpy type stubs were overly generic (notably in RAPS), used very localized `# type: ignore[...]` comments on assignments to avoid reintroducing `cast()`.

Overall, this PR removes `cast()` calls across the codebase, replaces them with more precise typing and runtime checks, and keeps static typing green for both standard and minimal-dependency environments.



## LLM Usage
- [x] I used a Large Language Model (LLM) for this contribution.
- [x] I carefully reviewed and verified all LLM-generated content.

If you used an LLM, please provide the following details:

- **LLM used**: Cursor
- **Purpose**:code generation
