### PR TITLE
feat: expose `p0_p1_output` in `VennAbersCalibrator.predict_proba`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,5 +52,6 @@
 * Omid Gheibi <omidgheibi@gmail.com>
 * Aman Vishnoi <amanvishnoi777@gmail.com>
 * Hannes Körner <HannesMK>
+* Elaine Dias <LEDazzio01>
 
 To be continued ...

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,6 +52,6 @@
 * Omid Gheibi <omidgheibi@gmail.com>
 * Aman Vishnoi <amanvishnoi777@gmail.com>
 * Hannes Körner <HannesMK>
-* Elaine Dias <LEDazzio01>
+* L. Elaine Dazzio <LEDazzio01>
 
 To be continued ...

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,6 +52,6 @@
 * Omid Gheibi <omidgheibi@gmail.com>
 * Aman Vishnoi <amanvishnoi777@gmail.com>
 * Hannes Körner <HannesMK>
-* L. Elaine Dazzio <LEDazzio01>
+* L. Elaine Dazzio <elaine.dazzio@gmail.com>
 
 To be continued ...

--- a/mapie/calibration.py
+++ b/mapie/calibration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from inspect import signature
-from typing import Dict, Optional, Tuple, Union, cast
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -1059,7 +1059,9 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
         self._is_fitted = True
         return self
 
-    def predict_proba(self, X: ArrayLike, loss="log") -> NDArray:
+    def predict_proba(
+        self, X: ArrayLike, loss: str = "log", p0_p1_output: bool = False
+    ) -> Union[NDArray, Tuple[NDArray, Any]]:
         """
         Prediction of the calibrated scores using fitted classifier and
         Venn-ABERS calibrator.
@@ -1069,10 +1071,23 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
         X : ArrayLike of shape (n_samples, n_features)
             Test data.
 
+        loss : str, default='log'
+            Log or Brier loss function. Only used in inductive/cross-validation
+            mode. For further details see Section 4 in
+            https://arxiv.org/pdf/1511.00213.pdf
+
+        p0_p1_output : bool, default=False
+            If True, returns tuple of (calibrated_probs, p0_p1) where p0_p1
+            contains the Venn-ABERS multiprobability outputs. The (p0, p1)
+            interval can be reported alongside the calibrated probability as
+            a measure of uncertainty.
+
         Returns
         -------
         NDArray of shape (n_samples, n_classes)
             Venn-ABERS calibrated probabilities.
+            If ``p0_p1_output=True``, returns a tuple of
+            (calibrated_probs, p0_p1_data) instead.
         """
         check_is_fitted(self)
 
@@ -1102,10 +1117,10 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
                     raise RuntimeError(
                         "va_calibrator_ should not be None for binary classification"
                     )
-                p_prime, _ = self.va_calibrator_.predict_proba(p_test_pred)
+                p_prime, p0_p1 = self.va_calibrator_.predict_proba(p_test_pred)
             else:
                 # Multi-class classification
-                p_prime, _ = predict_proba_prefitted_va(
+                p_prime, p0_p1 = predict_proba_prefitted_va(
                     self.p_cal_,
                     self.y_cal_,
                     p_test_pred,
@@ -1113,6 +1128,8 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
                     va_tpe="one_vs_one",
                 )
 
+            if p0_p1_output:
+                return p_prime, p0_p1
             return cast(NDArray, p_prime)
 
         # Standard inductive or cross validation mode
@@ -1129,13 +1146,17 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             )
 
         if "loss" in signature(self.va_calibrator_.predict_proba).parameters:
-            p_prime = self.va_calibrator_.predict_proba(
-                X_processed, loss=loss, p0_p1_output=False
+            result = self.va_calibrator_.predict_proba(
+                X_processed, loss=loss, p0_p1_output=p0_p1_output
             )
         else:
-            p_prime = self.va_calibrator_.predict_proba(X_processed, p0_p1_output=False)
+            result = self.va_calibrator_.predict_proba(
+                X_processed, p0_p1_output=p0_p1_output
+            )
 
-        return cast(NDArray, p_prime)
+        if p0_p1_output:
+            return result
+        return cast(NDArray, result)
 
     def predict(self, X: ArrayLike, loss="log") -> NDArray:
         """
@@ -1158,7 +1179,7 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             raise RuntimeError("classes_ should not be None after fitting")
 
         # Get calibrated probabilities
-        p_prime = self.predict_proba(X, loss=loss)
+        p_prime = cast(NDArray, self.predict_proba(X, loss=loss))
 
         # Store classes_ in a local variable to help type checker
         classes: NDArray = self.classes_

--- a/mapie/calibration.py
+++ b/mapie/calibration.py
@@ -1153,9 +1153,11 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
                 )
 
             if p0_p1_output:
-                return p_prime, p0_p1
-            else:
-                return p_prime
+                return cast(
+                    Tuple[NDArray, Union[NDArray, list[NDArray]]],
+                    (p_prime, p0_p1),
+                )
+            return cast(NDArray, p_prime)
 
         # Standard inductive or cross validation mode
         if self.va_calibrator_ is None:
@@ -1180,9 +1182,8 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             )
 
         if p0_p1_output:
-            return result
-        else:
-            return result
+            return cast(Tuple[NDArray, Union[NDArray, list[NDArray]]], result)
+        return cast(NDArray, result)
 
     def predict(self, X: ArrayLike, loss="log") -> NDArray:
         """
@@ -1219,4 +1220,4 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             # Multi-class classification
             y_pred = classes[np.argmax(p_prime, axis=1)]
 
-        return y_pred
+        return cast(NDArray, y_pred)

--- a/mapie/calibration.py
+++ b/mapie/calibration.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import warnings
 from inspect import signature
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, Union, cast, overload
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -1059,9 +1064,28 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
         self._is_fitted = True
         return self
 
+    @overload
     def predict_proba(
-        self, X: ArrayLike, loss: str = "log", p0_p1_output: bool = False
-    ) -> Union[NDArray, Tuple[NDArray, Any]]:
+        self,
+        X: ArrayLike,
+        loss: str = ...,
+        p0_p1_output: Literal[False] = ...,
+    ) -> NDArray: ...
+
+    @overload
+    def predict_proba(
+        self,
+        X: ArrayLike,
+        loss: str = ...,
+        p0_p1_output: Literal[True] = ...,
+    ) -> Tuple[NDArray, Union[NDArray, List[Any]]]: ...
+
+    def predict_proba(
+        self,
+        X: ArrayLike,
+        loss: str = "log",
+        p0_p1_output: bool = False,
+    ) -> Union[NDArray, Tuple[NDArray, Union[NDArray, List[Any]]]]:
         """
         Prediction of the calibrated scores using fitted classifier and
         Venn-ABERS calibrator.
@@ -1077,17 +1101,27 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             https://arxiv.org/pdf/1511.00213.pdf
 
         p0_p1_output : bool, default=False
-            If True, returns tuple of (calibrated_probs, p0_p1) where p0_p1
-            contains the Venn-ABERS multiprobability outputs. The (p0, p1)
-            interval can be reported alongside the calibrated probability as
-            a measure of uncertainty.
+            If True, returns a tuple of ``(calibrated_probs, p0_p1_data)``
+            where ``p0_p1_data`` contains the Venn-ABERS multiprobability
+            outputs. The structure of ``p0_p1_data`` depends on the mode:
+
+            - **Prefit binary** (``cv='prefit'``, 2 classes): ``NDArray`` of
+              shape ``(n_samples, 2)`` where columns are ``[p0, p1]``.
+            - **Prefit multiclass** (``cv='prefit'``, >2 classes): list of
+              ``NDArray``, one per one-vs-one pair.
+            - **Inductive/CV binary**: list of length 1, where each element
+              is an ``NDArray`` of shape ``(n_samples, 2)``.
+            - **Inductive/CV multiclass**: list of ``NDArray``, one per
+              one-vs-one pair.
 
         Returns
         -------
         NDArray of shape (n_samples, n_classes)
             Venn-ABERS calibrated probabilities.
-            If ``p0_p1_output=True``, returns a tuple of
-            (calibrated_probs, p0_p1_data) instead.
+
+            If ``p0_p1_output=True``, returns a tuple
+            ``(calibrated_probs, p0_p1_data)`` instead. See the
+            ``p0_p1_output`` parameter for the structure of ``p0_p1_data``.
         """
         check_is_fitted(self)
 

--- a/mapie/calibration.py
+++ b/mapie/calibration.py
@@ -2,12 +2,7 @@ from __future__ import annotations
 
 import warnings
 from inspect import signature
-from typing import Any, Dict, List, Optional, Tuple, Union, cast, overload
-
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
+from typing import Dict, Literal, Optional, Tuple, Union, cast, overload
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -1068,24 +1063,21 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
     def predict_proba(
         self,
         X: ArrayLike,
-        loss: str = ...,
-        p0_p1_output: Literal[False] = ...,
+        loss: str = "log",
+        p0_p1_output: Literal[False] = False,
     ) -> NDArray: ...
 
     @overload
     def predict_proba(
         self,
         X: ArrayLike,
-        loss: str = ...,
-        p0_p1_output: Literal[True] = ...,
-    ) -> Tuple[NDArray, Union[NDArray, List[Any]]]: ...
+        loss: str = "log",
+        p0_p1_output: Literal[True] = True,
+    ) -> Tuple[NDArray, Union[NDArray, list[NDArray]]]: ...
 
     def predict_proba(
-        self,
-        X: ArrayLike,
-        loss: str = "log",
-        p0_p1_output: bool = False,
-    ) -> Union[NDArray, Tuple[NDArray, Union[NDArray, List[Any]]]]:
+        self, X: ArrayLike, loss: str = "log", p0_p1_output: bool = False
+    ) -> Union[NDArray, Tuple[NDArray, Union[NDArray, list[NDArray]]]]:
         """
         Prediction of the calibrated scores using fitted classifier and
         Venn-ABERS calibrator.
@@ -1101,27 +1093,25 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             https://arxiv.org/pdf/1511.00213.pdf
 
         p0_p1_output : bool, default=False
-            If True, returns a tuple of ``(calibrated_probs, p0_p1_data)``
-            where ``p0_p1_data`` contains the Venn-ABERS multiprobability
-            outputs. The structure of ``p0_p1_data`` depends on the mode:
-
-            - **Prefit binary** (``cv='prefit'``, 2 classes): ``NDArray`` of
-              shape ``(n_samples, 2)`` where columns are ``[p0, p1]``.
-            - **Prefit multiclass** (``cv='prefit'``, >2 classes): list of
-              ``NDArray``, one per one-vs-one pair.
-            - **Inductive/CV binary**: list of length 1, where each element
-              is an ``NDArray`` of shape ``(n_samples, 2)``.
-            - **Inductive/CV multiclass**: list of ``NDArray``, one per
-              one-vs-one pair.
+            If True, also returns ``p0_p1`` Venn-ABERS probabilistic outputs.
 
         Returns
         -------
         NDArray of shape (n_samples, n_classes)
             Venn-ABERS calibrated probabilities.
 
-            If ``p0_p1_output=True``, returns a tuple
-            ``(calibrated_probs, p0_p1_data)`` instead. See the
-            ``p0_p1_output`` parameter for the structure of ``p0_p1_data``.
+        p0_p1 : Union[NDArray, list[NDArray]], default=None
+            Venn-ABERS calibrated p0 and p1 outputs when
+            ``p0_p1_output=True``.
+
+            - For binary classification, this is an array.
+            - For multiclass classification, this is a list where each element
+              corresponds to one binary subproblem. The size of the list
+              corresponds to the number of one-vs-one or one-vs-all binary
+              problems. Each element is an array of shape
+              ``(n_samples, n_folds * 2)``, with the first ``n_folds`` entries
+              in each row corresponding to p0 outputs and the last
+              ``n_folds`` to p1 outputs.
         """
         check_is_fitted(self)
 
@@ -1164,7 +1154,8 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
 
             if p0_p1_output:
                 return p_prime, p0_p1
-            return cast(NDArray, p_prime)
+            else:
+                return p_prime
 
         # Standard inductive or cross validation mode
         if self.va_calibrator_ is None:
@@ -1190,7 +1181,8 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
 
         if p0_p1_output:
             return result
-        return cast(NDArray, result)
+        else:
+            return result
 
     def predict(self, X: ArrayLike, loss="log") -> NDArray:
         """
@@ -1213,7 +1205,7 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             raise RuntimeError("classes_ should not be None after fitting")
 
         # Get calibrated probabilities
-        p_prime = cast(NDArray, self.predict_proba(X, loss=loss))
+        p_prime = self.predict_proba(X, loss=loss)
 
         # Store classes_ in a local variable to help type checker
         classes: NDArray = self.classes_
@@ -1227,4 +1219,4 @@ class VennAbersCalibrator(BaseEstimator, ClassifierMixin):
             # Multi-class classification
             y_pred = classes[np.argmax(p_prime, axis=1)]
 
-        return cast(NDArray, y_pred)
+        return y_pred

--- a/mapie/tests/test_calibration.py
+++ b/mapie/tests/test_calibration.py
@@ -1385,4 +1385,3 @@ def test_va_calibrator_p0_p1_output_inductive_multiclass() -> None:
     assert isinstance(p0_p1, list)
     # Should have C*(C-1)/2 = 3 pairs for 3 classes
     assert len(p0_p1) == 3
-

--- a/mapie/tests/test_calibration.py
+++ b/mapie/tests/test_calibration.py
@@ -1309,3 +1309,80 @@ def test_va_inductive_loss_branch_and_else_branch() -> None:
     va_cal.va_calibrator_.predict_proba = predict_proba_no_loss  # type: ignore[method-assign]
     assert "loss" not in signature(va_cal.va_calibrator_.predict_proba).parameters
     _ = va_cal.predict_proba(X_binary_test, loss="log")
+
+
+@pytest.mark.filterwarnings("ignore:: RuntimeWarning")
+def test_va_calibrator_p0_p1_output_prefit_binary() -> None:
+    """Test VennAbersCalibrator.predict_proba(p0_p1_output=True) in prefit binary mode."""
+    clf = GaussianNB().fit(X_binary_proper, y_binary_proper)
+    va_cal = VennAbersCalibrator(estimator=clf, cv="prefit")
+    va_cal.fit(X_binary_cal, y_binary_cal)
+
+    # Without p0_p1 — returns NDArray
+    probs_only = va_cal.predict_proba(X_binary_test)
+    assert isinstance(probs_only, np.ndarray)
+    assert probs_only.shape == (len(X_binary_test), 2)
+
+    # With p0_p1 — returns tuple
+    result = va_cal.predict_proba(X_binary_test, p0_p1_output=True)
+    assert isinstance(result, tuple)
+    p_prime, p0_p1 = result
+    assert p_prime.shape == (len(X_binary_test), 2)
+    assert isinstance(p0_p1, np.ndarray)
+    assert p0_p1.shape == (len(X_binary_test), 2)
+    np.testing.assert_array_equal(probs_only, p_prime)
+
+
+@pytest.mark.filterwarnings("ignore:: RuntimeWarning")
+def test_va_calibrator_p0_p1_output_prefit_multiclass() -> None:
+    """Test VennAbersCalibrator.predict_proba(p0_p1_output=True) in prefit multiclass mode."""
+    clf = GaussianNB().fit(X_multi_proper, y_multi_proper)
+    va_cal = VennAbersCalibrator(estimator=clf, cv="prefit")
+    va_cal.fit(X_multi_cal, y_multi_cal)
+
+    result = va_cal.predict_proba(X_multi_test, p0_p1_output=True)
+    assert isinstance(result, tuple)
+    p_prime, p0_p1 = result
+    assert p_prime.shape == (len(X_multi_test), 3)
+    assert np.allclose(p_prime.sum(axis=1), 1.0)
+    assert isinstance(p0_p1, list)
+
+
+@pytest.mark.filterwarnings("ignore:: RuntimeWarning")
+def test_va_calibrator_p0_p1_output_inductive_binary() -> None:
+    """Test VennAbersCalibrator.predict_proba(p0_p1_output=True) in inductive binary mode."""
+    va_cal = VennAbersCalibrator(
+        estimator=GaussianNB(), inductive=True, random_state=random_state_va
+    )
+    va_cal.fit(X_binary_train, y_binary_train)
+
+    # Without p0_p1
+    probs_only = va_cal.predict_proba(X_binary_test)
+    assert isinstance(probs_only, np.ndarray)
+
+    # With p0_p1
+    result = va_cal.predict_proba(X_binary_test, p0_p1_output=True)
+    assert isinstance(result, tuple)
+    p_prime, p0_p1 = result
+    assert p_prime.shape == (len(X_binary_test), 2)
+    assert np.allclose(p_prime.sum(axis=1), 1.0)
+    assert isinstance(p0_p1, list)
+
+
+@pytest.mark.filterwarnings("ignore:: RuntimeWarning")
+def test_va_calibrator_p0_p1_output_inductive_multiclass() -> None:
+    """Test VennAbersCalibrator.predict_proba(p0_p1_output=True) in inductive multiclass mode."""
+    va_cal = VennAbersCalibrator(
+        estimator=GaussianNB(), inductive=True, random_state=random_state_va
+    )
+    va_cal.fit(X_multi_train, y_multi_train)
+
+    result = va_cal.predict_proba(X_multi_test, p0_p1_output=True)
+    assert isinstance(result, tuple)
+    p_prime, p0_p1 = result
+    assert p_prime.shape == (len(X_multi_test), 3)
+    assert np.allclose(p_prime.sum(axis=1), 1.0)
+    assert isinstance(p0_p1, list)
+    # Should have C*(C-1)/2 = 3 pairs for 3 classes
+    assert len(p0_p1) == 3
+


### PR DESCRIPTION
## Description

Closes #870

The internal `VennAbersCV.predict_proba` and `VennAbersMultiClass.predict_proba` already support a `p0_p1_output` parameter to return raw (p0, p1) multiprobability outputs. However, `VennAbersCalibrator.predict_proba` was hardcoding `p0_p1_output=False` and never exposing this parameter to users.

This PR:
- Adds `p0_p1_output: bool = False` parameter to `VennAbersCalibrator.predict_proba`
- Passes it through to all three code paths: prefit binary, prefit multiclass, and IVAP/CVAP
- When `True`, returns `Tuple[NDArray, p0_p1_data]` instead of just `NDArray`
- Updates the docstring with the new parameter and return type documentation

## Changes

- **`mapie/calibration.py`**: Modified `VennAbersCalibrator.predict_proba` signature and all internal call sites
- Added `Any` to typing imports for the return type annotation

## Testing

- All 102 existing `test_calibration.py` tests pass ✅
- Manually verified `p0_p1_output=True` works correctly for:
  - Binary IVAP
  - Multi-class IVAP
  - Prefit binary
  - Prefit multi-class