### PR TITLE
chore: modernize CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -39,12 +39,21 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
 
       - name: Install dependencies
         run: |
           pip install -e ".[docs]"
           echo "--- Installed mkdocstrings versions ---"
           pip show mkdocstrings mkdocstrings-python
+
+      - name: Restore gallery cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            doc/generated
+          key: ${{ runner.os }}-docs-gallery-${{ hashFiles('examples/**', 'mapie/**', 'mkdocs.yml', 'pyproject.toml', 'doc/hooks/**') }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,12 @@ jobs:
     name: Tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    env:
+      # Limit BLAS/OpenMP threads so xdist workers do not oversubscribe CPUs.
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
     strategy:
       # Keep running all matrix jobs to get complete compatibility signal.
       fail-fast: false
@@ -111,6 +117,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     continue-on-error: true
+    env:
+      # Limit BLAS/OpenMP threads so xdist workers do not oversubscribe CPUs.
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: CI
 
 on:
   push:
@@ -8,28 +8,60 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  build:
+  quality:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v4.3.0
+      - name: Set up Python
+        uses: actions/setup-python@v5.6.0
+        with:
+          python-version: "3.13"
+          check-latest: true
+      - name: Install project with development extras
+        run: python -m pip install -e '.[dev]'
+      - name: Check linting
+        run: make lint
+      - name: Check format
+        run: make format
+      - name: Check static typing
+        run: make type-check
+
+  tests:
+    name: Tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         include:
           # minimum supported dependencies
-          - os: self-hosted-ubuntu
+          - name: minimum-supported
+            os: self-hosted-ubuntu
             python-version: "3.9"
             use-pinned-deps: true
             numpy-version: "==1.24.1"
             sklearn-version: "==1.4.*"
             scipy-version: "==1.10.*"
-          # latest stable dependencies
-          - os: ubuntu-latest
-            python-version: "3.x"
+            run-long-tests: true
+          # latest supported environments
+          - name: ubuntu-latest
+            os: ubuntu-latest
+            python-version: "3.13"
             use-pinned-deps: false
-          - os: windows-latest
-            python-version: "3.x"
+            run-long-tests: true
+          - name: windows-latest
+            os: windows-latest
+            python-version: "3.13"
             use-pinned-deps: false
-          - os: macos-latest
-            python-version: "3.x"
+            run-long-tests: false
+          - name: macos-latest
+            os: macos-latest
+            python-version: "3.13"
             use-pinned-deps: false
+            run-long-tests: false
     defaults:
       run:
         shell: bash
@@ -48,14 +80,8 @@ jobs:
           python -m pip install "numpy${{ matrix.numpy-version }}" "scikit-learn${{ matrix.sklearn-version }}" "scipy${{ matrix.scipy-version }}"
       - name: Install project with development extras
         run: python -m pip install -e '.[dev]'
-      - name: Check linting
-        run: make lint
-      - name: Check format
-        run: make format
-      - name: Check static typing
-        run: make type-check
       - name: Test and coverage with pytest
         run: make coverage
       - name: Long tests with pytest
-        if: github.event_name == 'push' || !github.event.pull_request.draft
+        if: matrix.run-long-tests && (github.event_name == 'push' || !github.event.pull_request.draft)
         run: make long-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   quality:
+    name: Quality checks
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,21 +7,33 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  # Restrict the default GITHUB_TOKEN to read-only repository access.
+  contents: read
+
+concurrency:
+  # Cancel older runs for the same PR/branch when new commits arrive.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         shell: bash
 
     steps:
       - name: Git clone
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.13"
-          check-latest: true
+          # Reuse pip downloads/wheels between runs to speed up CI.
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install project with development extras
         run: python -m pip install -e '.[dev]'
       - name: Check linting
@@ -34,12 +46,15 @@ jobs:
   tests:
     name: Tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
+      # Keep running all matrix jobs to get complete compatibility signal.
+      fail-fast: false
       matrix:
         include:
           # minimum supported dependencies
           - name: minimum-supported
-            os: self-hosted-ubuntu
+            os: ubuntu-latest
             python-version: "3.9"
             use-pinned-deps: true
             numpy-version: "==1.24.1"
@@ -68,13 +83,16 @@ jobs:
 
     steps:
       - name: Git clone
-        uses: actions/checkout@v4.3.0
+        uses: actions/checkout@v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-          check-latest: true
+          # Reuse pip downloads/wheels between runs to speed up CI.
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install minimum dependency constraints
+        # Force the lowest supported dependency set for compatibility checks.
         if: ${{ matrix.use-pinned-deps }}
         run: |
           python -m pip install "numpy${{ matrix.numpy-version }}" "scikit-learn${{ matrix.sklearn-version }}" "scipy${{ matrix.scipy-version }}"
@@ -83,5 +101,33 @@ jobs:
       - name: Test and coverage with pytest
         run: make coverage
       - name: Long tests with pytest
+        # Skip on draft PRs to keep early feedback fast.
         if: matrix.run-long-tests && (github.event_name == 'push' || !github.event.pull_request.draft)
         run: make long-tests
+
+  latest-canary:
+    # Track upcoming Python and dependency updates without blocking merges.
+    name: Latest canary (non-blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    continue-on-error: true
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v6.0.2
+      - name: Set up latest Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.x"
+          check-latest: true
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install project with development extras
+        run: python -m pip install -e '.[dev]'
+      - name: Upgrade core scientific dependencies
+        run: python -m pip install --upgrade numpy scikit-learn scipy
+      - name: Canary test and coverage with pytest
+        run: make coverage

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,9 @@ type-check:
 	mypy mapie
 
 coverage:
-	pytest -vsx \
+	pytest -vx \
+		-n auto \
+		--dist=loadfile \
 		--doctest-modules \
 		--pyargs mapie \
 		--cov-branch \

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ plugins:
         - doc/generated/mondrian
       within_subsection_order: FileNameSortKey
       plot_gallery: true
+      # Reuse gallery caches to skip unchanged examples when possible.
+      run_stale_examples: true
       download_all_examples: false
       abort_on_example_error: false
       only_warn_on_example_error: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
     "pre-commit==4.0.1",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
+    "pytest-xdist==3.8.0",
     "ruff==0.14.3",
     "twine==6.2.0",
     "wheel==0.45.1",


### PR DESCRIPTION
- no typing on minimum requirements, just tests. Avoids "obselete" typing errors
- Modernized CI workflow structure by splitting checks into dedicated quality, tests, and non-blocking latest-canary jobs.
- Improved reliability and performance with explicit permissions, workflow concurrency cancellation, job timeout-minutes, fail-fast: false, and pip caching via actions/setup-python.
- Updated test matrix to run minimum-supported dependencies on ubuntu-latest with Python 3.9, plus cross-platform tests on Python 3.13 (ubuntu, windows, macos).
- Added a forward-compatibility canary lane using python-version: "3.x" + check-latest: true and upgraded core scientific dependencies, while keeping it non-blocking (continue-on-error: true).
- Upgraded GitHub Actions references to current tags: actions/checkout@v6.0.2 and actions/setup-python@v6.2.0.
- run tests in parallel (up to 2x faster)
- mkdocs caching of gallery and packages to accelerate execution