### PR TITLE
refactor: simplify sample_weight handling in quantile regression module

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ## 1.x.x (2026-xx-xx)
 * Simplify internal `sample_weight` handling in classification module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
+* Simplify internal `sample_weight` handling in quantile regression module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
+* Remove `_prepare_fit_params_and_sample_weight` utility (no longer needed after regression, classification, and quantile regression refactors). (issue #753)
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/regression/quantile_regression.py
+++ b/mapie/regression/quantile_regression.py
@@ -19,7 +19,6 @@ from mapie.utils import (
     _check_lower_upper_bounds,
     _check_null_weight,
     _fit_estimator,
-    _prepare_fit_params_and_sample_weight,
     _prepare_params,
     _raise_error_if_fit_called_in_prefit_mode,
     _raise_error_if_method_already_called,
@@ -119,7 +118,6 @@ class ConformalizedQuantileRegressor:
             alpha=self._alpha,
         )
 
-        self._sample_weight: Optional[ArrayLike] = None
         self._predict_params: dict = {}
 
     def fit(
@@ -154,14 +152,11 @@ class ConformalizedQuantileRegressor:
         _raise_error_if_fit_called_in_prefit_mode(self._prefit)
         _raise_error_if_method_already_called("fit", self._is_fitted)
 
-        fit_params_, self._sample_weight = _prepare_fit_params_and_sample_weight(
-            fit_params
-        )
+        fit_params_ = _prepare_params(fit_params)
         self._mapie_quantile_regressor._initialize_fit_conformalize()
         self._mapie_quantile_regressor._fit_estimators(
             X=X_train,
             y=y_train,
-            sample_weight=self._sample_weight,
             **fit_params_,
         )
 
@@ -688,7 +683,6 @@ class _MapieQuantileRegressor(_MapieRegressor):
         self,
         X: ArrayLike,
         y: ArrayLike,
-        sample_weight: Optional[ArrayLike] = None,
         groups: Optional[ArrayLike] = None,
         X_calib: Optional[ArrayLike] = None,
         y_calib: Optional[ArrayLike] = None,
@@ -713,18 +707,6 @@ class _MapieQuantileRegressor(_MapieRegressor):
 
         y: ArrayLike of shape (n_samples,)
             Training labels.
-
-        sample_weight: Optional[ArrayLike] of shape (n_samples,)
-            Sample weights for fitting the out-of-fold models.
-            If `None`, then samples are equally weighted.
-            If some weights are null,
-            their corresponding observations are removed
-            before the fitting process and hence have no residuals.
-            If weights are non-uniform, residuals are still uniformly weighted.
-            Note that the sample weight defined are only for the training, not
-            for the calibration procedure.
-
-            By default `None`.
 
         groups: Optional[ArrayLike] of shape (n_samples,)
             Always ignored, exists for compatibility.
@@ -766,6 +748,8 @@ class _MapieQuantileRegressor(_MapieRegressor):
 
         **fit_params : dict
             Additional fit parameters.
+            Sample weights can be passed as
+            ``sample_weight=...`` in the keyword arguments.
 
         Returns
         -------
@@ -777,6 +761,7 @@ class _MapieQuantileRegressor(_MapieRegressor):
         if self.cv == "prefit":
             X_calib, y_calib = X, y
         else:
+            sample_weight = fit_params.pop("sample_weight", None)
             result = self._prepare_train_calib(
                 X=X,
                 y=y,
@@ -790,9 +775,8 @@ class _MapieQuantileRegressor(_MapieRegressor):
                 stratify=stratify,
             )
             X_train, y_train, X_calib, y_calib, sample_weight = result
-            self._fit_estimators(
-                X=X_train, y=y_train, sample_weight=sample_weight, **fit_params
-            )
+            fit_params["sample_weight"] = sample_weight
+            self._fit_estimators(X=X_train, y=y_train, **fit_params)
 
         self.conformalize(X_calib, y_calib)
 
@@ -843,13 +827,13 @@ class _MapieQuantileRegressor(_MapieRegressor):
         self,
         X: ArrayLike,
         y: ArrayLike,
-        sample_weight: Optional[ArrayLike] = None,
         **fit_params,
     ) -> None:
         """
         Fits the estimators with provided training data
         and stores them in self.estimators_.
         """
+        sample_weight = fit_params.pop("sample_weight", None)
         checked_estimator = self._check_estimator(self.estimator)
 
         X, y = indexable(X, y)

--- a/mapie/tests/test_quantile_regression.py
+++ b/mapie/tests/test_quantile_regression.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from inspect import signature
 from typing import Any, Tuple
 
 import numpy as np
@@ -114,12 +113,6 @@ def test_default_parameters() -> None:
     assert mapie_reg.alpha == 0.1
 
 
-def test_default_sample_weight() -> None:
-    """Test default sample weights."""
-    mapie_reg = _MapieQuantileRegressor()
-    assert signature(mapie_reg.fit).parameters["sample_weight"].default is None
-
-
 def test_default_parameters_estimator() -> None:
     """Test default values of estimator."""
     mapie_reg = _MapieQuantileRegressor()
@@ -223,7 +216,7 @@ def test_results_with_constant_sample_weights(
     mapie0 = _MapieQuantileRegressor(estimator=qt, **STRATEGIES[strategy])
     mapie1 = _MapieQuantileRegressor(estimator=qt, **STRATEGIES[strategy])
     mapie2 = _MapieQuantileRegressor(estimator=qt, **STRATEGIES[strategy])
-    mapie0.fit(X_train, y_train, X_calib=X_calib, y_calib=y_calib, sample_weight=None)
+    mapie0.fit(X_train, y_train, X_calib=X_calib, y_calib=y_calib)
     mapie1.fit(
         X_train,
         y_train,
@@ -603,7 +596,6 @@ def test_fit_parameters_passing(strategy: str) -> None:
         y_train,
         X_calib=X_calib,
         y_calib=y_calib,
-        sample_weight=None,
         monitor=early_stopping_monitor,
     )
 

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -38,7 +38,6 @@ from mapie.utils import (
     _check_verbose,
     _compute_quantiles,
     _fit_estimator,
-    _prepare_fit_params_and_sample_weight,
     _prepare_params,
     _raise_error_if_fit_called_in_prefit_mode,
     _raise_error_if_method_already_called,
@@ -387,24 +386,6 @@ class TestCastPredictionsToNdarrayTuple:
 def test_prepare_params(params, expected):
     assert _prepare_params(params) == expected
     assert _prepare_params(params) is not params
-
-
-class TestPrepareFitParamsAndSampleWeight:
-    def test_uses_prepare_params(self):
-        with patch("mapie.utils._prepare_params") as mock_prepare_params:
-            _prepare_fit_params_and_sample_weight({"param1": 1})
-            mock_prepare_params.assert_called()
-
-    def test_with_sample_weight(self):
-        fit_params = {"sample_weight": [0.1, 0.2, 0.3]}
-        assert _prepare_fit_params_and_sample_weight(fit_params) == (
-            {},
-            [0.1, 0.2, 0.3],
-        )
-
-    def test_without_sample_weight(self):
-        params = {"param1": 1}
-        assert _prepare_fit_params_and_sample_weight(params) == (params, None)
 
 
 class TestRaiseErrorIfPreviousMethodNotCalled:

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1363,14 +1363,6 @@ def _prepare_params(params: Union[dict, None]) -> dict:
     return copy.deepcopy(params) if params else {}
 
 
-def _prepare_fit_params_and_sample_weight(
-    fit_params: Union[dict, None],
-) -> Tuple[dict, Optional[ArrayLike]]:
-    fit_params_ = _prepare_params(fit_params)
-    sample_weight = fit_params_.pop("sample_weight", None)
-    return fit_params_, sample_weight
-
-
 def _raise_error_if_previous_method_not_called(
     current_method_name: str,
     previous_method_name: str,


### PR DESCRIPTION
## Summary

Completes the three-phase simplification of internal `sample_weight` handling (issue #753):

| Phase | Module | PR | Status |
|-------|--------|----|--------|
| 1 | Regression | #902 | ✅ Merged |
| 2 | Classification | #908 | ✅ Merged |
| **3** | **Quantile Regression** | **This PR** | 🔄 Open |

### Changes

- `_MapieQuantileRegressor.fit()`: `sample_weight` is now extracted from `**fit_params` instead of being a separate parameter
- `_MapieQuantileRegressor._fit_estimators()`: same — extracted from `**fit_params`
- `ConformalizedQuantileRegressor.fit()`: uses `_prepare_params()` instead of `_prepare_fit_params_and_sample_weight()`
- **Remove `_prepare_fit_params_and_sample_weight`** from `utils.py` — zero callers remaining after all three phases
- Updated tests and `HISTORY.md`

### Design Notes

- **No public API changes.** The public `ConformalizedQuantileRegressor` still accepts `sample_weight` inside `fit_params` as before.
- `_prepare_train_calib` and `_train_calib_split` keep `sample_weight` as an explicit parameter since they need to split it alongside X/y (analogous to `EnsembleRegressor` and `EnsembleClassifier`).
- Both `# type: ignore[override]` markers are retained — the method signatures still intentionally diverge from the parent class.

### Testing

- All 114 quantile regression tests pass
- All 512 common + regression + utils tests pass  
- Lint (`ruff check`), format (`ruff format`), and type check (`mypy`) all clean

Fixes #753 (final phase)