### PR TITLE
docs: add MAPIE 0.docs: add MAPIE 0.x to 1.x migration guidex to 1.x migration guide

### DIFF
--- a/doc/getting-started/migration-0x-to-1x.md
+++ b/doc/getting-started/migration-0x-to-1x.md
@@ -1,0 +1,128 @@
+# MAPIE 0.x → 1.x Migration Guide
+
+## Overview
+
+MAPIE 1.x introduced a significant architectural redesign for conformal regression APIs.
+
+The previous unified `MapieRegressor` class used in MAPIE 0.x was replaced by specialized conformal regression classes in MAPIE 1.x.
+
+This guide helps users migrate older notebooks, Kaggle examples, tutorials, and production pipelines.
+
+## Class Mapping
+
++--------------------------------------+--------------------------------------+
+| MAPIE 0.x                            | MAPIE 1.x                            |
++======================================+======================================+
+| MapieRegressor(method='plus')        | CrossConformalRegressor              |
++--------------------------------------+--------------------------------------+
+| MapieRegressor(method='base')        | SplitConformalRegressor              |
++--------------------------------------+--------------------------------------+
+| method='quantile'                    | ConformalizedQuantileRegressor       |
++--------------------------------------+--------------------------------------+
+| bootstrap-based conformal            | JackknifeAfterBootstrapRegressor     |
++--------------------------------------+--------------------------------------+
+
+## Old API Example (0.x)
+
+.. code-block:: python
+
+```
+from mapie.regression import MapieRegressor
+
+mapie = MapieRegressor(
+    estimator=model,
+    method='plus',
+    cv=5
+)
+
+mapie.fit(X_train, y_train)
+
+y_pred, y_pis = mapie.predict(X_test, alpha=0.10)
+```
+
+## New API Example (1.x)
+
+.. code-block:: python
+
+```
+from mapie.regression import CrossConformalRegressor
+
+mapie = CrossConformalRegressor(
+    estimator=model,
+    method='plus',
+    cv=5,
+    confidence_level=0.90
+)
+
+mapie.fit(X_train, y_train)
+
+y_pred, y_pis = mapie.predict(X_test)
+```
+
+## Parameter Changes
+
++---------------------+----------------------+
+| MAPIE 0.x           | MAPIE 1.x            |
++=====================+======================+
+| alpha=0.10          | confidence_level=0.90|
++---------------------+----------------------+
+
+## Prediction Interval Shape Changes
+
+In MAPIE 0.x:
+
+.. code-block:: python
+
+```
+lower = y_pis[:, 0, 0]
+upper = y_pis[:, 1, 0]
+```
+
+In MAPIE 1.x:
+
+.. code-block:: python
+
+```
+lower = y_pis[:, 0]
+upper = y_pis[:, 1]
+```
+
+## Notebook / Kaggle Installation Warning
+
+When installing or downgrading MAPIE inside Jupyter, Kaggle, or Colab notebooks:
+
+.. code-block:: python
+
+```
+pip install mapie==<version>
+```
+
+Python may continue using the already-imported MAPIE module from `sys.modules`.
+
+This can create confusion where:
+
+* pip reports successful installation
+* but `mapie.__version__` still shows the old version
+
+Recommended workflow:
+
+.. code-block:: python
+
+```
+# install package
+pip install mapie==<version>
+
+# restart notebook kernel before importing again
+```
+
+## Environment Notes
+
+MAPIE 0.x may not fully support Python 3.12 environments.
+
+Users running:
+
+* Kaggle
+* Colab
+* Python 3.12+
+
+are encouraged to migrate toward MAPIE 1.x APIs instead of downgrading older versions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,6 +155,7 @@ nav:
     - Conformalization Set: getting-started/split-cross-conformal.md
     - Choosing the Right Algorithm: getting-started/choosing-algorithm.md
     - v1 Release Notes: getting-started/v1-release-notes.md
+    - Migration Guide 0.x to 1.x: getting-started/migration-0x-to-1x.md
   - Conformal Prediction:
     - Regression Theory: theory/regression.md
     - Conformity Scores: theory/conformity-scores.md


### PR DESCRIPTION
## What this PR does

Adds a migration guide for users upgrading from MAPIE 0.x to 1.x.

This PR addresses common migration confusion around:

* removal of `MapieRegressor`
* conformal regressor class replacements
* `alpha` → `confidence_level` API changes
* prediction interval shape changes
* notebook kernel restart behavior after installation

## Motivation

Many older tutorials, Kaggle notebooks, and examples still reference MAPIE 0.x APIs.

Users upgrading to MAPIE 1.x currently encounter:

* ImportError for `MapieRegressor`
* prediction unpacking confusion
* notebook installation/version mismatch confusion

This PR aims to improve onboarding and reduce migration friction for new users.

## Changes Included

* Added migration guide for MAPIE 0.x → 1.x
* Added old/new API examples
* Added migration mapping tables
* Added notebook installation warning
* Updated MkDocs navigation

## Environment Tested

```txt id="jlwm27"
Python 3.12
MAPIE 1.4.0
scikit-learn 1.6.1
Kaggle Notebook
```

## Related Issues

Closes #[#915]
