### PR TITLE
docs: add notebook kernel restart warning

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -53,5 +53,6 @@
 * Aman Vishnoi <amanvishnoi777@gmail.com>
 * Hannes Körner <HannesMK>
 * L. Elaine Dazzio <elaine.dazzio@gmail.com>
+*- Sarthak Bhide (@Tamish03) <neetasarthak26@gmail.com>
 
 To be continued ...

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 * Simplify internal `sample_weight` handling in classification module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
 * Simplify internal `sample_weight` handling in quantile regression module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
 * Remove `_prepare_fit_params_and_sample_weight` utility (no longer needed after regression, classification, and quantile regression refactors). (issue #753)
+* Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
 
 ## 1.4.0 (2026-04-30)
 

--- a/doc/getting-started/quick-start.md
+++ b/doc/getting-started/quick-start.md
@@ -15,6 +15,22 @@ This package allows you to easily estimate uncertainties in both regression and 
     ```bash
     pip install mapie
     ```
+    > **Notebook Users (Kaggle / Jupyter / Colab)**
+>
+> After installing, upgrading, or downgrading MAPIE inside notebook environments:
+>
+> ```bash
+> pip install mapie==<version>
+> ```
+>
+> restart the notebook kernel before importing MAPIE again.
+>
+> Python may continue using the already-imported module from `sys.modules`, which can lead to:
+>
+> * stale imports
+> * outdated `mapie.__version__`
+> * confusing version mismatch behavior
+
 
 === "conda"
 


### PR DESCRIPTION
## What this PR does

fixes #916 

Adds a notebook-specific installation warning for:

* Jupyter
* Kaggle
* Colab users

after installing/upgrading/downgrading MAPIE inside active notebook kernels.

## Motivation

Notebook environments cache imported Python modules inside `sys.modules`.

This can create confusion where:

* `pip install` succeeds
* but MAPIE still reports the previous version
* stale imports continue being used

This PR adds a small clarification to reduce onboarding confusion for notebook users.

## Changes Included

* Added notebook kernel restart warning
* Added explanation for stale module behavior

## Environment Tested

```txt id="2’wini76"
Python 3.12
Kaggle Notebook
MAPIE 1.4.0
```
