### PR TITLE
refactor: rename aggregate_predictions and ensemble to aggregate_point_predictions

### DIFF
--- a/doc_legacy/v1_release_notes.rst
+++ b/doc_legacy/v1_release_notes.rst
@@ -209,9 +209,8 @@ Regression-specific
 - **v0.x**: Previously, the ``agg_function`` parameter had two usage: to aggregate predictions when setting ``ensemble=True`` in the ``predict`` method of ``MapieRegressor``, and to specify the aggregation used in ``JackknifeAfterBootstrapRegressor``.
 - **v1**:
 
-  - The ``agg_function`` parameter has been split into two distinct parameters: ``aggregate_point_predictions`` and ``aggregation_method``. ``aggregate_point_predictions`` is specific to ``CrossConformalRegressor``, and it specifies how predictions from multiple conformal regressors are aggregated when making point predictions. ``aggregation_method`` is specific to ``JackknifeAfterBootstrapRegressor``, and it specifies the aggregation technique for combining predictions across different bootstrap samples during conformalization.
-  - The ``ensemble`` parameter in ``JackknifeAfterBootstrapRegressor`` has been renamed to ``aggregate_point_predictions`` for consistency.
-  - Note that for both cross conformal regression techniques, predictions points are now computed by default using mean aggregation. This is to avoid prediction points outside of prediction intervals in the default setting.
+  - The ``agg_function`` and ``ensemble`` parameters have been replaced by ``aggregate_point_predictions`` and ``aggregation_method``. Both ``CrossConformalRegressor`` and ``JackknifeAfterBootstrapRegressor`` now use ``aggregate_point_predictions`` in their ``predict_interval`` and ``predict`` methods to control whether point predictions are aggregated across fold/bootstrap models. In ``CrossConformalRegressor`` the parameter is an ``Optional[str]`` (``None``, ``"mean"``, or ``"median"``); in ``JackknifeAfterBootstrapRegressor`` it is a ``bool``, since the aggregation technique is set at initialization via the ``aggregation_method`` parameter.
+  - Note that for both cross conformal regression techniques, prediction points are now computed by default using mean aggregation. This is to avoid prediction points outside of prediction intervals in the default setting.
 
 ``symmetry``
 ..................................................

--- a/doc_legacy/v1_release_notes.rst
+++ b/doc_legacy/v1_release_notes.rst
@@ -209,7 +209,8 @@ Regression-specific
 - **v0.x**: Previously, the ``agg_function`` parameter had two usage: to aggregate predictions when setting ``ensemble=True`` in the ``predict`` method of ``MapieRegressor``, and to specify the aggregation used in ``JackknifeAfterBootstrapRegressor``.
 - **v1**:
 
-  - The ``agg_function`` parameter has been split into two distinct parameters: ``aggregate_predictions`` and ``aggregation_method``. ``aggregate_predictions`` is specific to ``CrossConformalRegressor``, and it specifies how predictions from multiple conformal regressors are aggregated when making point predictions. ``aggregation_method`` is specific to ``JackknifeAfterBootstrapRegressor``, and it specifies the aggregation technique for combining predictions across different bootstrap samples during conformalization.
+  - The ``agg_function`` parameter has been split into two distinct parameters: ``aggregate_point_predictions`` and ``aggregation_method``. ``aggregate_point_predictions`` is specific to ``CrossConformalRegressor``, and it specifies how predictions from multiple conformal regressors are aggregated when making point predictions. ``aggregation_method`` is specific to ``JackknifeAfterBootstrapRegressor``, and it specifies the aggregation technique for combining predictions across different bootstrap samples during conformalization.
+  - The ``ensemble`` parameter in ``JackknifeAfterBootstrapRegressor`` has been renamed to ``aggregate_point_predictions`` for consistency.
   - Note that for both cross conformal regression techniques, predictions points are now computed by default using mean aggregation. This is to avoid prediction points outside of prediction intervals in the default setting.
 
 ``symmetry``

--- a/examples/regression/2-advanced-analysis/plot_nested-cv.py
+++ b/examples/regression/2-advanced-analysis/plot_nested-cv.py
@@ -92,7 +92,7 @@ mapie_non_nested = CrossConformalRegressor(
 )
 mapie_non_nested.fit_conformalize(X_train, y_train)
 y_pred_non_nested, y_pis_non_nested = mapie_non_nested.predict_interval(
-    X_test, aggregate_predictions="median"
+    X_test, aggregate_point_predictions="median"
 )
 widths_non_nested = y_pis_non_nested[:, 1, 0] - y_pis_non_nested[:, 0, 0]
 coverage_non_nested = regression_coverage_score(y_test, y_pis_non_nested)[0]
@@ -120,7 +120,7 @@ mapie_nested = CrossConformalRegressor(
 )
 mapie_nested.fit_conformalize(X_train, y_train)
 y_pred_nested, y_pis_nested = mapie_nested.predict_interval(
-    X_test, aggregate_predictions="median"
+    X_test, aggregate_point_predictions="median"
 )
 widths_nested = y_pis_nested[:, 1, 0] - y_pis_nested[:, 0, 0]
 coverage_nested = regression_coverage_score(y_test, y_pis_nested)[0]

--- a/examples/regression/3-scientific-articles/plot_barber2020_simulations.py
+++ b/examples/regression/3-scientific-articles/plot_barber2020_simulations.py
@@ -127,7 +127,7 @@ def PIs_vs_dimensions(
                 )
                 mapie.fit_conformalize(X_train, y_train)
                 _, y_pis = mapie.predict_interval(
-                    X_test, aggregate_predictions="median"
+                    X_test, aggregate_point_predictions="median"
                 )
                 coverage = regression_coverage_score(y_test, y_pis)[0]
                 results[strategy][dimension]["coverage"][trial] = coverage

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -484,7 +484,7 @@ class CrossConformalRegressor:
     def predict_interval(
         self,
         X: ArrayLike,
-        aggregate_predictions: Optional[str] = "mean",
+        aggregate_point_predictions: Optional[str] = "mean",
         minimize_interval_width: bool = False,
         allow_infinite_bounds: bool = False,
     ) -> Tuple[NDArray, NDArray]:
@@ -495,14 +495,14 @@ class CrossConformalRegressor:
         intervals will be predicted for each sample. See the return signature.
 
         By default, points are predicted using an aggregation.
-        See the `ensemble` parameter.
+        See the `aggregate_point_predictions` parameter.
 
         Parameters
         ----------
         X : ArrayLike
             Features
 
-        aggregate_predictions : Optional[str], default="mean"
+        aggregate_point_predictions : Optional[str], default="mean"
             The method to predict a point. Options:
 
             - None: a point is predicted using the regressor trained on the entire data
@@ -531,8 +531,8 @@ class CrossConformalRegressor:
             self.is_fitted_and_conformalized,
         )
 
-        ensemble = self._set_aggregate_predictions_and_return_ensemble(
-            aggregate_predictions
+        ensemble = self._set_aggregate_point_predictions_and_return_ensemble(
+            aggregate_point_predictions
         )
         predictions = self._mapie_regressor.predict(
             X,
@@ -547,20 +547,20 @@ class CrossConformalRegressor:
     def predict(
         self,
         X: ArrayLike,
-        aggregate_predictions: Optional[str] = "mean",
+        aggregate_point_predictions: Optional[str] = "mean",
     ) -> NDArray:
         """
         Predicts points.
 
         By default, points are predicted using an aggregation.
-        See the `ensemble` parameter.
+        See the `aggregate_point_predictions` parameter.
 
         Parameters
         ----------
         X : ArrayLike
             Features
 
-        aggregate_predictions : Optional[str], default="mean"
+        aggregate_point_predictions : Optional[str], default="mean"
             The method to predict a point. Options:
 
             - None: a point is predicted using the regressor trained on the entire data
@@ -580,8 +580,8 @@ class CrossConformalRegressor:
             self.is_fitted_and_conformalized,
         )
 
-        ensemble = self._set_aggregate_predictions_and_return_ensemble(
-            aggregate_predictions
+        ensemble = self._set_aggregate_point_predictions_and_return_ensemble(
+            aggregate_point_predictions
         )
         predictions = self._mapie_regressor.predict(
             X,
@@ -591,16 +591,16 @@ class CrossConformalRegressor:
         )
         return _cast_point_predictions_to_ndarray(predictions)
 
-    def _set_aggregate_predictions_and_return_ensemble(
-        self, aggregate_predictions: Optional[str]
+    def _set_aggregate_point_predictions_and_return_ensemble(
+        self, aggregate_point_predictions: Optional[str]
     ) -> bool:
-        if not aggregate_predictions:
+        if not aggregate_point_predictions:
             ensemble = False
         else:
             ensemble = True
-            self._mapie_regressor._check_agg_function(aggregate_predictions)
+            self._mapie_regressor._check_agg_function(aggregate_point_predictions)
             # A hack here, to allow choosing the aggregation function at prediction time
-            self._mapie_regressor.agg_function = aggregate_predictions
+            self._mapie_regressor.agg_function = aggregate_point_predictions
         return ensemble
 
 
@@ -789,7 +789,7 @@ class JackknifeAfterBootstrapRegressor:
     def predict_interval(
         self,
         X: ArrayLike,
-        ensemble: bool = True,
+        aggregate_point_predictions: bool = True,
         minimize_interval_width: bool = False,
         allow_infinite_bounds: bool = False,
     ) -> Tuple[NDArray, NDArray]:
@@ -800,14 +800,14 @@ class JackknifeAfterBootstrapRegressor:
         intervals will be predicted for each sample. See the return signature.
 
         By default, points are predicted using an aggregation.
-        See the `ensemble` parameter.
+        See the `aggregate_point_predictions` parameter.
 
         Parameters
         ----------
         X : ArrayLike
             Test data for prediction intervals.
 
-        ensemble : bool, default=True
+        aggregate_point_predictions : bool, default=True
             If True, a predicted point is an aggregation of the predictions of the
             regressors trained on each bootstrap samples. This aggregation depends on
             the `aggregation_method` provided during initialisation.
@@ -840,7 +840,7 @@ class JackknifeAfterBootstrapRegressor:
             alpha=self._alphas,
             optimize_beta=minimize_interval_width,
             allow_infinite_bounds=allow_infinite_bounds,
-            ensemble=ensemble,
+            ensemble=aggregate_point_predictions,
             **self._predict_params,
         )
         return _cast_predictions_to_ndarray_tuple(predictions)
@@ -848,20 +848,20 @@ class JackknifeAfterBootstrapRegressor:
     def predict(
         self,
         X: ArrayLike,
-        ensemble: bool = True,
+        aggregate_point_predictions: bool = True,
     ) -> NDArray:
         """
         Predicts points.
 
         By default, points are predicted using an aggregation.
-        See the `ensemble` parameter.
+        See the `aggregate_point_predictions` parameter.
 
         Parameters
         ----------
         X : ArrayLike
             Data features for generating point predictions.
 
-        ensemble : bool, default=True
+        aggregate_point_predictions : bool, default=True
             If True, a predicted point is an aggregation of the predictions of the
             regressors trained on each bootstrap samples. This aggregation depends on
             the `aggregation_method` provided during initialisation.
@@ -882,7 +882,7 @@ class JackknifeAfterBootstrapRegressor:
         predictions = self._mapie_regressor.predict(
             X,
             alpha=None,
-            ensemble=ensemble,
+            ensemble=aggregate_point_predictions,
             **self._predict_params,
         )
         return _cast_point_predictions_to_ndarray(predictions)

--- a/mapie/tests/test_non_regression.py
+++ b/mapie/tests/test_non_regression.py
@@ -359,10 +359,10 @@ params_test_cases_regression_cross = [
             "fit_params": {"sample_weight": sample_weight},
         },
         "predict_interval": {
-            "aggregate_predictions": "median",
+            "aggregate_point_predictions": "median",
         },
         "predict": {
-            "aggregate_predictions": "median",
+            "aggregate_point_predictions": "median",
         },
     },
     {
@@ -391,10 +391,10 @@ params_test_cases_regression_cross = [
         },
         "predict_interval": {
             "allow_infinite_bounds": True,
-            "aggregate_predictions": None,
+            "aggregate_point_predictions": None,
         },
         "predict": {
-            "aggregate_predictions": None,
+            "aggregate_point_predictions": None,
         },
     },
 ]


### PR DESCRIPTION
Closes #906

## Summary

Renames parameters for consistency and clarity across the regression module:

- **`CrossConformalRegressor`**: `aggregate_predictions` → `aggregate_point_predictions` in `predict_interval()` and `predict()`
- **`JackknifeAfterBootstrapRegressor`**: `ensemble` → `aggregate_point_predictions` in `predict_interval()` and `predict()`

Also updates:
- All related notebooks (`plot_barber2020_simulations.py`, `plot_nested-cv.py`)
- Non-regression tests
- Migration guide (`v1_release_notes.rst`)

## Notes

- The parameter **types are preserved**: `Optional[str]` for `CrossConformalRegressor` (accepts `None`, `"mean"`, `"median"`) and `bool` for `JackknifeAfterBootstrapRegressor` (since its aggregation method is set at `__init__` time via `aggregation_method`).
- No behavioral changes — this is a pure rename refactor.
- All existing tests pass (313 regression + 23 non-regression).