### PR TITLE
fix: make optimize_beta actually minimize prediction interval width

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,5 +54,6 @@
 * Hannes Körner <HannesMK>
 * L. Elaine Dazzio <elaine.dazzio@gmail.com>
 *- Sarthak Bhide (@Tamish03) <neetasarthak26@gmail.com>
+* Imran Ahamed <immu4989@gmail.com>
 
 To be continued ...

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 * Simplify internal `sample_weight` handling in quantile regression module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
 * Remove `_prepare_fit_params_and_sample_weight` utility (no longer needed after regression, classification, and quantile regression refactors). (issue #753)
 * Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
+* Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/conformity_scores/regression.py
+++ b/mapie/conformity_scores/regression.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABCMeta, abstractmethod
 from typing import Tuple, cast
 
@@ -186,7 +185,7 @@ class BaseRegressionScore(BaseConformityScore, metaclass=ABCMeta):
 
         Parameters
         ----------
-        alpha_np: NDArray
+        alpha_np: NDArray of shape (n_alpha,)
             The quantiles to compute.
 
         upper_bounds: NDArray of shape (n_samples,)
@@ -197,45 +196,36 @@ class BaseRegressionScore(BaseConformityScore, metaclass=ABCMeta):
 
         Returns
         -------
-        NDArray of shape (n_samples,)
+        NDArray of shape (n_alpha,)
             Array of betas minimizing the differences
             `(1-alpha+beta)-quantile - beta-quantile`.
         """
-        # Using logging.warning instead of warnings.warn to avoid warnings during tests
-        logging.warning(
-            "The option to optimize beta (minimize interval width) is not working and "
-            "needs to be fixed. See more details in "
-            "https://github.com/scikit-learn-contrib/MAPIE/issues/588"
-        )
-
+        n = len(lower_bounds)
+        upper_f = upper_bounds.astype(float)
+        lower_f = lower_bounds.astype(float)
         beta_np = cast(
             NDArray[np.float64],
-            np.full(
-                shape=(len(lower_bounds), len(alpha_np)),
-                fill_value=np.nan,
-                dtype=float,
-            ),
+            np.full(shape=(len(alpha_np),), fill_value=np.nan, dtype=float),
         )
         for ind_alpha, _alpha in enumerate(alpha_np):
+            _alpha = float(_alpha)
             betas = np.linspace(
-                _alpha / (len(lower_bounds) + 1),
+                _alpha / (n + 1),
                 _alpha,
-                num=len(lower_bounds),
+                num=n,
                 endpoint=True,
             )
             one_alpha_beta = np.nanquantile(
-                upper_bounds.astype(float),
+                upper_f,
                 1 - _alpha + betas,
-                axis=1,
                 method="higher",
             )
             beta = np.nanquantile(
-                lower_bounds.astype(float),
+                lower_f,
                 betas,
-                axis=1,
                 method="lower",
             )
-            beta_np[:, ind_alpha] = betas[np.argmin(one_alpha_beta - beta, axis=0)]
+            beta_np[ind_alpha] = betas[np.argmin(one_alpha_beta - beta)]
 
         return beta_np
 
@@ -319,8 +309,8 @@ class BaseRegressionScore(BaseConformityScore, metaclass=ABCMeta):
         if optimize_beta:
             beta_np = self._beta_optimize(
                 alpha_np,
-                conformity_scores.reshape(1, -1),
-                conformity_scores.reshape(1, -1),
+                conformity_scores,
+                conformity_scores,
             )
         else:
             beta_np = alpha_np / 2

--- a/mapie/tests/test_conformity_scores_bounds.py
+++ b/mapie/tests/test_conformity_scores_bounds.py
@@ -411,3 +411,32 @@ def test_intervals_shape_with_every_score(
     n_samples = X_toy.shape[0]
     assert y_pred.shape[0] == n_samples
     assert intervals.shape == (n_samples, 2, len(alpha))
+
+
+@pytest.mark.parametrize(
+    "alpha_np",
+    [np.array([0.1]), np.array([0.1, 0.2, 0.5])],
+)
+def test_beta_optimize_shape_and_range(alpha_np: NDArray) -> None:
+    rng = np.random.default_rng(random_state)
+    conformity_scores = rng.standard_normal(50)
+    beta_np = AbsoluteConformityScore._beta_optimize(
+        alpha_np, conformity_scores, conformity_scores
+    )
+    n = len(conformity_scores)
+    assert beta_np.shape == (len(alpha_np),)
+    assert beta_np.dtype == np.float64
+    assert not np.isnan(beta_np).any()
+    for ind, _alpha in enumerate(alpha_np):
+        assert _alpha / (n + 1) <= beta_np[ind] <= _alpha
+
+
+def test_beta_optimize_handles_float32_alpha() -> None:
+    rng = np.random.default_rng(random_state)
+    conformity_scores = rng.standard_normal(50)
+    alpha_np = np.array([0.1, 0.2], dtype=np.float32)
+    beta_np = AbsoluteConformityScore._beta_optimize(
+        alpha_np, conformity_scores, conformity_scores
+    )
+    assert beta_np.shape == (2,)
+    assert not np.isnan(beta_np).any()

--- a/mapie/tests/test_non_regression.py
+++ b/mapie/tests/test_non_regression.py
@@ -491,11 +491,7 @@ def test_cross_and_jackknife(params: dict) -> None:
     ) = run_pipeline_cross_or_jackknife(params)
 
     np.testing.assert_array_equal(preds_using_predict, preds)
-
-    if not minimize_interval_width:
-        # condition to remove when optimize_beta/minimize_interval_width works
-        # but keep assertion to check shapes
-        assert pred_intervals.shape == (X_test_length, 2, n_confidence_level)
+    assert pred_intervals.shape == (X_test_length, 2, n_confidence_level)
 
 
 params_test_cases_regression_split = [

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -71,8 +71,8 @@ STRATEGIES = {
 }
 
 WIDTHS = {
-    "blockbootstrap_enbpi_mean_wopt": 3.89,
-    "blockbootstrap_enbpi_median_wopt": 3.85,
+    "blockbootstrap_enbpi_mean_wopt": 3.84,
+    "blockbootstrap_enbpi_median_wopt": 3.89,
     "blockbootstrap_enbpi_mean": 3.89,
     "blockbootstrap_enbpi_median": 3.85,
     "blockbootstrap_aci_mean": 3.89,  # same as enbpi
@@ -408,7 +408,7 @@ def test_interval_prediction_with_beta_optimize() -> None:
     _, y_pis = mapie_ts_reg.predict(X_test, confidence_level=0.95, optimize_beta=True)
     width_mean = (y_pis[:, 1, 0] - y_pis[:, 0, 0]).mean()
     coverage = regression_coverage_score(y_test, y_pis)[0]
-    np.testing.assert_allclose(width_mean, 3.67, rtol=1e-2)
+    np.testing.assert_allclose(width_mean, 3.59, rtol=1e-2)
     np.testing.assert_allclose(coverage, 0.916, rtol=1e-2)
 
 


### PR DESCRIPTION

# Description

`_beta_optimize` has been a silent no-op since MAPIE v0.4 (per @Valentin-Laurent's
analysis in #588). The caller in `BaseRegressionScore.get_bounds` reshaped
`conformity_scores` to `(1, n)` before passing it to `_beta_optimize`, which
made `len(lower_bounds) == 1` inside the function and collapsed the β-search
grid (`np.linspace(α/(n+1), α, num=n)`) to a single candidate. The output
shape `(n_samples, n_alpha)` also mismatched the non-optimize branch
(`alpha_np / 2`, shape `(n_alpha,)`), producing the wrong prediction-interval
shape when `optimize_beta=True` was used with multiple confidence levels,
the symptom reported in #484.

This PR fixes the four defects enumerated in #588:

1. **Reshape collapsing the search grid** : drop `.reshape(1, -1)` in
   `get_bounds`; pass `conformity_scores` directly as 1D.
2. **`len(lower_bounds)` always 1** : auto-resolved once the reshape is gone.
3. **`_alpha` dtype handling in `enumerate`** — cast `float(_alpha)` at the
   top of the loop to neutralize numpy 2.x dtype-promotion surprises when
   `alpha_np` is `float32`.
4. **Wrong PI shape with a list of alphas** : `_beta_optimize` now returns
   shape `(n_alpha,)`, matching the non-optimize branch.

The two argument signature for `lower_bounds` / `upper_bounds` is kept
unchanged , per @Valentin-Laurent's clarification in the issue thread,
this is intentional for CQR (conformalized quantile regression), where
the lower and upper residual distributions can differ from one another.

Also removed the `logging.warning` (and `import logging`) that flagged the
broken state.

Fixes #588.
Also resolves #484 (`ValueError` on multiple prediction intervals in the
time series tutorial with `optimize_beta=True`).

## Type of change

- Bug fix (non breaking change which fixes an issue)

# How Has This Been Tested?

Full local CI passes: `make lint && make format && make type-check && make coverage`
, **2522 tests passing, 100% coverage** in 1m 43s.

- [x] **New focused unit tests** in `test_conformity_scores_bounds.py`:
  - `test_beta_optimize_shape_and_range` (parameterized over single and
    multi alpha): pins output shape `(n_alpha,)`, dtype `float64`, no NaNs,
    and that each β lies in the search grid range `[α/(n+1), α]`.
  - `test_beta_optimize_handles_float32_alpha`: pins the dtype-cast fix.
- [x] **`test_non_regression.py`**: removed the
  `if not minimize_interval_width:` guard around the shape assertion.
  The assertion `pred_intervals.shape == (X_test_length, 2, n_confidence_level)`
  now fires for the multi-alpha + `optimize_beta=True` test cases , the
  exact surface that reproduced #484.
- [x] **`test_time_series_regression.py`**: the two `_wopt` strategies in
  the `WIDTHS` table previously had values identical to their non-`_wopt`
  counterparts (3.89 == 3.89, 3.85 == 3.85) , a direct fingerprint of the
  no-op. After the fix: optimized-mean drops to 3.84 (narrower, as
  expected); optimized-median moves to 3.89 (β picked away from α/2 by
  the optimizer); coverage held at 0.956 in both cases within `rtol=1e-2`.
  The inline expected `width_mean` in
  `test_interval_prediction_with_beta_optimize` was similarly recomputed
  (3.67 → 3.59).

Reproduce:
uv sync --python 3.12 --extra dev --extra docs --extra notebooks
make lint && make format && make type-check && make coverage



# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`

## Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) and [AUTHORS.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.md) files

