### PR TITLE
fix: add defensive validation for sample_weight routing

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 * Remove `_prepare_fit_params_and_sample_weight` utility (no longer needed after regression, classification, and quantile regression refactors). (issue #753)
 * Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
 * Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
+* Add defensive validation: `_MapieRegressor` and `_MapieClassifier` now raise `TypeError` when `sample_weight` is passed as a top-level keyword argument instead of inside `fit_params`. Previously, top-level `sample_weight` was silently ignored. Also fix `TimeSeriesRegressor` tests that were affected by the same silent-ignore bug.
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -28,6 +28,7 @@ from mapie.utils import (
     _check_alpha_and_n_samples,
     _check_cv,
     _check_cv_not_string,
+    _check_deprecated_sample_weight_kwarg,
     _check_estimator_classification,
     _check_n_features_in,
     _check_n_jobs,
@@ -897,6 +898,7 @@ class _MapieClassifier(ClassifierMixin, BaseEstimator):
             The model itself.
         """
         self._fit_params = _prepare_params(kwargs.pop("fit_params", {}))
+        _check_deprecated_sample_weight_kwarg(kwargs)
         predict_params = kwargs.pop("predict_params", {})
 
         if len(predict_params) > 0:

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -25,6 +25,7 @@ from mapie.utils import (
     _check_alpha_and_n_samples,
     _check_cv,
     _check_cv_not_string,
+    _check_deprecated_sample_weight_kwarg,
     _check_estimator_fit_predict,
     _check_if_param_in_allowed_values,
     _check_n_features_in,
@@ -1404,6 +1405,7 @@ class _MapieRegressor(RegressorMixin, BaseEstimator):
         **kwargs: Any,
     ):
         self._fit_params = _prepare_params(kwargs.pop("fit_params", {}))
+        _check_deprecated_sample_weight_kwarg(kwargs)
 
         # Checks
         (

--- a/mapie/tests/test_classification.py
+++ b/mapie/tests/test_classification.py
@@ -1699,3 +1699,11 @@ def test_mapieclassifier_cv_string_check():
 
     with pytest.raises(ValueError, match=r'.*must be equal to "prefit".*'):
         _MapieClassifier(estimator=clf, cv="crossval")
+
+
+def test_sample_weight_as_top_level_kwarg_raises() -> None:
+    """Ensure sample_weight must be passed inside fit_params, not as a kwarg."""
+    clf = LogisticRegression().fit(X_toy, y_toy)
+    mapie_clf = _MapieClassifier(estimator=clf, cv="prefit")
+    with pytest.raises(TypeError, match="fit_params"):
+        mapie_clf.fit(X_toy, y_toy, sample_weight=np.ones(len(X_toy)))

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -1082,3 +1082,10 @@ def test_invalid_method(method: str) -> None:
         ValueError, match="(Invalid method.)|(Invalid conformity score.)*"
     ):
         mapie_estimator.fit(X_toy, y_toy)
+
+
+def test_sample_weight_as_top_level_kwarg_raises() -> None:
+    """Ensure sample_weight must be passed inside fit_params, not as a kwarg."""
+    mapie_reg = _MapieRegressor(cv="prefit", estimator=LinearRegression().fit(X, y))
+    with pytest.raises(TypeError, match="fit_params"):
+        mapie_reg.fit(X, y, sample_weight=np.ones(len(X)))

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -223,9 +223,9 @@ def test_results_with_constant_sample_weights(strategy: str) -> None:
     mapie0 = TimeSeriesRegressor(**STRATEGIES[strategy])
     mapie1 = TimeSeriesRegressor(**STRATEGIES[strategy])
     mapie2 = TimeSeriesRegressor(**STRATEGIES[strategy])
-    mapie0.fit(X, y, sample_weight=None)
-    mapie1.fit(X, y, sample_weight=np.ones(shape=n_samples))
-    mapie2.fit(X, y, sample_weight=np.ones(shape=n_samples) * 5)
+    mapie0.fit(X, y)
+    mapie1.fit(X, y, fit_params={"sample_weight": np.ones(shape=n_samples)})
+    mapie2.fit(X, y, fit_params={"sample_weight": np.ones(shape=n_samples) * 5})
     y_pred0, y_pis0 = mapie0.predict(X, confidence_level=0.95)
     y_pred1, y_pis1 = mapie1.predict(X, confidence_level=0.95)
     y_pred2, y_pis2 = mapie2.predict(X, confidence_level=0.95)
@@ -497,3 +497,13 @@ def test_methods_preservation_in_fit(method: str, cv: str) -> None:
     mapie_ts_reg.fit(X_val, y_val)
     mapie_ts_reg.update(X_test, y_test)
     assert mapie_ts_reg.method == method
+
+
+def test_sample_weight_as_top_level_kwarg_raises() -> None:
+    """Ensure sample_weight must be passed inside fit_params, not as a kwarg."""
+    mapie_ts_reg = TimeSeriesRegressor(
+        cv=BlockBootstrap(n_resamplings=30, n_blocks=5, random_state=random_state),
+        agg_function="mean",
+    )
+    with pytest.raises(TypeError, match="fit_params"):
+        mapie_ts_reg.fit(X, y, sample_weight=np.ones(len(X)))

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1363,6 +1363,23 @@ def _prepare_params(params: Union[dict, None]) -> dict:
     return copy.deepcopy(params) if params else {}
 
 
+def _check_deprecated_sample_weight_kwarg(kwargs: dict) -> None:
+    """Raise ``TypeError`` if ``sample_weight`` appears in *kwargs*.
+
+    Since the ``sample_weight`` routing refactor,
+    ``sample_weight`` must be passed inside ``fit_params``,
+    e.g. ``fit_params={"sample_weight": ...}``.
+    This helper catches the old calling convention early and
+    gives the caller a clear migration message.
+    """
+    if "sample_weight" in kwargs:
+        raise TypeError(
+            "'sample_weight' must be passed inside 'fit_params', "
+            "e.g., fit_params={'sample_weight': ...}. "
+            "Passing it as a top-level keyword argument is not supported."
+        )
+
+
 def _raise_error_if_previous_method_not_called(
     current_method_name: str,
     previous_method_name: str,


### PR DESCRIPTION
## Summary

Completes the `sample_weight` refactor series (Phase 1: #902, Phase 2: #908, Phase 3: #914) by adding **runtime enforcement** of the internal contract: `sample_weight` must always flow through `fit_params`, never as a top-level keyword argument.

Also fixes a **bug in `TimeSeriesRegressor`** where `sample_weight` passed as a top-level kwarg was silently ignored.

## Motivation

After the Phase 1-3 refactor, `_MapieRegressor.fit()` and `_MapieClassifier.fit()` use `**kwargs`, so a caller could write:

```python
mapie.fit(X, y, sample_weight=weights)  # silently swallowed — never applied!
```

The weight ends up in `kwargs` but is never extracted or used. This PR catches that mistake with a clear `TypeError` and migration message.

### Bug: `TimeSeriesRegressor` tests silently broken

`TimeSeriesRegressor` inherits `_MapieRegressor.fit(**kwargs)`. The test `test_results_with_constant_sample_weights` (lines 226-228) passed `sample_weight` as a top-level argument — the weights were **never applied**, so the test was not actually verifying weighted behavior.

## Changes

- **`mapie/utils.py`**: Add `_check_deprecated_sample_weight_kwarg()` utility
- **`mapie/regression/regression.py`**: Add validation in `_MapieRegressor.init_fit()` after `fit_params` is popped from kwargs
- **`mapie/classification.py`**: Add validation in `_MapieClassifier.fit()` after `fit_params` is popped from kwargs
- **`mapie/tests/test_time_series_regression.py`**: Fix `sample_weight` routing to use `fit_params={"sample_weight": ...}` + add negative test
- **`mapie/tests/test_regression.py`**: Add negative test
- **`mapie/tests/test_classification.py`**: Add negative test
- **`HISTORY.md`**: Changelog entry

No public API changes. Issue #753.

## LLM Usage
- [x] I used a Large Language Model (LLM) for this contribution.
- [x] I carefully reviewed and verified all LLM-generated content.

- **LLM used**: Google Gemini (via Antigravity)
- **Purpose**: Codebase analysis to identify the silent failure path in `TimeSeriesRegressor`, and code generation for the defensive validation utility and tests