### PR TITLE
fix: reject Subsample as cv in CrossConformalRegressor

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
 * Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
 * Add defensive validation: `_MapieRegressor` and `_MapieClassifier` now raise `TypeError` when `sample_weight` is passed as a top-level keyword argument instead of inside `fit_params`. Previously, top-level `sample_weight` was silently ignored. Also fix `TimeSeriesRegressor` tests that were affected by the same silent-ignore bug.
+* Add validation to reject `Subsample` as `cv` in `CrossConformalRegressor`, directing users to `JackknifeAfterBootstrapRegressor` instead. (issue #924)
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -25,6 +25,7 @@ from mapie.utils import (
     _check_alpha_and_n_samples,
     _check_cv,
     _check_cv_not_string,
+    _check_cv_not_subsample,
     _check_deprecated_sample_weight_kwarg,
     _check_estimator_fit_predict,
     _check_if_param_in_allowed_values,
@@ -408,6 +409,7 @@ class CrossConformalRegressor:
             method, "method", CrossConformalRegressor._VALID_METHODS
         )
         _check_cv_not_string(cv)
+        _check_cv_not_subsample(cv)
 
         self._mapie_regressor = _MapieRegressor(
             estimator=estimator,

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -208,6 +208,21 @@ class TestWrongMethodsOrderRaisesErrorForCrossTechniques:
             technique.fit_conformalize(X_conformalize, y_conformalize)
 
 
+def test_cross_conformal_regressor_rejects_subsample():
+    """Test that CrossConformalRegressor raises an error when cv=Subsample().
+
+    Users should use JackknifeAfterBootstrapRegressor for bootstrap-based
+    conformal prediction.  See https://github.com/scikit-learn-contrib/MAPIE/issues/924
+    """
+    from mapie.subsample import Subsample
+
+    with pytest.raises(
+        ValueError,
+        match=r".*Subsample.*JackknifeAfterBootstrapRegressor.*",
+    ):
+        CrossConformalRegressor(cv=Subsample())
+
+
 X_toy = np.arange(18).reshape(-1, 1)
 y_toy = np.array([0, 0, 1, 0, 1, 2, 1, 2, 2, 0, 0, 1, 0, 1, 2, 1, 2, 2])
 

--- a/mapie/tests/test_utils.py
+++ b/mapie/tests/test_utils.py
@@ -355,6 +355,29 @@ def test_check_cv_not_string():
         _check_cv_not_string("string")
 
 
+class TestCheckCvNotSubsample:
+    def test_raises_error_for_subsample(self):
+        from mapie.subsample import Subsample
+        from mapie.utils import _check_cv_not_subsample
+
+        with pytest.raises(
+            ValueError,
+            match=r".*Subsample.*CrossConformalRegressor.*"
+            r"JackknifeAfterBootstrapRegressor.*",
+        ):
+            _check_cv_not_subsample(Subsample())
+
+    def test_accepts_int(self):
+        from mapie.utils import _check_cv_not_subsample
+
+        assert _check_cv_not_subsample(5) is None
+
+    def test_accepts_kfold(self):
+        from mapie.utils import _check_cv_not_subsample
+
+        assert _check_cv_not_subsample(KFold()) is None
+
+
 class TestCastPointPredictionsToNdarray:
     def test_error(self, point_and_interval_predictions):
         with pytest.raises(TypeError):

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1337,17 +1337,23 @@ def _check_cv_not_string(cv: Union[int, str, BaseCrossValidator]) -> None:
         )
 
 
-def _check_cv_not_subsample(cv: Union[int, BaseCrossValidator]) -> None:
+def _check_cv_not_subsample(
+    cv: Union[int, str, BaseCrossValidator],
+    caller: str = "CrossConformalRegressor",
+) -> None:
     """Check that ``cv`` is not a ``Subsample`` instance.
 
     ``Subsample`` (bootstrap resampling) should not be used with
-    ``CrossConformalRegressor``.  Users should use the dedicated
+    cross-conformal regressors.  Users should use the dedicated
     ``JackknifeAfterBootstrapRegressor`` class instead.
 
     Parameters
     ----------
-    cv : Union[int, BaseCrossValidator]
+    cv : Union[int, str, BaseCrossValidator]
         The cross-validator to check.
+    caller : str
+        Name of the calling class, used in the error message.
+        By default ``"CrossConformalRegressor"``.
 
     Raises
     ------
@@ -1358,10 +1364,10 @@ def _check_cv_not_subsample(cv: Union[int, BaseCrossValidator]) -> None:
 
     if isinstance(cv, Subsample):
         raise ValueError(
-            "'cv' must not be a Subsample instance in "
-            "CrossConformalRegressor. "
-            "Use JackknifeAfterBootstrapRegressor instead for "
-            "bootstrap-based conformal prediction."
+            f"'cv' must not be a Subsample instance in "
+            f"{caller}. "
+            f"Use JackknifeAfterBootstrapRegressor instead for "
+            f"bootstrap-based conformal prediction."
         )
 
 

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1337,6 +1337,34 @@ def _check_cv_not_string(cv: Union[int, str, BaseCrossValidator]) -> None:
         )
 
 
+def _check_cv_not_subsample(cv: Union[int, BaseCrossValidator]) -> None:
+    """Check that ``cv`` is not a ``Subsample`` instance.
+
+    ``Subsample`` (bootstrap resampling) should not be used with
+    ``CrossConformalRegressor``.  Users should use the dedicated
+    ``JackknifeAfterBootstrapRegressor`` class instead.
+
+    Parameters
+    ----------
+    cv : Union[int, BaseCrossValidator]
+        The cross-validator to check.
+
+    Raises
+    ------
+    ValueError
+        If ``cv`` is a ``Subsample`` instance.
+    """
+    from mapie.subsample import Subsample
+
+    if isinstance(cv, Subsample):
+        raise ValueError(
+            "'cv' must not be a Subsample instance in "
+            "CrossConformalRegressor. "
+            "Use JackknifeAfterBootstrapRegressor instead for "
+            "bootstrap-based conformal prediction."
+        )
+
+
 def _cast_point_predictions_to_ndarray(
     point_predictions: Union[NDArray, Tuple[NDArray, NDArray]],
 ) -> NDArray:


### PR DESCRIPTION
## Description

Adds an explicit validation check that raises `ValueError` when `CrossConformalRegressor` is instantiated with `cv=Subsample()`, directing users to the dedicated `JackknifeAfterBootstrapRegressor` class instead.

Previously, only the type hint and docstring signaled this was incorrect usage, but the following code would silently succeed:

```python
from mapie.regression import CrossConformalRegressor
from mapie.subsample import Subsample

v1 = CrossConformalRegressor(cv=Subsample())
v1.fit_conformalize(X_train, y_train)
v1.predict(X_test)
```

Now, this raises a clear error at construction time:

```
ValueError: 'cv' must not be a Subsample instance in CrossConformalRegressor.
Use JackknifeAfterBootstrapRegressor instead for bootstrap-based conformal prediction.
```

Fixes #924

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests for `_check_cv_not_subsample` (rejects `Subsample`, accepts `int`, accepts `KFold`)
- [x] Integration test verifying `CrossConformalRegressor(cv=Subsample())` raises `ValueError`
- [x] Full test suite (2529 tests pass)
- [x] Coverage at 100%

## Checklist

### Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

### Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`

### Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) file

### LLM Usage
- [x] I used a Large Language Model (LLM) for this contribution.
- [x] I carefully reviewed and verified all LLM-generated content.

**LLM used**: Claude (via Antigravity IDE)
**Purpose**: Code generation, test writing