### PR TITLE
Rework - Add attribute conformity_scores to all Mapie objects

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
 * Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
 * Add defensive validation: `_MapieRegressor` and `_MapieClassifier` now raise `TypeError` when `sample_weight` is passed as a top-level keyword argument instead of inside `fit_params`. Previously, top-level `sample_weight` was silently ignored. Also fix `TimeSeriesRegressor` tests that were affected by the same silent-ignore bug.
+* Add `conformity_scores` attribute to all Mapie objects, exposing conformity scores through a public property. (issue #921)
 
 ## 1.4.0 (2026-04-30)
 

--- a/examples/classification/2-advanced-analysis/plot_comp_methods_on_2d_dataset.py
+++ b/examples/classification/2-advanced-analysis/plot_comp_methods_on_2d_dataset.py
@@ -168,7 +168,7 @@ def plot_scores(
 
 fig, axs = plt.subplots(1, 2, figsize=(10, 5))
 for i, conformity_score in enumerate(conformity_scores):
-    conf_scores = mapie[conformity_score]._mapie_classifier.conformity_scores_
+    conf_scores = mapie[conformity_score].conformity_scores
     n = mapie[conformity_score]._mapie_classifier.n_samples_
     quantiles = mapie[
         conformity_score

--- a/examples/classification/2-advanced-analysis/plot_crossconformal.py
+++ b/examples/classification/2-advanced-analysis/plot_crossconformal.py
@@ -148,7 +148,7 @@ fig, axs = plt.subplots(1, len(mapies[conformity_scores[0]]), figsize=(20, 4))
 for i, (key, mapie) in enumerate(mapies[conformity_scores[0]].items()):
     quantiles = mapie._mapie_classifier.conformity_score_function_.quantiles_[89]
     axs[i].set_xlabel("Conformity scores")
-    axs[i].hist(mapie._mapie_classifier.conformity_scores_)
+    axs[i].hist(mapie.conformity_scores)
     axs[i].axvline(quantiles, ls="--", color="k")
     axs[i].set_title(f"split={key}\nquantile={quantiles:.3f}")
 plt.suptitle(

--- a/examples/classification/2-advanced-analysis/plot_main-tutorial-binary-classification.py
+++ b/examples/classification/2-advanced-analysis/plot_main-tutorial-binary-classification.py
@@ -190,7 +190,7 @@ def plot_scores(
 
 
 fig, axs = plt.subplots(1, 1, figsize=(10, 5))
-conformity_scores = mapie_clf._mapie_classifier.conformity_scores_
+conformity_scores = mapie_clf.conformity_scores
 quantiles = mapie_clf._mapie_classifier.conformity_score_function_.quantiles_
 plot_scores(confidence_level, conformity_scores, quantiles, "lac", axs)
 plt.show()

--- a/examples/regression/2-advanced-analysis/plot_conformal_predictive_distribution.py
+++ b/examples/regression/2-advanced-analysis/plot_conformal_predictive_distribution.py
@@ -79,9 +79,7 @@ class MapieConformalPredictiveDistribution(SplitConformalRegressor):
 
     def get_cumulative_distribution_function(self, X):
         y_pred, _ = self.predict_interval(X)
-        cs = self._mapie_regressor.conformity_scores_[
-            ~np.isnan(self._mapie_regressor.conformity_scores_)
-        ]
+        cs = self.conformity_scores[~np.isnan(self.conformity_scores)]
         res = self._conformity_score.get_estimation_distribution(
             y_pred.reshape((-1, 1)), cs, X=X
         )

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -319,6 +319,11 @@ class SplitConformalClassifier:
         NDArray
             Array of conformity scores, with shape `(n_samples,)`.
         """
+        _raise_error_if_previous_method_not_called(
+            "conformity_scores",
+            "conformalize",
+            self._is_conformalized,
+        )
         return self._mapie_classifier.conformity_scores_
 
 
@@ -583,6 +588,11 @@ class CrossConformalClassifier:
         NDArray
             Array of conformity scores, with shape `(n_samples,)`.
         """
+        _raise_error_if_previous_method_not_called(
+            "conformity_scores",
+            "fit_conformalize",
+            self.is_fitted_and_conformalized,
+        )
         return self._mapie_classifier.conformity_scores_
 
 

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -308,6 +308,19 @@ class SplitConformalClassifier:
         )
         return _cast_point_predictions_to_ndarray(predictions)
 
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `conformalize` method
+        on the conformalization set.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(n_samples,)`.
+        """
+        return self._mapie_classifier.conformity_scores_
+
 
 class CrossConformalClassifier:
     """
@@ -557,6 +570,20 @@ class CrossConformalClassifier:
             **self._predict_params,
         )
         return _cast_point_predictions_to_ndarray(predictions)
+
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `fit_conformalize`
+        method, on the out-of-fold predictions produced during
+        cross-validation.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(n_samples,)`.
+        """
+        return self._mapie_classifier.conformity_scores_
 
 
 class _MapieClassifier(ClassifierMixin, BaseEstimator):

--- a/mapie/exchangeability_testing/martingales.py
+++ b/mapie/exchangeability_testing/martingales.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from copy import deepcopy
-from typing import Literal, Optional, Union, cast
+from typing import Literal, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -371,20 +371,7 @@ class OnlineMartingaleTest:
             self.mapie_estimator._is_conformalized = False
         self.mapie_estimator.conformalize(X, y)  # compute scores internally
 
-        if self.task == "classification":
-            self.mapie_estimator = cast(SplitConformalClassifier, self.mapie_estimator)
-            scores = cast(
-                NDArray,
-                self.mapie_estimator._mapie_classifier.conformity_scores_,
-            )
-        else:
-            self.mapie_estimator = cast(SplitConformalRegressor, self.mapie_estimator)
-            scores = cast(
-                NDArray,
-                self.mapie_estimator._mapie_regressor.conformity_scores_,
-            )
-
-        return scores
+        return self.mapie_estimator.conformity_scores
 
     @property
     def reject_threshold(self) -> float:

--- a/mapie/exchangeability_testing/permutations.py
+++ b/mapie/exchangeability_testing/permutations.py
@@ -1,7 +1,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, Literal, Optional, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -249,20 +249,7 @@ class PermutationTest(ABC):
 
         self.mapie_estimator.conformalize(X, y)  # compute scores internally
 
-        if self.task == "classification":
-            self.mapie_estimator = cast(SplitConformalClassifier, self.mapie_estimator)
-            scores = cast(
-                NDArray,
-                self.mapie_estimator._mapie_classifier.conformity_scores_,
-            )
-        else:
-            self.mapie_estimator = cast(SplitConformalRegressor, self.mapie_estimator)
-            scores = cast(
-                NDArray,
-                self.mapie_estimator._mapie_regressor.conformity_scores_,
-            )
-
-        return scores
+        return self.mapie_estimator.conformity_scores
 
     @abstractmethod
     def run(self, X: NDArray, y: NDArray) -> "PermutationTest":

--- a/mapie/regression/quantile_regression.py
+++ b/mapie/regression/quantile_regression.py
@@ -293,6 +293,24 @@ class ConformalizedQuantileRegressor:
         predictions, _ = estimator.predict(X, **self._predict_params)
         return predictions
 
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `conformalize` method
+        on the conformalization set.
+
+        For conformalized quantile regression, three scores are stored per
+        sample: the signed residual against the lower-quantile estimator,
+        the signed residual against the upper-quantile estimator, and their
+        pointwise maximum.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(3, n_samples)`.
+        """
+        return self._mapie_quantile_regressor.conformity_scores_
+
 
 class _MapieQuantileRegressor(_MapieRegressor):
     """

--- a/mapie/regression/quantile_regression.py
+++ b/mapie/regression/quantile_regression.py
@@ -309,6 +309,11 @@ class ConformalizedQuantileRegressor:
         NDArray
             Array of conformity scores, with shape `(3, n_samples)`.
         """
+        _raise_error_if_previous_method_not_called(
+            "conformity_scores",
+            "conformalize",
+            self._is_conformalized,
+        )
         return self._mapie_quantile_regressor.conformity_scores_
 
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -315,6 +315,11 @@ class SplitConformalRegressor:
         NDArray
             Array of conformity scores, with shape `(n_samples,)`.
         """
+        _raise_error_if_previous_method_not_called(
+            "conformity_scores",
+            "conformalize",
+            self._is_conformalized,
+        )
         return self._mapie_regressor.conformity_scores_
 
 
@@ -629,6 +634,11 @@ class CrossConformalRegressor:
         NDArray
             Array of conformity scores, with shape `(n_samples,)`.
         """
+        _raise_error_if_previous_method_not_called(
+            "conformity_scores",
+            "fit_conformalize",
+            self.is_fitted_and_conformalized,
+        )
         return self._mapie_regressor.conformity_scores_
 
 
@@ -939,6 +949,11 @@ class JackknifeAfterBootstrapRegressor:
         NDArray
             Array of conformity scores, with shape `(n_samples,)`.
         """
+        _raise_error_if_previous_method_not_called(
+            "conformity_scores",
+            "fit_conformalize",
+            self.is_fitted_and_conformalized,
+        )
         return self._mapie_regressor.conformity_scores_
 
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -304,6 +304,19 @@ class SplitConformalRegressor:
         )
         return _cast_point_predictions_to_ndarray(predictions)
 
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `conformalize` method
+        on the conformalization set.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(n_samples,)`.
+        """
+        return self._mapie_regressor.conformity_scores_
+
 
 class CrossConformalRegressor:
     """
@@ -604,6 +617,20 @@ class CrossConformalRegressor:
             self._mapie_regressor.agg_function = aggregate_point_predictions
         return ensemble
 
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `fit_conformalize`
+        method, on the out-of-fold predictions produced during
+        cross-validation.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(n_samples,)`.
+        """
+        return self._mapie_regressor.conformity_scores_
+
 
 class JackknifeAfterBootstrapRegressor:
     """
@@ -899,6 +926,20 @@ class JackknifeAfterBootstrapRegressor:
         else:
             raise ValueError("resampling must be an integer or a Subsample instance")
         return cv
+
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `fit_conformalize`
+        method, on the out-of-fold predictions produced during
+        cross-validation.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(n_samples,)`.
+        """
+        return self._mapie_regressor.conformity_scores_
 
 
 class _MapieRegressor(RegressorMixin, BaseEstimator):

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -508,4 +508,5 @@ class TimeSeriesRegressor(_MapieRegressor):
         NDArray
             Array of conformity scores, with shape `(n_samples,)`.
         """
+        check_is_fitted(self)
         return self.conformity_scores_

--- a/mapie/regression/time_series_regression.py
+++ b/mapie/regression/time_series_regression.py
@@ -496,3 +496,16 @@ class TimeSeriesRegressor(_MapieRegressor):
                 _transform_confidence_level_to_alpha_list(confidence_level)
             )
         return alpha
+
+    @property
+    def conformity_scores(self) -> NDArray:
+        """
+        Returns the conformity scores computed by the `fit` method on the
+        out-of-resample predictions of the bootstrap ensemble.
+
+        Returns
+        -------
+        NDArray
+            Array of conformity scores, with shape `(n_samples,)`.
+        """
+        return self.conformity_scores_

--- a/mapie/tests/exchangeability_testing/test_online_tests.py
+++ b/mapie/tests/exchangeability_testing/test_online_tests.py
@@ -727,6 +727,10 @@ def test_compute_non_conformity_scores_classification_branch(monkeypatch):
             self._conformalize_X = np.asarray(X)
             self._conformalize_y = np.asarray(y)
 
+        @property
+        def conformity_scores(self):
+            return self._mapie_classifier.conformity_scores_
+
     estimator = DummyMapieClassifier()
 
     def fake_train_test_split(X, y, test_size, shuffle):
@@ -770,6 +774,10 @@ def test_compute_non_conformity_scores_regression_branch(monkeypatch):
         def conformalize(self, X, y):
             self.conformalize_calls += 1
 
+        @property
+        def conformity_scores(self):
+            return self._mapie_regressor.conformity_scores_
+
     estimator = DummyMapieRegressor()
 
     monkeypatch.setattr(
@@ -802,6 +810,10 @@ def test_compute_non_conformity_scores_uses_provided_estimator_without_creation(
             self.conformalize_calls += 1
             self._mapie_regressor.conformity_scores_ = np.array([0.9, 1.1])
 
+        @property
+        def conformity_scores(self):
+            return self._mapie_regressor.conformity_scores_
+
     provided = DummyProvidedRegressor()
     omt = OnlineMartingaleTest(mapie_estimator=provided, task="regression")
 
@@ -827,6 +839,10 @@ def test_compute_non_conformity_scores_can_reuse_estimator_across_updates():
         def conformalize(self, X, y):
             self.conformalize_calls += 1
             self._mapie_regressor.conformity_scores_ = np.asarray(y, dtype=float)
+
+        @property
+        def conformity_scores(self):
+            return self._mapie_regressor.conformity_scores_
 
     omt = OnlineMartingaleTest(
         mapie_estimator=DummyProvidedRegressor(),
@@ -863,6 +879,10 @@ def test_compute_non_conformity_scores_warns_when_estimator_not_fitted(monkeypat
 
         def conformalize(self, X, y):
             self._mapie_regressor.conformity_scores_ = np.array([0.4, 0.6])
+
+        @property
+        def conformity_scores(self):
+            return self._mapie_regressor.conformity_scores_
 
     def fake_train_test_split(X, y, test_size, shuffle):
         assert test_size == pytest.approx(0.7)

--- a/mapie/tests/exchangeability_testing/test_permutation_tests.py
+++ b/mapie/tests/exchangeability_testing/test_permutation_tests.py
@@ -40,6 +40,10 @@ class DummyClassificationEstimator:
         self._mapie_classifier.conformity_scores_ = np.arange(len(y), dtype=float)
         return self
 
+    @property
+    def conformity_scores(self):
+        return self._mapie_classifier.conformity_scores_
+
 
 class DummyUnknownEstimator:
     def __init__(self):

--- a/mapie/tests/test_conformity_scores_property.py
+++ b/mapie/tests/test_conformity_scores_property.py
@@ -1,0 +1,130 @@
+import numpy as np
+import pytest
+from sklearn.datasets import make_classification, make_regression
+from sklearn.linear_model import (
+    LinearRegression,
+    LogisticRegression,
+    QuantileRegressor,
+)
+from sklearn.model_selection import train_test_split
+
+from mapie.classification import (
+    CrossConformalClassifier,
+    SplitConformalClassifier,
+)
+from mapie.regression import (
+    ConformalizedQuantileRegressor,
+    CrossConformalRegressor,
+    JackknifeAfterBootstrapRegressor,
+    SplitConformalRegressor,
+)
+from mapie.regression.time_series_regression import TimeSeriesRegressor
+from mapie.subsample import BlockBootstrap
+
+RANDOM_STATE = 42
+
+
+@pytest.fixture
+def classification_data():
+    X, y = make_classification(
+        n_samples=200, n_features=4, n_classes=2, random_state=RANDOM_STATE
+    )
+    return train_test_split(X, y, test_size=0.5, random_state=RANDOM_STATE)
+
+
+@pytest.fixture
+def regression_data():
+    X, y = make_regression(
+        n_samples=200, n_features=3, noise=10.0, random_state=RANDOM_STATE
+    )
+    return train_test_split(X, y, test_size=0.5, random_state=RANDOM_STATE)
+
+
+class TestConformityScoresProperty:
+    def test_split_conformal_classifier(self, classification_data):
+        X_train, X_calib, y_train, y_calib = classification_data
+        estimator = SplitConformalClassifier(
+            estimator=LogisticRegression(), prefit=False
+        )
+        estimator.fit(X_train, y_train).conformalize(X_calib, y_calib)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert (
+            estimator.conformity_scores
+            is estimator._mapie_classifier.conformity_scores_
+        )
+
+    def test_cross_conformal_classifier(self, classification_data):
+        X_train, X_calib, y_train, y_calib = classification_data
+        X, y = np.concatenate([X_train, X_calib]), np.concatenate([y_train, y_calib])
+        estimator = CrossConformalClassifier(estimator=LogisticRegression(), cv=5)
+        estimator.fit_conformalize(X, y)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert (
+            estimator.conformity_scores
+            is estimator._mapie_classifier.conformity_scores_
+        )
+
+    def test_split_conformal_regressor(self, regression_data):
+        X_train, X_calib, y_train, y_calib = regression_data
+        estimator = SplitConformalRegressor(estimator=LinearRegression(), prefit=False)
+        estimator.fit(X_train, y_train).conformalize(X_calib, y_calib)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert (
+            estimator.conformity_scores is estimator._mapie_regressor.conformity_scores_
+        )
+
+    def test_cross_conformal_regressor(self, regression_data):
+        X_train, X_calib, y_train, y_calib = regression_data
+        X, y = np.concatenate([X_train, X_calib]), np.concatenate([y_train, y_calib])
+        estimator = CrossConformalRegressor(estimator=LinearRegression(), cv=5)
+        estimator.fit_conformalize(X, y)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert (
+            estimator.conformity_scores is estimator._mapie_regressor.conformity_scores_
+        )
+
+    def test_jackknife_after_bootstrap_regressor(self, regression_data):
+        X_train, X_calib, y_train, y_calib = regression_data
+        X, y = np.concatenate([X_train, X_calib]), np.concatenate([y_train, y_calib])
+        estimator = JackknifeAfterBootstrapRegressor(
+            estimator=LinearRegression(), resampling=10
+        )
+        estimator.fit_conformalize(X, y)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert (
+            estimator.conformity_scores is estimator._mapie_regressor.conformity_scores_
+        )
+
+    def test_conformalized_quantile_regressor(self, regression_data):
+        X_train, X_calib, y_train, y_calib = regression_data
+        estimator = ConformalizedQuantileRegressor(
+            estimator=QuantileRegressor(solver="highs"),
+            confidence_level=0.9,
+            prefit=False,
+        )
+        estimator.fit(X_train, y_train).conformalize(X_calib, y_calib)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert estimator.conformity_scores.shape[0] == 3
+        assert (
+            estimator.conformity_scores
+            is estimator._mapie_quantile_regressor.conformity_scores_
+        )
+
+    def test_time_series_regressor(self, regression_data):
+        X_train, X_calib, y_train, y_calib = regression_data
+        X, y = np.concatenate([X_train, X_calib]), np.concatenate([y_train, y_calib])
+        estimator = TimeSeriesRegressor(
+            estimator=LinearRegression(),
+            method="enbpi",
+            cv=BlockBootstrap(n_resamplings=10, length=20, random_state=RANDOM_STATE),
+        )
+        estimator.fit(X, y)
+
+        assert isinstance(estimator.conformity_scores, np.ndarray)
+        assert estimator.conformity_scores is estimator.conformity_scores_

--- a/mapie/tests/test_conformity_scores_property.py
+++ b/mapie/tests/test_conformity_scores_property.py
@@ -128,3 +128,52 @@ class TestConformityScoresProperty:
 
         assert isinstance(estimator.conformity_scores, np.ndarray)
         assert estimator.conformity_scores is estimator.conformity_scores_
+
+
+class TestConformityScoresPropertyRaisesBeforeComputation:
+    def test_split_conformal_classifier(self):
+        estimator = SplitConformalClassifier(
+            estimator=LogisticRegression(), prefit=False
+        )
+        with pytest.raises(ValueError):
+            estimator.conformity_scores
+
+    def test_cross_conformal_classifier(self):
+        estimator = CrossConformalClassifier(estimator=LogisticRegression(), cv=5)
+        with pytest.raises(ValueError):
+            estimator.conformity_scores
+
+    def test_split_conformal_regressor(self):
+        estimator = SplitConformalRegressor(estimator=LinearRegression(), prefit=False)
+        with pytest.raises(ValueError):
+            estimator.conformity_scores
+
+    def test_cross_conformal_regressor(self):
+        estimator = CrossConformalRegressor(estimator=LinearRegression(), cv=5)
+        with pytest.raises(ValueError):
+            estimator.conformity_scores
+
+    def test_jackknife_after_bootstrap_regressor(self):
+        estimator = JackknifeAfterBootstrapRegressor(
+            estimator=LinearRegression(), resampling=10
+        )
+        with pytest.raises(ValueError):
+            estimator.conformity_scores
+
+    def test_conformalized_quantile_regressor(self):
+        estimator = ConformalizedQuantileRegressor(
+            estimator=QuantileRegressor(solver="highs"),
+            confidence_level=0.9,
+            prefit=False,
+        )
+        with pytest.raises(ValueError):
+            estimator.conformity_scores
+
+    def test_time_series_regressor(self):
+        estimator = TimeSeriesRegressor(
+            estimator=LinearRegression(),
+            method="enbpi",
+            cv=BlockBootstrap(n_resamplings=10, length=20, random_state=RANDOM_STATE),
+        )
+        with pytest.raises(ValueError):
+            estimator.conformity_scores


### PR DESCRIPTION
# Description

Adds a public `conformity_scores` attribute to all Mapie objects.

Fixes #921

## Type of change

Please remove options that are irrelevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Full unit test suite passes (`uv run pytest mapie/tests/ --ignore=mapie/tests/long_tests`), no failures.
- [x] Manual verification via a notebook that instantiates each of the seven classes on dummy data fits + conformalizes, then prints `type` of `estimator.conformity_scores`. All seven return `numpy.ndarray`.
- [x] `PValuePermutationTest` exercised on both a `SplitConformalClassifier` and a `SplitConformalRegressor`; both produce a valid p-value and `is_exchangeable` flag through the refactored caller.
- [x] `OnlineMartingaleTest._compute_non_conformity_scores` exercised on a `SplitConformalRegressor`).

# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`

## Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) and [AUTHORS.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.md) files

## LLM Usage
- [x] I used a Large Language Model (LLM) for this contribution.
- [x] I carefully reviewed and verified all LLM-generated content.

If you used an LLM, please provide the following details:

- **LLM used**: Claude via Github Copilot
- **Purpose**:  docstring writing, code generation and verification.
