### PR TITLE
fix: allow refitting CrossConformalRegressor via fit_conformalize and add reset()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 * Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
 * Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
 * Add defensive validation: `_MapieRegressor` and `_MapieClassifier` now raise `TypeError` when `sample_weight` is passed as a top-level keyword argument instead of inside `fit_params`. Previously, top-level `sample_weight` was silently ignored. Also fix `TimeSeriesRegressor` tests that were affected by the same silent-ignore bug.
+* Add `reset()` method on `CrossConformalRegressor` and allow refitting via `fit_conformalize` (now emits a `UserWarning` and discards prior conformity scores instead of raising). Same pattern can be propagated to other conformal classes in follow-up PRs. (issue #710)
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any, Iterable, Optional, Tuple, Union, cast
 
 import numpy as np
@@ -427,6 +428,20 @@ class CrossConformalRegressor:
 
         self._predict_params: dict = {}
 
+    def reset(self) -> CrossConformalRegressor:
+        """
+        Discard previously computed conformity scores so that
+        `fit_conformalize` can be called again with new data.
+
+        Returns
+        -------
+        Self
+            This CrossConformalRegressor instance, reset to its pre-fit state.
+        """
+        self.is_fitted_and_conformalized = False
+        self._predict_params = {}
+        return self
+
     def fit_conformalize(
         self,
         X: ArrayLike,
@@ -439,6 +454,10 @@ class CrossConformalRegressor:
         Estimates the uncertainty of the base regressor in a cross-validation style:
         fits the base regressor on different folds of the dataset
         and computes conformity scores on the corresponding out-of-fold data.
+
+        If called on an instance that has already been fitted, a `UserWarning` is
+        emitted and the previously computed conformity scores are discarded before
+        the new fit. Call `reset()` explicitly to suppress the warning.
 
         Parameters
         ----------
@@ -464,10 +483,16 @@ class CrossConformalRegressor:
         Self
             This CrossConformalRegressor instance, fitted and conformalized.
         """
-        _raise_error_if_method_already_called(
-            "fit_conformalize",
-            self.is_fitted_and_conformalized,
-        )
+        if self.is_fitted_and_conformalized:
+            warnings.warn(
+                "CrossConformalRegressor.fit_conformalize was already called; "
+                "conformity scores from the previous fit will be discarded. "
+                "Call .reset() explicitly before fit_conformalize to suppress "
+                "this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.reset()
 
         fit_params_ = _prepare_params(fit_params)
         self._predict_params = _prepare_params(predict_params)

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -1,3 +1,4 @@
+import warnings
 from inspect import signature
 from typing import Any, List, Tuple
 
@@ -204,8 +205,16 @@ class TestWrongMethodsOrderRaisesErrorForCrossTechniques:
 
         technique.fit_conformalize(X_conformalize, y_conformalize)
 
-        with pytest.raises(ValueError, match=r"fit_conformalize method already called"):
-            technique.fit_conformalize(X_conformalize, y_conformalize)
+        if cross_technique is CrossConformalRegressor:
+            with pytest.warns(
+                UserWarning, match=r"fit_conformalize was already called"
+            ):
+                technique.fit_conformalize(X_conformalize, y_conformalize)
+        else:
+            with pytest.raises(
+                ValueError, match=r"fit_conformalize method already called"
+            ):
+                technique.fit_conformalize(X_conformalize, y_conformalize)
 
 
 X_toy = np.arange(18).reshape(-1, 1)
@@ -358,3 +367,48 @@ def test_none_alpha_results(pack: Tuple[BaseEstimator, BaseEstimator]) -> None:
     mapie_estimator.fit(X_toy, y_toy)
     y_pred = mapie_estimator.predict(X_toy)
     np.testing.assert_allclose(y_pred_expected, y_pred)
+
+
+class TestCrossConformalRegressorReset:
+    def test_reset_clears_state(self, dataset_regression) -> None:
+        _, X_conformalize, _, _, y_conformalize, _ = dataset_regression
+        technique = CrossConformalRegressor(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+        assert technique.is_fitted_and_conformalized
+
+        returned = technique.reset()
+        assert returned is technique
+        assert not technique.is_fitted_and_conformalized
+        assert technique._predict_params == {}
+
+    def test_explicit_reset_then_refit_does_not_warn(self, dataset_regression) -> None:
+        _, X_conformalize, _, _, y_conformalize, _ = dataset_regression
+        technique = CrossConformalRegressor(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+        technique.reset()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            technique.fit_conformalize(X_conformalize, y_conformalize)
+        assert technique.is_fitted_and_conformalized
+
+    def test_refit_produces_calibration_from_second_dataset(
+        self, dataset_regression
+    ) -> None:
+        _, X_conformalize, X_test, _, y_conformalize, _ = dataset_regression
+        scale_a, scale_b = 0.5, 50.0
+
+        refit_technique = CrossConformalRegressor(
+            estimator=DummyRegressor(), random_state=RANDOM_STATE
+        )
+        refit_technique.fit_conformalize(X_conformalize, y_conformalize * scale_a)
+        with pytest.warns(UserWarning):
+            refit_technique.fit_conformalize(X_conformalize, y_conformalize * scale_b)
+        _, intervals_refit = refit_technique.predict_interval(X_test)
+
+        reference_technique = CrossConformalRegressor(
+            estimator=DummyRegressor(), random_state=RANDOM_STATE
+        )
+        reference_technique.fit_conformalize(X_conformalize, y_conformalize * scale_b)
+        _, intervals_reference = reference_technique.predict_interval(X_test)
+
+        np.testing.assert_allclose(intervals_refit, intervals_reference)


### PR DESCRIPTION
# Description

Implements the design @GBrelurut confirmed in
[#710 (comment)](https://github.com/scikit-learn-contrib/MAPIE/issues/710#issuecomment-4541586434):

> "I love the idea of the `.reset()` method to have an explicit action.
> I would have it used in the fit() method with a warning."
> "I think it is best to have a narrow scope on CrossConformalRegressor and
> propagate later to other objects."

Concretely:

- **Adds a public `reset()` method** on `CrossConformalRegressor` that discards
  the conformity scores computed during a prior `fit_conformalize`, returning
  the instance to its pre-fit state (mirrors sklearn's fluent-API convention by
  returning `self`).
- **Replaces the `_raise_error_if_method_already_called` guard inside
  `fit_conformalize`**: on an already-fitted instance, the method now emits a
  `UserWarning` and internally calls `self.reset()` before proceeding with the
  new fit. Users who want surprise-free behavior can call `.reset()` explicitly
  to suppress the warning.

The underlying calibration-leakage concern that originally motivated the guard
(per @GBrelurut: *"the intention was to avoid cases where a model could be
trained anew and conformity scores were not updated"*) is preserved through the
internal state-reset, not via the hard error.

**Scope is intentionally narrow to `CrossConformalRegressor`** per @GBrelurut's
guidance. The same pattern can be propagated to `JackknifeAfterBootstrapRegressor`,
`CrossConformalClassifier`, `SplitConformalRegressor`,
`ConformalizedQuantileRegressor`, and `SplitConformalClassifier` in follow-up PRs.

Fixes #710.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (docstring updated on
  `fit_conformalize`; new docstring on `reset()`)

# How Has This Been Tested?

Full local CI passes: `make lint && make format && make type-check && make coverage`
— **2525 tests passing (+3 from new tests), 100% coverage** in 1m 37s.

- [x] `test_common.py::TestWrongMethodsOrderRaisesErrorForCrossTechniques::test_wrong_methods_order`:
  the existing test now branches — for `CrossConformalRegressor` it asserts a
  `UserWarning` is emitted on the second `fit_conformalize` call; for
  `JackknifeAfterBootstrapRegressor` and `CrossConformalClassifier` it still
  asserts the existing `ValueError` (unchanged behavior — those classes are
  out of scope per #710's narrow scope).
- [x] **New** `test_common.py::TestCrossConformalRegressorReset` with three
  focused tests:
  - `test_reset_clears_state`: `.reset()` returns `self`, clears
    `is_fitted_and_conformalized`, and resets `_predict_params` to `{}`.
  - `test_explicit_reset_then_refit_does_not_warn`: calling `.reset()` before
    `fit_conformalize` suppresses the `UserWarning`
    (verified with `warnings.simplefilter("error", UserWarning)`).
  - `test_refit_produces_calibration_from_second_dataset`: fit on `y * 0.5`,
    then refit on `y * 50.0`; verifies the resulting prediction intervals are
    bit-identical to a freshly-constructed instance fit only on `y * 50.0`.
    This proves there is no calibration leakage from the first fit.

Reproduce:
uv sync --python 3.12 --extra dev --extra docs --extra notebooks
make lint && make format && make type-check && make coverage



# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [x] When updating documentation: doc builds successfully and without warnings: `make doc`
- [x] When updating documentation: code examples in doc run successfully: `make doctest`

## Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) and [AUTHORS.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.md) files (HISTORY.md updated this PR; AUTHORS.md already lists me from #923).