### PR TITLE
chore: silence intentional UserWarnings emitted during test runs

### DIFF
--- a/mapie/tests/exchangeability_testing/test_online_tests.py
+++ b/mapie/tests/exchangeability_testing/test_online_tests.py
@@ -12,6 +12,10 @@ import mapie.exchangeability_testing.exchangeability as et_module
 import mapie.exchangeability_testing.martingales as omt_module
 from mapie.exchangeability_testing.martingales import OnlineMartingaleTest
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The provided MAPIE estimator is not fitted:UserWarning"
+)
+
 
 def test_fixed_dataset_exchangeability_validation_errors():
     """Test fixed-dataset wrapper validation on method names."""

--- a/mapie/tests/exchangeability_testing/test_permutation_tests.py
+++ b/mapie/tests/exchangeability_testing/test_permutation_tests.py
@@ -21,6 +21,15 @@ from mapie.regression import (
     SplitConformalRegressor,
 )
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:The provided MAPIE estimator is not fitted:UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:Exchangeability test rejected the null hypothesis:UserWarning"
+    ),
+]
+
 
 class DummyMapieClassifier:
     def __init__(self):

--- a/mapie/tests/risk_control/test_binary_classification_control.py
+++ b/mapie/tests/risk_control/test_binary_classification_control.py
@@ -658,9 +658,7 @@ class TestBinaryClassificationControllerGetPredictionsPerParam:
         ):
             bcc.calibrate([1, 2], [0, 1])
 
-    @pytest.mark.filterwarnings(
-        "ignore:No predict parameters were found:UserWarning"
-    )
+    @pytest.mark.filterwarnings("ignore:No predict parameters were found:UserWarning")
     def test_warning_one_dim_binary_predictions(self):
         """Test warning raised when predictions are binary (0 or 1) with one-dimensional parameters"""
 
@@ -1169,9 +1167,7 @@ def test_calibrate_without_learning_sequence_raises():
         bcc.calibrate(realistic_X_calib, realistic_y_calib)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:No predict parameters were found:UserWarning"
-)
+@pytest.mark.filterwarnings("ignore:No predict parameters were found:UserWarning")
 def test_calibrate_uses_sequence_when_split_fixed():
     predict_params = np.array([0.1, 0.2, 0.3])
 

--- a/mapie/tests/risk_control/test_binary_classification_control.py
+++ b/mapie/tests/risk_control/test_binary_classification_control.py
@@ -658,6 +658,9 @@ class TestBinaryClassificationControllerGetPredictionsPerParam:
         ):
             bcc.calibrate([1, 2], [0, 1])
 
+    @pytest.mark.filterwarnings(
+        "ignore:No predict parameters were found:UserWarning"
+    )
     def test_warning_one_dim_binary_predictions(self):
         """Test warning raised when predictions are binary (0 or 1) with one-dimensional parameters"""
 
@@ -1166,6 +1169,9 @@ def test_calibrate_without_learning_sequence_raises():
         bcc.calibrate(realistic_X_calib, realistic_y_calib)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:No predict parameters were found:UserWarning"
+)
 def test_calibrate_uses_sequence_when_split_fixed():
     predict_params = np.array([0.1, 0.2, 0.3])
 

--- a/mapie/tests/risk_control/test_fwer_control.py
+++ b/mapie/tests/risk_control/test_fwer_control.py
@@ -137,6 +137,9 @@ def test_fixed_sequence_multistart_correct_parsing():
     assert np.array_equal(rejected, np.array([0, 1, 2, 4, 8, 9, 10, 11]))
 
 
+@pytest.mark.filterwarnings(
+    "ignore:n_starts is greater than the number of tests:UserWarning"
+)
 def test_fixed_sequence_starts_clipped():
     fwer_procedure = FWERFixedSequenceTesting(n_starts=10)
     rejected = fwer_procedure.run(np.array([0.0, 0.0]), delta=0.1)

--- a/mapie/tests/risk_control/test_multi_label_classification_control.py
+++ b/mapie/tests/risk_control/test_multi_label_classification_control.py
@@ -18,18 +18,12 @@ from mapie.risk_control.methods import find_best_predict_param
 from mapie.utils import check_is_fitted
 
 pytestmark = [
-    pytest.mark.filterwarnings(
-        "ignore:No predict parameters were found:UserWarning"
-    ),
-    pytest.mark.filterwarnings(
-        "ignore:The risk cannot be controlled:UserWarning"
-    ),
+    pytest.mark.filterwarnings("ignore:No predict parameters were found:UserWarning"),
+    pytest.mark.filterwarnings("ignore:The risk cannot be controlled:UserWarning"),
     pytest.mark.filterwarnings(
         r"ignore:WARNING.+you are using method 'crc':UserWarning"
     ),
-    pytest.mark.filterwarnings(
-        r"ignore:WARNING.+you are using crc method:UserWarning"
-    ),
+    pytest.mark.filterwarnings(r"ignore:WARNING.+you are using crc method:UserWarning"),
     pytest.mark.filterwarnings(
         r"ignore:\s*Warning.+the risk couldn't be controlled:UserWarning"
     ),

--- a/mapie/tests/risk_control/test_multi_label_classification_control.py
+++ b/mapie/tests/risk_control/test_multi_label_classification_control.py
@@ -17,6 +17,24 @@ from mapie.risk_control import MultiLabelClassificationController
 from mapie.risk_control.methods import find_best_predict_param
 from mapie.utils import check_is_fitted
 
+pytestmark = [
+    pytest.mark.filterwarnings(
+        "ignore:No predict parameters were found:UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The risk cannot be controlled:UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        r"ignore:WARNING.+you are using method 'crc':UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        r"ignore:WARNING.+you are using crc method:UserWarning"
+    ),
+    pytest.mark.filterwarnings(
+        r"ignore:\s*Warning.+the risk couldn't be controlled:UserWarning"
+    ),
+]
+
 Params = TypedDict(
     "Params",
     {

--- a/mapie/tests/test_conformity_scores_bounds.py
+++ b/mapie/tests/test_conformity_scores_bounds.py
@@ -254,9 +254,7 @@ def test_residual_normalised_conformity_score_get_conformity_scores(
     np.testing.assert_allclose(conf_scores, expected_signed_conf_scores)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Estimator does not appear fitted:UserWarning"
-)
+@pytest.mark.filterwarnings("ignore:Estimator does not appear fitted:UserWarning")
 def test_residual_normalised_score_prefit_with_notfitted_estim() -> None:
     """Test that a not fitted estimator and prefit=True raises an error."""
     residual_norm_conf_score = ResidualNormalisedScore(

--- a/mapie/tests/test_conformity_scores_bounds.py
+++ b/mapie/tests/test_conformity_scores_bounds.py
@@ -254,6 +254,9 @@ def test_residual_normalised_conformity_score_get_conformity_scores(
     np.testing.assert_allclose(conf_scores, expected_signed_conf_scores)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Estimator does not appear fitted:UserWarning"
+)
 def test_residual_normalised_score_prefit_with_notfitted_estim() -> None:
     """Test that a not fitted estimator and prefit=True raises an error."""
     residual_norm_conf_score = ResidualNormalisedScore(

--- a/mapie/tests/test_time_series_regression.py
+++ b/mapie/tests/test_time_series_regression.py
@@ -18,6 +18,10 @@ from mapie.metrics.regression import regression_coverage_score
 from mapie.regression import TimeSeriesRegressor
 from mapie.subsample import BlockBootstrap
 
+pytestmark = pytest.mark.filterwarnings(
+    r"ignore:\s*This function behavior has been changed:UserWarning"
+)
+
 random_state = 1
 X_toy = np.array(range(5)).reshape(-1, 1)
 y_toy = (5.0 + 2.0 * X_toy**1.1).flatten()


### PR DESCRIPTION
## Summary

- `make tests` previously emitted 335 `UserWarning`s, all from library code raising expected informational messages while tests sweep parameters / exercise edge cases.
- This PR silences those warnings via targeted `pytest.mark.filterwarnings` markers (message-anchored, `UserWarning`-scoped) at module or per-test level. Library behavior is unchanged.
- Result: **335 → 7** warnings in `make tests`. The 7 remaining are out of scope (4 doctest warnings on library modules + 2 sklearn `EstimatorCheckFailedWarning`s in the time-series sklearn-compat test, both better addressed separately).

## Changes

Test-side only, 7 files in `mapie/tests/`:

- `risk_control/test_multi_label_classification_control.py` — module-level `pytestmark` with 5 message-targeted filters (≈290 warnings)
- `exchangeability_testing/test_permutation_tests.py` — module-level `pytestmark` (≈20 warnings)
- `exchangeability_testing/test_online_tests.py` — module-level `pytestmark` (≈1 warning)
- `test_time_series_regression.py` — module-level `pytestmark` for the `update_conformity_scores` deprecation-style message (12 warnings)
- `risk_control/test_binary_classification_control.py` — 2 per-test decorators
- `risk_control/test_fwer_control.py` — 1 per-test decorator
- `test_conformity_scores_bounds.py` — 1 per-test decorator

Every filter is anchored to a specific message substring and scoped to `UserWarning` so an unrelated warning would still surface.