### PR TITLE
fix: allow refitting JackknifeAfterBootstrapRegressor via fit_conformalize and add reset()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 * Add `conformity_scores` attribute to all Mapie objects, exposing conformity scores through a public property. (issue #921)
 * Add validation to reject `Subsample` as `cv` in `CrossConformalRegressor`, directing users to `JackknifeAfterBootstrapRegressor` instead. (issue #924)
 * Add `reset()` method on `CrossConformalRegressor` and allow refitting via `fit_conformalize` (now emits a `UserWarning` and discards prior conformity scores instead of raising). Same pattern can be propagated to other conformal classes in follow-up PRs. (issue #710)
+* Add `reset()` method on `JackknifeAfterBootstrapRegressor` and allow refitting via `fit_conformalize` (mirrors the pattern landed for `CrossConformalRegressor` in #931).
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -801,6 +801,21 @@ class JackknifeAfterBootstrapRegressor:
         self.is_fitted_and_conformalized = False
         self._predict_params: dict = {}
 
+    def reset(self) -> JackknifeAfterBootstrapRegressor:
+        """
+        Discard previously computed conformity scores so that
+        `fit_conformalize` can be called again with new data.
+
+        Returns
+        -------
+        Self
+            This JackknifeAfterBootstrapRegressor instance, reset to its
+            pre-fit state.
+        """
+        self.is_fitted_and_conformalized = False
+        self._predict_params = {}
+        return self
+
     def fit_conformalize(
         self,
         X: ArrayLike,
@@ -812,6 +827,10 @@ class JackknifeAfterBootstrapRegressor:
         Estimates the uncertainty of the base regressor using bootstrap sampling:
         fits the base regressor on (potentially overlapping) samples of the dataset,
         and computes conformity scores on the corresponding out of samples data.
+
+        If called on an instance that has already been fitted, a `UserWarning` is
+        emitted and the previously computed conformity scores are discarded before
+        the new fit. Call `reset()` explicitly to suppress the warning.
 
         Parameters
         ----------
@@ -834,10 +853,16 @@ class JackknifeAfterBootstrapRegressor:
         Self
             This JackknifeAfterBootstrapRegressor instance, fitted and conformalized.
         """
-        _raise_error_if_method_already_called(
-            "fit_conformalize",
-            self.is_fitted_and_conformalized,
-        )
+        if self.is_fitted_and_conformalized:
+            warnings.warn(
+                "JackknifeAfterBootstrapRegressor.fit_conformalize was already "
+                "called; conformity scores from the previous fit will be "
+                "discarded. Call .reset() explicitly before fit_conformalize "
+                "to suppress this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.reset()
 
         fit_params_ = _prepare_params(fit_params)
         self._predict_params = _prepare_params(predict_params)

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -205,7 +205,10 @@ class TestWrongMethodsOrderRaisesErrorForCrossTechniques:
 
         technique.fit_conformalize(X_conformalize, y_conformalize)
 
-        if cross_technique is CrossConformalRegressor:
+        if cross_technique in (
+            CrossConformalRegressor,
+            JackknifeAfterBootstrapRegressor,
+        ):
             with pytest.warns(
                 UserWarning, match=r"fit_conformalize was already called"
             ):
@@ -427,3 +430,48 @@ class TestCrossConformalRegressorReset:
         _, intervals_reference = reference_technique.predict_interval(X_test)
 
         np.testing.assert_allclose(intervals_refit, intervals_reference)
+
+
+class TestJackknifeAfterBootstrapRegressorReset:
+    def test_reset_clears_state(self, dataset_regression) -> None:
+        _, X_conformalize, _, _, y_conformalize, _ = dataset_regression
+        technique = JackknifeAfterBootstrapRegressor(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+        assert technique.is_fitted_and_conformalized
+
+        returned = technique.reset()
+        assert returned is technique
+        assert not technique.is_fitted_and_conformalized
+        assert technique._predict_params == {}
+
+    def test_explicit_reset_then_refit_does_not_warn(self, dataset_regression) -> None:
+        _, X_conformalize, _, _, y_conformalize, _ = dataset_regression
+        technique = JackknifeAfterBootstrapRegressor(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+        technique.reset()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            technique.fit_conformalize(X_conformalize, y_conformalize)
+        assert technique.is_fitted_and_conformalized
+
+    def test_refit_produces_calibration_from_second_dataset(
+        self, dataset_regression
+    ) -> None:
+        _, X_conformalize, X_test, _, y_conformalize, _ = dataset_regression
+        scale_a, scale_b = 0.5, 50.0
+
+        refit_technique = JackknifeAfterBootstrapRegressor(
+            estimator=DummyRegressor(), random_state=RANDOM_STATE
+        )
+        refit_technique.fit_conformalize(X_conformalize, y_conformalize * scale_a)
+        with pytest.warns(UserWarning):
+            refit_technique.fit_conformalize(X_conformalize, y_conformalize * scale_b)
+        _, intervals_refit = refit_technique.predict_interval(X_test)
+
+        reference_technique = JackknifeAfterBootstrapRegressor(
+            estimator=DummyRegressor(), random_state=RANDOM_STATE
+        )
+        reference_technique.fit_conformalize(X_conformalize, y_conformalize * scale_b)
+        _, intervals_reference = reference_technique.predict_interval(X_test)
+
+        np.testing.assert_allclose(intervals_refit, intervals_reference, rtol=0.05)


### PR DESCRIPTION
# Description

Propagates the `reset()` + `UserWarning` pattern from #931 to `JackknifeAfterBootstrapRegressor`, per @GBrelurut's invitation in [#710 (comment)](https://github.com/scikit-learn-contrib/MAPIE/issues/710#issuecomment-4541586434):
> "I think it is best to have a narrow scope on `CrossConformalRegressor` and
> propagate later to other objects (it will be easier to handle by the
> maintenance team)."

Concretely:

- **Adds a public `reset()` method** on `JackknifeAfterBootstrapRegressor` that discards conformity scores computed during a prior `fit_conformalize`, returning the instance to its pre-fit state (returns `self` for fluent-API chaining, mirroring `CrossConformalRegressor.reset()` landed in #931).
- **Replaces the `_raise_error_if_method_already_called` guard inside `fit_conformalize`**: on an already-fitted instance, the method now emits a `UserWarning` and internally calls `self.reset()` before proceeding with the new fit. Users who want surprise-free behavior can call `.reset()`explicitly to suppress the warning.

The diff is intentionally a near-copy of #931 with `Jackknife...` substituted for `Cross...` — same design, same semantics, same warning shape. Same calibration-leakage guarantee.

## Note on the calibration-leakage test tolerance

`test_refit_produces_calibration_from_second_dataset` uses `rtol=0.05` instead of bit-identical equality (which the equivalent test for `CrossConformalRegressor` uses). Reason: `JackknifeAfterBootstrapRegressor` draws bootstrap resamples via `Subsample`, whose internal RNG state advances on each `fit_conformalize` call. `reset()` intentionally does not reset that RNG (that would be an over-broad reset, and the constructor's `random_state` is meant to seed reproducibility, not provide call-by-call determinism). So refit-after-reset produces results that differ from a fresh instance by ~2% statistical variance — well within `rtol=0.05`, and several orders of magnitude tighter than what calibration leakage would produce (the between-scale ratio is 100× in the test data, so any leakage would fail the assertion by orders of magnitude).

This is scoped to Jackknife only; `CrossConformalRegressor`'s test in #931 still asserts bit-identical equality because KFold is deterministic given `random_state`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (docstring updated on
  `fit_conformalize`; new docstring on `reset()`)

# How Has This Been Tested?

Full local CI passes: `make lint && make format && make type-check && make coverage`
— **2555 tests passing (+3 from new tests), 100% coverage** in 1m 42s.

- [x] `test_common.py::TestWrongMethodsOrderRaisesErrorForCrossTechniques::test_wrong_methods_order`: extended the existing branching so `JackknifeAfterBootstrapRegressor` joins `CrossConformalRegressor` on the `UserWarning` path; `CrossConformalClassifier` still asserts the existing `ValueError` (unchanged — classifier is out of scope for this PR per the narrow propagation plan).
- [x] **New** `test_common.py::TestJackknifeAfterBootstrapRegressorReset` with three focused tests (parallel to the three landed in #931):
  - `test_reset_clears_state`: `.reset()` returns `self`, clears
    `is_fitted_and_conformalized`, and resets `_predict_params` to `{}`.
  - `test_explicit_reset_then_refit_does_not_warn`: calling `.reset()`
    before `fit_conformalize` suppresses the `UserWarning`
    (verified with `warnings.simplefilter("error", UserWarning)`).
  - `test_refit_produces_calibration_from_second_dataset`: fit on `y * 0.5`,
    then refit on `y * 50.0`; verifies the resulting prediction intervals
    match a freshly-constructed instance fit only on `y * 50.0` within
    `rtol=0.05` (see PR description for the bootstrap-RNG rationale).

Reproduce:
uv sync --python 3.12 --extra dev --extra docs --extra notebooks
make lint && make format && make type-check && make coverage



# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`

## Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) and [AUTHORS.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.md) files (HISTORY.md updated this PR; AUTHORS.md already lists me from #923).