### PR TITLE
fix: propagate random_state to Subsample in JackknifeAfterBootstrapRegressor

### DIFF
--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -780,7 +780,7 @@ class JackknifeAfterBootstrapRegressor:
             JackknifeAfterBootstrapRegressor._VALID_AGGREGATION_METHODS,
         )
 
-        cv = self._check_and_convert_resampling_to_cv(resampling)
+        cv = self._check_and_convert_resampling_to_cv(resampling, random_state)
 
         self._mapie_regressor = _MapieRegressor(
             estimator=estimator,
@@ -980,9 +980,10 @@ class JackknifeAfterBootstrapRegressor:
     @staticmethod
     def _check_and_convert_resampling_to_cv(
         resampling: Union[int, Subsample],
+        random_state: Optional[Union[int, np.random.RandomState]] = None,
     ) -> Subsample:
         if isinstance(resampling, int):
-            cv = Subsample(n_resamplings=resampling)
+            cv = Subsample(n_resamplings=resampling, random_state=random_state)
         elif isinstance(resampling, Subsample):
             cv = resampling
         else:


### PR DESCRIPTION
## Problem

`JackknifeAfterBootstrapRegressor`'s CI test `test_refit_produces_calibration_from_second_dataset` failed on macOS with intervals exceeding the `rtol=0.05` tolerance.

The failure was not macOS-specific — it exposed a latent non-determinism. The `random_state` passed to `JackknifeAfterBootstrapRegressor` was **never forwarded** to the `Subsample` cv constructed from the default integer `resampling` value. As a result, `Subsample(random_state=None)` fell back to the **global numpy RNG** during bootstrap resampling.

This made results depend on global RNG state and call order: the test's `refit_technique` calls `fit_conformalize` twice (consuming the global RNG twice) while the `reference_technique` calls it once, leaving the two in different RNG states and producing different bootstrap samples. The tolerance masked the divergence on Linux but it crossed the threshold on macOS. The divergence is reproducible on Linux too.

## Fix

Thread the regressor's `random_state` into the `Subsample` when it is built from an integer `resampling`:

- `__init__`: `cv = self._check_and_convert_resampling_to_cv(resampling, random_state)`
- `_check_and_convert_resampling_to_cv`: accept `random_state` and pass it to `Subsample(n_resamplings=resampling, random_state=random_state)`

A user-supplied `Subsample` is left untouched (the user owns its `random_state`).

This also closes a genuine reproducibility gap in the public API: previously two identical `JackknifeAfterBootstrapRegressor(random_state=1)` instances could produce different intervals depending on global RNG history.

## Testing

`test_common`, `test_subsample`, and `test_regression` suites pass (456 tests), including both previously failing `test_refit_produces_calibration_from_second_dataset` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)