### PR TITLE
doc: add risk control example for defining a custom risk

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # History
 
 ## 1.x.x (2026-xx-xx)
+* Add a risk control advanced-analysis example showing how to define and control a custom risk (specificity) with `BinaryRisk` and the `BinaryClassificationController`.
 * Add validation that a custom `BinaryRisk` returns per-sample occurrence values that are binary indicators (booleans, or values equal to 0 or 1); a `ValueError` is now raised otherwise, as the binary Hoeffding-Bentkus guarantees require it.
 * Simplify internal `sample_weight` handling in classification module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
 * Simplify internal `sample_weight` handling in quantile regression module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)

--- a/doc/stylesheets/extra.css
+++ b/doc/stylesheets/extra.css
@@ -87,8 +87,10 @@
 }
 
 /* Fix gallery section headings overlapping with floated thumbnails.
-   Increase container size so captions don't overflow, and use
-   inline-block to prevent float bleed. */
+   Use inline-block to prevent float bleed. `min-height` keeps short cards
+   aligned, while letting tall cards grow so long titles aren't clipped
+   (hence no `overflow: hidden`). Each inline-block row sizes to its tallest
+   card, so growing cards don't overlap the next row. */
 .mkd-glr-thumbcontainer {
   float: none !important;
   display: inline-block;
@@ -96,7 +98,6 @@
   width: 190px;
   min-height: 220px !important;
   margin: 6px;
-  overflow: hidden;
 }
 
 .mkd-glr-thumbcontainer a.internal {

--- a/doc/stylesheets/extra.css
+++ b/doc/stylesheets/extra.css
@@ -90,12 +90,14 @@
    Use inline-block to prevent float bleed. `min-height` keeps short cards
    aligned, while letting tall cards grow so long titles aren't clipped
    (hence no `overflow: hidden`). Each inline-block row sizes to its tallest
-   card, so growing cards don't overlap the next row. */
+   card, so growing cards don't overlap the next row.
+   The width is set so 4 cards fit per row (instead of 5), giving titles more
+   horizontal space and reducing wrapping. */
 .mkd-glr-thumbcontainer {
   float: none !important;
   display: inline-block;
   vertical-align: top;
-  width: 190px;
+  width: 240px;
   min-height: 220px !important;
   margin: 6px;
 }
@@ -106,7 +108,7 @@
 
 .mkd-glr-thumbcontainer img {
   max-height: 112px;
-  max-width: 180px;
+  max-width: 230px;
 }
 
 .mkd-glr-clear {

--- a/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
+++ b/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
@@ -65,12 +65,8 @@ clf.fit(X_train, y_train)
 #
 # For specificity (true negative rate), we look at the actual negatives
 # (``y_true == 0``, the condition) and count those that are correctly predicted
-# as negative (``y_pred == 0``, the occurrence):
-#
-# $$
-# \text{specificity} = \frac{\#(y_{pred} = 0 \text{ and } y_{true} = 0)}
-#                            {\#(y_{true} = 0)}
-# $$
+# as negative (``y_pred == 0``, the occurrence). In other words,
+# ``specificity = count(y_pred == 0 and y_true == 0) / count(y_true == 0)``.
 #
 # Because a higher specificity is better, we set ``higher_is_better=True`` so
 # that MAPIE treats it as a performance metric rather than a risk.

--- a/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
+++ b/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
@@ -18,7 +18,6 @@ raising too many alarms on healthy/benign cases, while keeping recall (the
 ability to catch the positive cases) as high as possible.
 """
 
-
 import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.datasets import make_circles

--- a/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
+++ b/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
@@ -1,0 +1,196 @@
+"""
+Defining a custom risk for binary classification
+================================================
+
+
+MAPIE ships with several predefined risks and performance metrics for binary
+classification (precision, recall, accuracy, false positive rate...). When the
+metric you care about is not one of them, you can define your own with
+`BinaryRisk` and control it exactly like a predefined one.
+
+In this example, we show how to define
+**specificity** (the true negative rate) as a custom risk and use it with the
+`BinaryClassificationController`.
+
+Specificity is the proportion of actual negatives that are correctly predicted
+as negative. It is a natural target in screening problems where we want to avoid
+raising too many alarms on healthy/benign cases, while keeping recall (the
+ability to catch the positive cases) as high as possible.
+"""
+
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.datasets import make_circles
+from sklearn.metrics import recall_score
+from sklearn.neural_network import MLPClassifier
+
+from mapie.risk_control import BinaryClassificationController, BinaryRisk
+from mapie.utils import train_conformalize_test_split
+
+RANDOM_STATE = 42
+
+##############################################################################
+# First, load the dataset and split it into training, calibration
+# (for conformalization), and test sets, then fit a classifier on the training
+# data.
+
+X, y = make_circles(n_samples=5000, noise=0.3, factor=0.3, random_state=RANDOM_STATE)
+(X_train, X_calib, X_test, y_train, y_calib, y_test) = train_conformalize_test_split(
+    X,
+    y,
+    train_size=0.7,
+    conformalize_size=0.1,
+    test_size=0.2,
+    random_state=RANDOM_STATE,
+)
+
+clf = MLPClassifier(max_iter=150, random_state=RANDOM_STATE)
+clf.fit(X_train, y_train)
+
+##############################################################################
+# Defining the custom risk
+# -------------------------
+#
+# Any metric that can be written as
+# ``sum(occurrence if condition) / sum(condition)`` can be controlled by the
+# `BinaryClassificationController`, thanks to the Learn Then Test framework
+# implemented in MAPIE.
+#
+# A `BinaryRisk` is therefore defined by two per-sample functions, both taking
+# the ground-truth labels ``y_true`` and the predictions ``y_pred`` and
+# returning boolean arrays:
+#
+# - ``risk_condition``: which samples count towards the metric (the denominator),
+# - ``risk_occurrence``: among those, which ones are a "success" (the numerator).
+#
+# For specificity (true negative rate), we look at the actual negatives
+# (``y_true == 0``, the condition) and count those that are correctly predicted
+# as negative (``y_pred == 0``, the occurrence):
+#
+# .. math::
+#     \text{specificity} = \frac{\sum (y_{pred} = 0 \text{ if } y_{true} = 0)}
+#                               {\sum (y_{true} = 0)}
+#
+# Because a higher specificity is better, we set ``higher_is_better=True`` so
+# that MAPIE treats it as a performance metric rather than a risk.
+
+specificity = BinaryRisk(
+    risk_occurrence=lambda y_true, y_pred: y_pred == 0,
+    risk_condition=lambda y_true, y_pred: y_true == 0,
+    higher_is_better=True,
+)
+
+##############################################################################
+# Controlling the custom risk
+# ----------------------------
+#
+# We now initialize a `BinaryClassificationController` using the probability
+# estimation function of the fitted estimator (``clf.predict_proba``), our
+# custom ``specificity`` risk, a target level, and a confidence level. The
+# controller thresholds the predicted probability of the positive class: a
+# higher threshold predicts fewer positives, which mechanically increases
+# specificity but lowers recall.
+#
+# When a custom risk is used, ``best_predict_param_choice="auto"`` cannot guess
+# a sensible secondary objective, so we specify one explicitly. Here we maximize
+# recall: among all thresholds that guarantee the target specificity, the
+# controller selects the one that catches the most positive cases.
+
+target_specificity = 0.8
+confidence_level = 0.9
+bcc = BinaryClassificationController(
+    clf.predict_proba,
+    specificity,
+    target_level=target_specificity,
+    confidence_level=confidence_level,
+    best_predict_param_choice="recall",
+)
+bcc.calibrate(X_calib, y_calib)
+
+print(
+    f"{len(bcc.valid_predict_params)} thresholds found that guarantee a specificity "
+    f"of at least {target_specificity} with a confidence of {confidence_level}.\n"
+    "Among those, the one that maximizes the secondary objective (recall here) is: "
+    f"{bcc.best_predict_param:.2f}."
+)
+
+##############################################################################
+# Just like with a predefined risk, we can visualize how the threshold values
+# impact specificity and which thresholds are statistically guaranteed.
+
+proba_positive_class = clf.predict_proba(X_calib)[:, 1]
+
+tested_thresholds = bcc._predict_params
+specificities = np.full(len(tested_thresholds), np.inf)
+for i, threshold in enumerate(tested_thresholds):
+    y_pred = (proba_positive_class >= threshold).astype(int)
+    # specificity is the recall of the negative class
+    specificities[i] = recall_score(y_calib, y_pred, pos_label=0)
+
+valid_thresholds_indices = np.array(
+    [t in bcc.valid_predict_params for t in tested_thresholds]
+)
+best_threshold_index = np.where(tested_thresholds == bcc.best_predict_param)[0][0]
+
+plt.figure()
+plt.scatter(
+    tested_thresholds[valid_thresholds_indices],
+    specificities[valid_thresholds_indices],
+    c="tab:green",
+    label="Valid thresholds",
+)
+plt.scatter(
+    tested_thresholds[~valid_thresholds_indices],
+    specificities[~valid_thresholds_indices],
+    c="tab:red",
+    label="Invalid thresholds",
+)
+plt.scatter(
+    tested_thresholds[best_threshold_index],
+    specificities[best_threshold_index],
+    c="tab:green",
+    label="Best threshold",
+    marker="*",
+    edgecolors="k",
+    s=300,
+)
+plt.axhline(target_specificity, color="tab:gray", linestyle="--")
+plt.text(
+    0.05,
+    target_specificity + 0.02,
+    "Target specificity",
+    color="tab:gray",
+    fontstyle="italic",
+)
+plt.xlabel("Threshold")
+plt.ylabel("Specificity")
+plt.legend()
+plt.show()
+
+##############################################################################
+# Like in the quickstart, low thresholds correspond to specificity values below
+# the target and are therefore invalid. Some thresholds whose empirical
+# specificity is above the target are also rejected: risk control takes a margin
+# to account for the uncertainty due to the finite size of the calibration set,
+# so that the guarantee holds on unseen data with high probability.
+#
+# We can confirm this on the test set by using the ``predict`` method of the
+# controller, which applies the best threshold.
+
+y_pred_test = bcc.predict(X_test)
+test_specificity = recall_score(y_test, y_pred_test, pos_label=0)
+test_recall = recall_score(y_test, y_pred_test, pos_label=1)
+
+print(
+    "With the best threshold, on the test set:\n"
+    f"- specificity is {test_specificity:.3f} (target was {target_specificity}),\n"
+    f"- recall is {test_recall:.3f}."
+)
+
+##############################################################################
+# The specificity measured on the test set is close to (and above) the target,
+# illustrating that the guarantee obtained on the calibration set transfers to
+# unseen data. The same recipe applies to any binary metric that can be written
+# as ``sum(occurrence if condition) / sum(condition)``: define it once with
+# `BinaryRisk`, then control it with the `BinaryClassificationController`.

--- a/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
+++ b/examples/risk_control/2-advanced-analysis/plot_risk_control_custom_risk.py
@@ -67,9 +67,10 @@ clf.fit(X_train, y_train)
 # (``y_true == 0``, the condition) and count those that are correctly predicted
 # as negative (``y_pred == 0``, the occurrence):
 #
-# .. math::
-#     \text{specificity} = \frac{\sum (y_{pred} = 0 \text{ if } y_{true} = 0)}
-#                               {\sum (y_{true} = 0)}
+# $$
+# \text{specificity} = \frac{\#(y_{pred} = 0 \text{ and } y_{true} = 0)}
+#                            {\#(y_{true} = 0)}
+# $$
 #
 # Because a higher specificity is better, we set ``higher_is_better=True`` so
 # that MAPIE treats it as a performance metric rather than a risk.


### PR DESCRIPTION
Add an advanced-analysis example showing how to define and control a custom risk (specificity) with BinaryRisk and BinaryClassificationController, inspired by the risk control quickstart.
