### PR TITLE
fix: bug for which the best threshold is not optimal + relax monotonicity check

### DIFF
--- a/mapie/risk_control/binary_classification.py
+++ b/mapie/risk_control/binary_classification.py
@@ -308,6 +308,7 @@ class BinaryClassificationController:
                 y_calibrate_,
                 predictions_per_param,
                 valid_params_index,
+                risk_values,
             )
 
         self.p_values = p_values
@@ -480,16 +481,24 @@ class BinaryClassificationController:
         y_calibrate_: NDArray,
         predictions_per_param: NDArray,
         valid_params_index: List[Any],
+        risk_values: NDArray,
     ):
         secondary_risks_per_param, _ = self._get_risk_values_and_eff_sample_sizes(
             y_calibrate_,
             predictions_per_param[valid_params_index],
             [self._best_predict_param_choice],
         )
-
-        self.best_predict_param = self.valid_predict_params[
-            np.argmin(secondary_risks_per_param)
-        ]
+        best_index = np.flatnonzero(
+            secondary_risks_per_param == secondary_risks_per_param.min()
+        )
+        if len(best_index) > 1:
+            # When several parameters reach the minimum secondary risk, break ties by
+            # selecting the one that maximizes the first risk (te be less conservative).
+            first_risk_values = risk_values[0, valid_params_index]
+            best_index = best_index[np.argmax(first_risk_values[best_index])]
+        else:
+            best_index = best_index[0]
+        self.best_predict_param = self.valid_predict_params[best_index]
         if isinstance(self.best_predict_param, np.ndarray):
             self.best_predict_param = tuple(self.best_predict_param.tolist())
 

--- a/mapie/risk_control/methods.py
+++ b/mapie/risk_control/methods.py
@@ -317,7 +317,7 @@ def ltt_procedure(
     )  # to handle multiple risks, take max over risks (no effect if mono risk)
 
     # Fixed Sequence Testing (FST) only supports a single monotonic risk.
-    # - If non-monotonic: raise error.
+    # - If non-monotonic: raise warning.
     # - If decreasing: reverse order so FST tests easiest -> hardest;
     #   store permutation to remap indices afterward.
     order = None
@@ -331,7 +331,14 @@ def ltt_procedure(
         direction = _check_risk_monotonicity(r_hat[0])
 
         if direction == "none":
-            raise ValueError("fixed_sequence requires a monotonic risk over lambdas.")
+            warnings.warn(
+                "Fixed sequence testing requires a monotonic risk over lambdas (thresholds) to find "
+                "optimal solutions but this hypothesis is not verified here. "
+                "We recommand you try split_fixed_sequence instead if the hypothesis ordering is not known a priori.",
+                UserWarning,
+            )
+            average_variation = np.mean(np.diff(r_hat[0]))
+            direction = "increasing" if average_variation > 0 else "decreasing"
 
         if direction == "decreasing":
             order = np.arange(len(p_values))[::-1]

--- a/mapie/tests/risk_control/test_binary_classification_control.py
+++ b/mapie/tests/risk_control/test_binary_classification_control.py
@@ -500,6 +500,7 @@ class TestBinaryClassificationControllerSetBestPredictParam:
             y_calibrate_=dummy_y,
             predictions_per_param=dummy_predictions,
             valid_params_index=valid_params_index,
+            risk_values=np.array([[0.5]]),
         )
 
         assert controller.best_predict_param == dummy_single_param[0]
@@ -525,6 +526,7 @@ class TestBinaryClassificationControllerSetBestPredictParam:
             y_calibrate_=y_calibrate,
             predictions_per_param=predictions_per_param,
             valid_params_index=valid_params_index,
+            risk_values=np.array([[0.5, 0.7]]),
         )
 
         assert controller.best_predict_param == expected
@@ -549,6 +551,7 @@ class TestBinaryClassificationControllerSetBestPredictParam:
             y_calibrate_=y_calibrate,
             predictions_per_param=predictions_per_param,
             valid_params_index=valid_params_index,
+            risk_values=np.array([[0.5]]),
         )
         assert controller.best_predict_param == dummy_single_param[0]
 

--- a/mapie/tests/risk_control/test_risk_control.py
+++ b/mapie/tests/risk_control/test_risk_control.py
@@ -217,12 +217,18 @@ def test_ltt_fst_multirisk_error():
         ltt_procedure(r_hat, alpha_np, delta, n_obs, fwer_method="fixed_sequence")
 
 
-def test_ltt_fst_non_monotone_error():
-    r_hat = np.array([[0.1, 0.4, 0.2]])
+@pytest.mark.parametrize(
+    "r_hat",
+    [
+        np.array([[0.1, 0.4, 0.2]]),  # increasing on average
+        np.array([[0.4, 0.1, 0.2]]),  # decreasing on average
+    ],
+)
+def test_ltt_fst_non_monotone_warns(r_hat):
     n_obs = np.ones_like(r_hat)
     alpha_np = np.array([[0.5]])
 
-    with pytest.raises(ValueError, match=r".*requires a monotonic risk.*"):
+    with pytest.warns(UserWarning, match=r".*requires a monotonic risk.*"):
         ltt_procedure(r_hat, alpha_np, 0.1, n_obs, fwer_method="fixed_sequence")
 
 


### PR DESCRIPTION
1. Fix a bug where the best predict param is not optimal: when the secondary risk is minimum at several indices, now we explicitely maximize the original risk (to be less conservative) instead of naively picking the first index as previously.

2. replace error with warning when the risk is not monotone. Useful when applying FST e.g. to precision which returned an error previously.