### PR TITLE
fix: allow refitting CrossConformalClassifier via fit_conformalize and add reset()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@
 * Add `reset()` method on `CrossConformalRegressor` and allow refitting via `fit_conformalize` (now emits a `UserWarning` and discards prior conformity scores instead of raising). Same pattern can be propagated to other conformal classes in follow-up PRs. (issue #710)
 * Add a repository backup of the BlogFeedback dataset (`examples/data/blogData_train.zip`) used by the Kim et al. (2020) example, now loaded by default so the example no longer depends on the UCI download server.
 * Add `reset()` method on `JackknifeAfterBootstrapRegressor` and allow refitting via `fit_conformalize` (mirrors the pattern landed for `CrossConformalRegressor` in #931).
+* Add `reset()` method on `CrossConformalClassifier` and allow refitting via `fit_conformalize` (mirrors the pattern landed in #931 and #936); completes the warn-on-refit pattern across all Cross/Jackknife conformal techniques.
 
 ## 1.4.0 (2026-04-30)
 

--- a/mapie/classification.py
+++ b/mapie/classification.py
@@ -432,6 +432,20 @@ class CrossConformalClassifier:
 
         self._predict_params: dict = {}
 
+    def reset(self) -> CrossConformalClassifier:
+        """
+        Discard previously computed conformity scores so that
+        `fit_conformalize` can be called again with new data.
+
+        Returns
+        -------
+        Self
+            This CrossConformalClassifier instance, reset to its pre-fit state.
+        """
+        self.is_fitted_and_conformalized = False
+        self._predict_params = {}
+        return self
+
     def fit_conformalize(
         self,
         X: ArrayLike,
@@ -444,6 +458,10 @@ class CrossConformalClassifier:
         Estimates the uncertainty of the base classifier in a cross-validation style:
         fits the base classifier on different folds of the dataset
         and computes conformity scores on the corresponding out-of-fold data.
+
+        If called on an instance that has already been fitted, a `UserWarning` is
+        emitted and the previously computed conformity scores are discarded before
+        the new fit. Call `reset()` explicitly to suppress the warning.
 
         Parameters
         ----------
@@ -469,10 +487,16 @@ class CrossConformalClassifier:
         Self
             This CrossConformalClassifier instance, fitted and conformalized.
         """
-        _raise_error_if_method_already_called(
-            "fit_conformalize",
-            self.is_fitted_and_conformalized,
-        )
+        if self.is_fitted_and_conformalized:
+            warnings.warn(
+                "CrossConformalClassifier.fit_conformalize was already called; "
+                "conformity scores from the previous fit will be discarded. "
+                "Call .reset() explicitly before fit_conformalize to suppress "
+                "this warning.",
+                UserWarning,
+                stacklevel=2,
+            )
+            self.reset()
 
         fit_params_ = _prepare_params(fit_params)
         self._predict_params = _prepare_params(predict_params)

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -205,19 +205,8 @@ class TestWrongMethodsOrderRaisesErrorForCrossTechniques:
 
         technique.fit_conformalize(X_conformalize, y_conformalize)
 
-        if cross_technique in (
-            CrossConformalRegressor,
-            JackknifeAfterBootstrapRegressor,
-        ):
-            with pytest.warns(
-                UserWarning, match=r"fit_conformalize was already called"
-            ):
-                technique.fit_conformalize(X_conformalize, y_conformalize)
-        else:
-            with pytest.raises(
-                ValueError, match=r"fit_conformalize method already called"
-            ):
-                technique.fit_conformalize(X_conformalize, y_conformalize)
+        with pytest.warns(UserWarning, match=r"fit_conformalize was already called"):
+            technique.fit_conformalize(X_conformalize, y_conformalize)
 
 
 def test_cross_conformal_regressor_rejects_subsample():
@@ -475,3 +464,51 @@ class TestJackknifeAfterBootstrapRegressorReset:
         _, intervals_reference = reference_technique.predict_interval(X_test)
 
         np.testing.assert_allclose(intervals_refit, intervals_reference, rtol=0.05)
+
+
+class TestCrossConformalClassifierReset:
+    def test_reset_clears_state(self, dataset_classification) -> None:
+        _, X_conformalize, _, _, y_conformalize, _ = dataset_classification
+        technique = CrossConformalClassifier(estimator=DummyClassifier())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+        assert technique.is_fitted_and_conformalized
+
+        returned = technique.reset()
+        assert returned is technique
+        assert not technique.is_fitted_and_conformalized
+        assert technique._predict_params == {}
+
+    def test_explicit_reset_then_refit_does_not_warn(
+        self, dataset_classification
+    ) -> None:
+        _, X_conformalize, _, _, y_conformalize, _ = dataset_classification
+        technique = CrossConformalClassifier(estimator=DummyClassifier())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+        technique.reset()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            technique.fit_conformalize(X_conformalize, y_conformalize)
+        assert technique.is_fitted_and_conformalized
+
+    def test_refit_produces_calibration_from_second_dataset(
+        self, dataset_classification
+    ) -> None:
+        _, X_conformalize, X_test, _, y_conformalize, _ = dataset_classification
+        rng = np.random.RandomState(RANDOM_STATE)
+        y_perm = rng.permutation(y_conformalize)
+
+        refit_technique = CrossConformalClassifier(
+            estimator=DummyClassifier(), random_state=RANDOM_STATE
+        )
+        refit_technique.fit_conformalize(X_conformalize, y_conformalize)
+        with pytest.warns(UserWarning):
+            refit_technique.fit_conformalize(X_conformalize, y_perm)
+        _, sets_refit = refit_technique.predict_set(X_test)
+
+        reference_technique = CrossConformalClassifier(
+            estimator=DummyClassifier(), random_state=RANDOM_STATE
+        )
+        reference_technique.fit_conformalize(X_conformalize, y_perm)
+        _, sets_reference = reference_technique.predict_set(X_test)
+
+        np.testing.assert_array_equal(sets_refit, sets_reference)


### PR DESCRIPTION
# Description

Completes the `reset()` + `UserWarning` propagation across all Cross/Jackknifeconformal techniques, per @GBrelurut's invitation in [#710 (comment)](https://github.com/scikit-learn-contrib/MAPIE/issues/710#issuecomment-4541586434):

> "I think it is best to have a narrow scope on `CrossConformalRegressor` and
> propagate later to other objects (it will be easier to handle by the maintenance team)."

This is the third (and final, for Cross/Jackknife) PR in the series:
- #931 — `CrossConformalRegressor` (initial implementation)
- #936 — `JackknifeAfterBootstrapRegressor` (regressor mirror)
- this PR — `CrossConformalClassifier` (classifier mirror)

Concretely:

- **Adds a public `reset()` method** on `CrossConformalClassifier` that discards conformity scores computed during a prior `fit_conformalize`, returning the instance to its pre-fit state (returns `self`, matches the pattern from #931/#936).
- **Replaces the `_raise_error_if_method_already_called` guard inside `fit_conformalize`**: on an already-fitted instance, the method now emits a `UserWarning` and internally calls `self.reset()` before proceeding. Users who want surprise-free behavior can call `.reset()` explicitly.
- **Test cleanup**: in `test_common.py::TestWrongMethodsOrderRaisesErrorForCrossTechniques`, the previous PRs left a conditional whose `else: pytest.raises(...)` branch was dead once this PR lands (all three Cross/Jackknife techniques now emit the warning, none raise). Collapsed it into an unconditional `pytest.warns` assertion.

Split classes (`SplitConformalRegressor`, `ConformalizedQuantileRegressor`,`SplitConformalClassifier`) are intentionally left out of this PR. Their `fit()` and `conformalize()` guards have a different lifecycle (two-phase rather than single-phase), so the pattern needs a distinct design discussion. Happy to tackle that in a follow-up after this lands.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update (docstring updated on
  `fit_conformalize`; new docstring on `reset()`)

# How Has This Been Tested?

Full local CI passes: `make lint && make format && make type-check && make coverage`
— **2559 tests passing (+3 from new tests), 100% coverage** in 1m 41s.

- [x] `test_common.py::TestWrongMethodsOrderRaisesErrorForCrossTechniques::test_wrong_methods_order`: collapsed the previously-branched assertion to an unconditional `pytest.warns(UserWarning, ...)` — all three Cross/Jackknife techniques (`CrossConformalRegressor`, `JackknifeAfterBootstrapRegressor`, `CrossConformalClassifier`) now share the same refit behavior.
- [x] **New** `test_common.py::TestCrossConformalClassifierReset` with three focused tests (parallel to those landed in #931 and #936):
  - `test_reset_clears_state`: `.reset()` returns `self`, clears `is_fitted_and_conformalized`, resets `_predict_params` to `{}`.
  - `test_explicit_reset_then_refit_does_not_warn`: calling `.reset()` before `fit_conformalize` suppresses the`UserWarning` (verified with `warnings.simplefilter("error", UserWarning)`).
  - `test_refit_produces_calibration_from_second_dataset`: classifier analog of the regressor leakage test — fit on `y_conformalize`, refit on `np.random.RandomState(...).permutation(y_conformalize)`, verify the resulting `predict_set` output matches a freshly-constructed instance fit only on the permuted labels. Bit-identical equality(`assert_array_equal`) since `CrossConformalClassifier` uses deterministic `KFold` under `random_state`.

Reproduce:
uv sync --python 3.12 --extra dev --extra docs --extra notebooks
make lint && make format && make type-check && make coverage



# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc`
- [ ] When updating documentation: code examples in doc run successfully: `make doctest`

## Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) and [AUTHORS.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.md) files (HISTORY.md updated this PR; AUTHORS.md already lists me from #923).