### PR TITLE
fix: restore backward compatibility for predict-argument renames (#906)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # History
 
 ## 1.x.x (2026-xx-xx)
+* Restore backward compatibility for the predict-argument renames introduced in #919: `CrossConformalRegressor`'s `aggregate_predictions` and `JackknifeAfterBootstrapRegressor`'s `ensemble` (in `predict` and `predict_interval`) keep working as deprecated aliases for `aggregate_point_predictions`, now emitting a `FutureWarning` instead of raising a `TypeError`. (issue #906)
 * Add a risk control advanced-analysis example showing how to define and control a custom risk (specificity) with `BinaryRisk` and the `BinaryClassificationController`.
 * Add validation that a custom `BinaryRisk` returns per-sample occurrence values that are binary indicators (booleans, or values equal to 0 or 1); a `ValueError` is now raised otherwise, as the binary Hoeffding-Bentkus guarantees require it.
 * Simplify internal `sample_weight` handling in classification module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)

--- a/mapie/regression/regression.py
+++ b/mapie/regression/regression.py
@@ -40,7 +40,9 @@ from mapie.utils import (
     _raise_error_if_fit_called_in_prefit_mode,
     _raise_error_if_method_already_called,
     _raise_error_if_previous_method_not_called,
+    _resolve_renamed_parameter,
     _transform_confidence_level_to_alpha_list,
+    _UNSET,
     check_is_fitted,
     check_sklearn_user_model_is_fitted,
 )
@@ -533,6 +535,7 @@ class CrossConformalRegressor:
         aggregate_point_predictions: Optional[str] = "mean",
         minimize_interval_width: bool = False,
         allow_infinite_bounds: bool = False,
+        aggregate_predictions: Any = _UNSET,
     ) -> Tuple[NDArray, NDArray]:
         """
         Predicts points and intervals.
@@ -563,6 +566,12 @@ class CrossConformalRegressor:
         allow_infinite_bounds : bool, default=False
             If True, allows prediction intervals with infinite bounds.
 
+        aggregate_predictions : Optional[str]
+            .. deprecated::
+                Renamed to `aggregate_point_predictions`. Passing
+                `aggregate_predictions` still works but emits a
+                `FutureWarning` and will be removed in a future release.
+
         Returns
         -------
         Tuple[NDArray, NDArray]
@@ -571,6 +580,12 @@ class CrossConformalRegressor:
             - Prediction points, of shape `(n_samples,)`
             - Prediction intervals, of shape `(n_samples, 2, n_confidence_levels)`
         """
+        aggregate_point_predictions = _resolve_renamed_parameter(
+            "aggregate_point_predictions",
+            aggregate_point_predictions,
+            "aggregate_predictions",
+            aggregate_predictions,
+        )
         _raise_error_if_previous_method_not_called(
             "predict_interval",
             "fit_conformalize",
@@ -594,6 +609,7 @@ class CrossConformalRegressor:
         self,
         X: ArrayLike,
         aggregate_point_predictions: Optional[str] = "mean",
+        aggregate_predictions: Any = _UNSET,
     ) -> NDArray:
         """
         Predicts points.
@@ -615,11 +631,23 @@ class CrossConformalRegressor:
             - "median": Aggregates (using median) the predictions of the regressors
               trained on each cross-validation fold
 
+        aggregate_predictions : Optional[str]
+            .. deprecated::
+                Renamed to `aggregate_point_predictions`. Passing
+                `aggregate_predictions` still works but emits a
+                `FutureWarning` and will be removed in a future release.
+
         Returns
         -------
         NDArray
             Array of point predictions, with shape `(n_samples,)`.
         """
+        aggregate_point_predictions = _resolve_renamed_parameter(
+            "aggregate_point_predictions",
+            aggregate_point_predictions,
+            "aggregate_predictions",
+            aggregate_predictions,
+        )
         _raise_error_if_previous_method_not_called(
             "predict",
             "fit_conformalize",
@@ -882,6 +910,7 @@ class JackknifeAfterBootstrapRegressor:
         aggregate_point_predictions: bool = True,
         minimize_interval_width: bool = False,
         allow_infinite_bounds: bool = False,
+        ensemble: Any = _UNSET,
     ) -> Tuple[NDArray, NDArray]:
         """
         Predicts points and intervals.
@@ -911,6 +940,12 @@ class JackknifeAfterBootstrapRegressor:
         allow_infinite_bounds : bool, default=False
             If True, allows prediction intervals with infinite bounds.
 
+        ensemble : bool
+            .. deprecated::
+                Renamed to `aggregate_point_predictions`. Passing `ensemble`
+                still works but emits a `FutureWarning` and will be removed in
+                a future release.
+
         Returns
         -------
         Tuple[NDArray, NDArray]
@@ -919,6 +954,12 @@ class JackknifeAfterBootstrapRegressor:
             - Prediction points, of shape `(n_samples,)`
             - Prediction intervals, of shape `(n_samples, 2, n_confidence_levels)`
         """
+        aggregate_point_predictions = _resolve_renamed_parameter(
+            "aggregate_point_predictions",
+            aggregate_point_predictions,
+            "ensemble",
+            ensemble,
+        )
         _raise_error_if_previous_method_not_called(
             "predict_interval",
             "fit_conformalize",
@@ -939,6 +980,7 @@ class JackknifeAfterBootstrapRegressor:
         self,
         X: ArrayLike,
         aggregate_point_predictions: bool = True,
+        ensemble: Any = _UNSET,
     ) -> NDArray:
         """
         Predicts points.
@@ -958,11 +1000,23 @@ class JackknifeAfterBootstrapRegressor:
             If False, a point is predicted using the regressor trained on the entire
             data
 
+        ensemble : bool
+            .. deprecated::
+                Renamed to `aggregate_point_predictions`. Passing `ensemble`
+                still works but emits a `FutureWarning` and will be removed in
+                a future release.
+
         Returns
         -------
         NDArray
             Array of point predictions, with shape `(n_samples,)`.
         """
+        aggregate_point_predictions = _resolve_renamed_parameter(
+            "aggregate_point_predictions",
+            aggregate_point_predictions,
+            "ensemble",
+            ensemble,
+        )
         _raise_error_if_previous_method_not_called(
             "predict",
             "fit_conformalize",

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -466,6 +466,74 @@ class TestJackknifeAfterBootstrapRegressorReset:
         np.testing.assert_allclose(intervals_refit, intervals_reference, rtol=0.05)
 
 
+class TestDeprecatedAggregatePointPredictionsRenaming:
+    """The `aggregate_predictions` (CrossConformalRegressor) and `ensemble`
+    (JackknifeAfterBootstrapRegressor) arguments were renamed to
+    `aggregate_point_predictions`. The old names still work but emit a
+    `FutureWarning`."""
+
+    @staticmethod
+    def _assert_same_output(deprecated, new) -> None:
+        # `predict_interval` returns a (points, intervals) tuple, `predict` an array.
+        if isinstance(new, tuple):
+            for deprecated_array, new_array in zip(deprecated, new):
+                np.testing.assert_array_equal(deprecated_array, new_array)
+        else:
+            np.testing.assert_array_equal(deprecated, new)
+
+    @pytest.mark.parametrize("predict_method", ["predict", "predict_interval"])
+    def test_cross_conformal_aggregate_predictions_deprecated(
+        self, dataset_regression, predict_method
+    ) -> None:
+        _, X_conformalize, X_test, _, y_conformalize, _ = dataset_regression
+        technique = CrossConformalRegressor(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+
+        with pytest.warns(FutureWarning, match=r"aggregate_predictions.*deprecated"):
+            deprecated = getattr(technique, predict_method)(
+                X_test, aggregate_predictions="median"
+            )
+        new = getattr(technique, predict_method)(
+            X_test, aggregate_point_predictions="median"
+        )
+        self._assert_same_output(deprecated, new)
+
+    @pytest.mark.parametrize("predict_method", ["predict", "predict_interval"])
+    def test_jackknife_ensemble_deprecated(
+        self, dataset_regression, predict_method
+    ) -> None:
+        _, X_conformalize, X_test, _, y_conformalize, _ = dataset_regression
+        technique = JackknifeAfterBootstrapRegressor(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+
+        with pytest.warns(FutureWarning, match=r"ensemble.*deprecated"):
+            deprecated = getattr(technique, predict_method)(X_test, ensemble=False)
+        new = getattr(technique, predict_method)(
+            X_test, aggregate_point_predictions=False
+        )
+        self._assert_same_output(deprecated, new)
+
+    @pytest.mark.parametrize(
+        "technique_class, predict_method",
+        [
+            (CrossConformalRegressor, "predict"),
+            (CrossConformalRegressor, "predict_interval"),
+            (JackknifeAfterBootstrapRegressor, "predict"),
+            (JackknifeAfterBootstrapRegressor, "predict_interval"),
+        ],
+    )
+    def test_new_name_does_not_warn(
+        self, dataset_regression, technique_class, predict_method
+    ) -> None:
+        _, X_conformalize, X_test, _, y_conformalize, _ = dataset_regression
+        technique = technique_class(estimator=DummyRegressor())
+        technique.fit_conformalize(X_conformalize, y_conformalize)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            getattr(technique, predict_method)(X_test)
+
+
 class TestCrossConformalClassifierReset:
     def test_reset_clears_state(self, dataset_classification) -> None:
         _, X_conformalize, _, _, y_conformalize, _ = dataset_classification

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -1414,6 +1414,56 @@ def _check_deprecated_sample_weight_kwarg(kwargs: dict) -> None:
         )
 
 
+class _Unset:
+    """Sentinel type marking a deprecated argument that was not supplied."""
+
+
+_UNSET = _Unset()
+
+
+def _resolve_renamed_parameter(
+    new_name: str,
+    new_value: Any,
+    old_name: str,
+    old_value: Any,
+) -> Any:
+    """Resolve a renamed keyword argument, warning if the old name is used.
+
+    If the deprecated ``old_name`` argument was supplied (i.e. ``old_value``
+    is not the :data:`_UNSET` sentinel), emit a ``FutureWarning`` and return
+    that value. Otherwise return ``new_value`` unchanged.
+
+    Parameters
+    ----------
+    new_name : str
+        Name of the current (non-deprecated) parameter.
+
+    new_value : Any
+        Value passed (or defaulted) for the current parameter.
+
+    old_name : str
+        Name of the deprecated parameter.
+
+    old_value : Any
+        Value passed for the deprecated parameter, or :data:`_UNSET` if it
+        was not supplied.
+
+    Returns
+    -------
+    Any
+        The value to use for the parameter.
+    """
+    if isinstance(old_value, _Unset):
+        return new_value
+    warnings.warn(
+        f"`{old_name}` is deprecated and will be removed in a future release. "
+        f"Use `{new_name}` instead.",
+        FutureWarning,
+        stacklevel=3,
+    )
+    return old_value
+
+
 def _raise_error_if_previous_method_not_called(
     current_method_name: str,
     previous_method_name: str,


### PR DESCRIPTION
## Summary

PR #919 renamed two public `predict` / `predict_interval` arguments for consistency, but did so as a **hard rename** with no deprecation path:

- `CrossConformalRegressor`: `aggregate_predictions` → `aggregate_point_predictions`
- `JackknifeAfterBootstrapRegressor`: `ensemble` → `aggregate_point_predictions`

Existing user code passing the old names by keyword broke with a `TypeError`. This PR reintroduces the old names as **deprecated aliases**: they keep working, forward their value to the new parameter, and emit a `FutureWarning`.

## Changes

- **`mapie/utils.py`**: Add `_resolve_renamed_parameter()` helper and a `_UNSET` sentinel. If the deprecated name is supplied it warns (`FutureWarning`) and returns that value; otherwise it returns the new parameter unchanged.
- **`mapie/regression/regression.py`**: Add the old argument names back as deprecated keyword aliases on all four methods (`predict` + `predict_interval` for both classes), routing through the helper. Positional calls are unaffected (the new arg occupies the same position the old one did), so only keyword use of the old names triggers the warning. Docstrings mark each as deprecated.
- **`mapie/tests/test_common.py`**: Add `TestDeprecatedAggregatePointPredictionsRenaming` — verifies the old names warn and produce output identical to the new name, and that the new name does not warn.
- **`HISTORY.md`**: Changelog entry.

## Notes

- When the deprecated name is passed it takes precedence (and warns). Passing both the old and new name simultaneously is **not** treated as an error: the new parameter has a real default (`"mean"` / `True`), so there is no reliable way to distinguish an explicit default from an omitted argument. This matches the common deprecation-shim pattern. Happy to add a hard error on double-passing if preferred.

## Verification

`make lint`, `make format`, `mypy`, and the affected test suites (`test_common`, `test_regression`, `test_non_regression`, `test_utils`) all pass.

Closes #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)