### PR TITLE
add aucroc_score and auarc_score uncertainty metrics

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -59,5 +59,6 @@
 * Nazim Fadli <nazimfadli25@gmail.com>
 * Damien Bouet <Damien-Bouet>
 * Edgar Jaber <EdgarJaber>
+* Dresden Goehner <dr.dresden0416@gmail.com>
 
 To be continued ...

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@
 
 - Add `ConditionalSplitConformalRegressor` and `ConditionalSplitConformalClassifier`, implementing conformal prediction with conditional guarantees (Gibbs et al., 2023), adapted from https://github.com/jjcherian/conditional-conformal.
 - Add experimental multivariate standardized residuals
+- Add `aucroc_score` and `auarc_score` to `mapie/metrics/uncertainty.py` for uncertainty evaluation following Lin et al. (2023); resolves #551.
 
 ## 1.4.1 (2026-06-08)
 

--- a/mapie/metrics/__init__.py
+++ b/mapie/metrics/__init__.py
@@ -1,9 +1,11 @@
 from . import classification
 from . import calibration
 from . import regression
+from . import uncertainty
 
 __all__ = [
     "classification",
     "calibration",
     "regression",
+    "uncertainty",
 ]

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -90,30 +90,30 @@ def aucroc_score(
     Quantification for Black-box Large Language Models. TMLR.
     https://arxiv.org/abs/2305.19187
     """
-    y_wrong = column_or_1d(np.asarray(y_wrong, dtype=float))
-    y_uncertainty = column_or_1d(np.asarray(y_uncertainty, dtype=float))
+    y_wrong_arr = column_or_1d(np.asarray(y_wrong, dtype=float))
+    y_uncertainty_arr = column_or_1d(np.asarray(y_uncertainty, dtype=float))
 
-    check_consistent_length(y_wrong, y_uncertainty)
+    check_consistent_length(y_wrong_arr, y_uncertainty_arr)
 
-    if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
+    if np.any(np.isnan(y_wrong_arr)) or np.any(np.isnan(y_uncertainty_arr)):
         raise ValueError("y_wrong and y_uncertainty must not contain NaN values.")
-    if np.any(np.isinf(y_wrong)) or np.any(np.isinf(y_uncertainty)):
+    if np.any(np.isinf(y_wrong_arr)) or np.any(np.isinf(y_uncertainty_arr)):
         raise ValueError("y_wrong and y_uncertainty must not contain Inf values.")
 
-    unique_labels = np.unique(y_wrong)
+    unique_labels = np.unique(y_wrong_arr)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
         raise ValueError(
             "y_wrong must be a binary array containing only 0 and 1. "
             f"Got unique values: {unique_labels}."
         )
 
-    if np.any(y_uncertainty < 0):
+    if np.any(y_uncertainty_arr < 0):
         raise ValueError("y_uncertainty must contain only non-negative values.")
 
     # sklearn's roc_auc_score handles the AUC computation;
     # we use uncertainty as the score that should rank positives (wrong=1)
     # higher than negatives (wrong=0).
-    return float(roc_auc_score(y_wrong, y_uncertainty))
+    return float(roc_auc_score(y_wrong_arr, y_uncertainty_arr))
 
 
 def auarc_score(
@@ -184,32 +184,32 @@ def auarc_score(
     Quantification for Black-box Large Language Models. TMLR.
     https://arxiv.org/abs/2305.19187
     """
-    y_wrong = column_or_1d(np.asarray(y_wrong, dtype=float))
-    y_uncertainty = column_or_1d(np.asarray(y_uncertainty, dtype=float))
+    y_wrong_arr = column_or_1d(np.asarray(y_wrong, dtype=float))
+    y_uncertainty_arr = column_or_1d(np.asarray(y_uncertainty, dtype=float))
 
-    check_consistent_length(y_wrong, y_uncertainty)
+    check_consistent_length(y_wrong_arr, y_uncertainty_arr)
 
-    if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
+    if np.any(np.isnan(y_wrong_arr)) or np.any(np.isnan(y_uncertainty_arr)):
         raise ValueError("y_wrong and y_uncertainty must not contain NaN values.")
-    if np.any(np.isinf(y_wrong)) or np.any(np.isinf(y_uncertainty)):
+    if np.any(np.isinf(y_wrong_arr)) or np.any(np.isinf(y_uncertainty_arr)):
         raise ValueError("y_wrong and y_uncertainty must not contain Inf values.")
 
-    unique_labels = np.unique(y_wrong)
+    unique_labels = np.unique(y_wrong_arr)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
         raise ValueError(
             "y_wrong must be a binary array containing only 0 and 1. "
             f"Got unique values: {unique_labels}."
         )
 
-    if np.any(y_uncertainty < 0):
+    if np.any(y_uncertainty_arr < 0):
         raise ValueError("y_uncertainty must contain only non-negative values.")
 
-    n = len(y_wrong)
+    n = len(y_wrong_arr)
 
     # Sort by descending uncertainty: highest uncertainty rejected first.
     # Stable sort ensures deterministic behaviour for tied uncertainty values.
-    rejection_order = np.argsort(y_uncertainty)[::-1]
-    y_wrong_sorted = y_wrong[rejection_order]
+    rejection_order = np.argsort(y_uncertainty_arr)[::-1]
+    y_wrong_sorted = y_wrong_arr[rejection_order]
 
     # accuracy_at_k[k] = accuracy when the k most uncertain samples
     # are rejected, i.e. we retain samples[k:] (n - k samples).

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -16,14 +16,11 @@ e.g. prediction interval width for regression, or 1 minus max
 softmax probability for classification).
 """
 
-
 import numpy as np
 from numpy.typing import ArrayLike
 from sklearn.metrics import roc_auc_score
 from sklearn.utils import column_or_1d
 from sklearn.utils.validation import check_consistent_length
-
-
 
 
 def aucroc_score(
@@ -96,19 +93,12 @@ def aucroc_score(
     y_wrong = column_or_1d(np.asarray(y_wrong, dtype=float))
     y_uncertainty = column_or_1d(np.asarray(y_uncertainty, dtype=float))
 
-
     check_consistent_length(y_wrong, y_uncertainty)
 
-
     if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
-        raise ValueError(
-            "y_wrong and y_uncertainty must not contain NaN values."
-        )
+        raise ValueError("y_wrong and y_uncertainty must not contain NaN values.")
     if np.any(np.isinf(y_wrong)) or np.any(np.isinf(y_uncertainty)):
-        raise ValueError(
-            "y_wrong and y_uncertainty must not contain Inf values."
-        )
-
+        raise ValueError("y_wrong and y_uncertainty must not contain Inf values.")
 
     unique_labels = np.unique(y_wrong)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
@@ -117,19 +107,13 @@ def aucroc_score(
             f"Got unique values: {unique_labels}."
         )
 
-
     if np.any(y_uncertainty < 0):
-        raise ValueError(
-            "y_uncertainty must contain only non-negative values."
-        )
-
+        raise ValueError("y_uncertainty must contain only non-negative values.")
 
     # sklearn's roc_auc_score handles the AUC computation;
     # we use uncertainty as the score that should rank positives (wrong=1)
     # higher than negatives (wrong=0).
     return float(roc_auc_score(y_wrong, y_uncertainty))
-
-
 
 
 def auarc_score(
@@ -203,19 +187,12 @@ def auarc_score(
     y_wrong = column_or_1d(np.asarray(y_wrong, dtype=float))
     y_uncertainty = column_or_1d(np.asarray(y_uncertainty, dtype=float))
 
-
     check_consistent_length(y_wrong, y_uncertainty)
 
-
     if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
-        raise ValueError(
-            "y_wrong and y_uncertainty must not contain NaN values."
-        )
+        raise ValueError("y_wrong and y_uncertainty must not contain NaN values.")
     if np.any(np.isinf(y_wrong)) or np.any(np.isinf(y_uncertainty)):
-        raise ValueError(
-            "y_wrong and y_uncertainty must not contain Inf values."
-        )
-
+        raise ValueError("y_wrong and y_uncertainty must not contain Inf values.")
 
     unique_labels = np.unique(y_wrong)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
@@ -224,21 +201,15 @@ def auarc_score(
             f"Got unique values: {unique_labels}."
         )
 
-
     if np.any(y_uncertainty < 0):
-        raise ValueError(
-            "y_uncertainty must contain only non-negative values."
-        )
-
+        raise ValueError("y_uncertainty must contain only non-negative values.")
 
     n = len(y_wrong)
-
 
     # Sort by descending uncertainty: highest uncertainty rejected first.
     # Stable sort ensures deterministic behaviour for tied uncertainty values.
     rejection_order = np.argsort(y_uncertainty)[::-1]
     y_wrong_sorted = y_wrong[rejection_order]
-
 
     # accuracy_at_k[k] = accuracy when the k most uncertain samples
     # are rejected, i.e. we retain samples[k:] (n - k samples).
@@ -247,10 +218,8 @@ def auarc_score(
     # cumulative correct from the retained tail as we reject from the front
     cumulative_correct_from_tail = np.cumsum(y_correct_sorted[::-1])[::-1]
 
-
     retained_counts = np.arange(n, 0, -1, dtype=float)  # n, n-1, ..., 1
     accuracy_curve = cumulative_correct_from_tail / retained_counts
-
 
     # AUARC = mean accuracy across all rejection thresholds (0 rejected,
     # 1 rejected, ..., n-1 rejected), i.e. when retaining n, n-1, ..., 1

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -1,19 +1,16 @@
 """
 Uncertainty evaluation metrics for MAPIE.
 
+Implements AUROC and AUARC as model-agnostic metrics for
+evaluating how well uncertainty estimates rank or reject
+incorrect predictions.
 
-Implements AUCROC and AUARC as introduced in:
-    Lin et al. (2023), "Generating with Confidence: Uncertainty
-    Quantification for Black-box Large Language Models",
-    TMLR. https://arxiv.org/abs/2305.19187
-
-
-These metrics are model-agnostic and apply to both regression
-and classification tasks. The caller is responsible for computing
-``y_wrong`` (binary: 1 if prediction is incorrect) and
-``y_uncertainty`` (a non-negative scalar uncertainty per sample,
-e.g. prediction interval width for regression, or 1 minus max
-softmax probability for classification).
+These metrics apply to both regression and classification.
+The caller is responsible for computing ``correctness``
+(binary: 1 if the prediction is correct) and ``confidence``
+(a scalar where higher values indicate greater confidence /
+lower uncertainty — e.g. 1 / prediction interval width for
+regression, or max softmax probability for classification).
 """
 
 import numpy as np
@@ -23,206 +20,154 @@ from sklearn.utils import column_or_1d
 from sklearn.utils.validation import check_consistent_length
 
 
-def aucroc_score(
-    y_wrong: ArrayLike,
-    y_uncertainty: ArrayLike,
+def auroc(
+    correctness: ArrayLike,
+    confidence: ArrayLike,
 ) -> float:
     """
-    Area Under the ROC Curve measuring how well uncertainty
-    ranks incorrect predictions.
+    Area Under the ROC Curve measuring how well confidence
+    ranks correct predictions.
 
+    A high score means that samples with higher confidence tend
+    to be the ones where the model is correct — i.e. the confidence
+    is *predictive* of correctness.
 
-    A high score means that samples with larger uncertainty tend
-    to be the ones where the model is wrong — i.e. the uncertainty
-    is *predictive* of errors.
-
-
-    Defined as ``AUCROC(y_wrong, y_uncertainty)`` following
-    Lin et al. (2023).
-
+    Defined as ``AUROC(correctness, confidence)``.
 
     Parameters
     ----------
-    y_wrong : ArrayLike of shape (n_samples,)
+    correctness : ArrayLike of shape (n_samples,)
         Binary array. 1 if the prediction for that sample is
-        considered wrong, 0 if correct. The definition of "wrong"
-        is left to the caller (e.g. outside prediction interval
-        for regression, misclassified for classification).
+        considered correct, 0 if incorrect.
 
-
-    y_uncertainty : ArrayLike of shape (n_samples,)
-        Non-negative scalar uncertainty estimate per sample.
-        Higher values must indicate higher uncertainty.
-        For regression, a common choice is prediction interval
-        width. For classification, ``1 - max(softmax)`` or
-        prediction-set size are typical choices.
-
+    confidence : ArrayLike of shape (n_samples,)
+        Scalar confidence estimate per sample.
+        Higher values must indicate higher confidence
+        (lower uncertainty).
 
     Returns
     -------
     float
-        AUCROC score in [0, 1]. A score of 0.5 corresponds to a
-        random uncertainty estimator. A score close to 1 means
-        the uncertainty reliably identifies wrong predictions.
-
+        AUROC score in [0, 1]. A score of 0.5 corresponds to a
+        random confidence estimator. A score close to 1 means
+        the confidence reliably identifies correct predictions.
 
     Raises
     ------
     ValueError
-        If ``y_wrong`` and ``y_uncertainty`` have different lengths,
-        contain NaN or Inf values, if ``y_wrong`` is not binary,
-        or if ``y_uncertainty`` contains negative values.
-
+        If ``correctness`` and ``confidence`` have different
+        lengths, contain NaN or Inf values, or if ``correctness``
+        is not binary.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from mapie.metrics.uncertainty import aucroc_score
-    >>> y_wrong = np.array([0, 0, 1, 1])
-    >>> y_uncertainty = np.array([0.1, 0.2, 0.8, 0.9])
-    >>> aucroc_score(y_wrong, y_uncertainty)
+    >>> from mapie.metrics.uncertainty import auroc
+    >>> correctness = np.array([1, 1, 0, 0])
+    >>> confidence = np.array([0.9, 0.8, 0.2, 0.1])
+    >>> auroc(correctness, confidence)
     1.0
-
-
-    References
-    ----------
-    Lin et al. (2023). Generating with Confidence: Uncertainty
-    Quantification for Black-box Large Language Models. TMLR.
-    https://arxiv.org/abs/2305.19187
     """
-    y_wrong_arr = column_or_1d(np.asarray(y_wrong, dtype=float))
-    y_uncertainty_arr = column_or_1d(np.asarray(y_uncertainty, dtype=float))
+    correctness_arr = column_or_1d(np.asarray(correctness, dtype=float))
+    confidence_arr = column_or_1d(np.asarray(confidence, dtype=float))
 
-    check_consistent_length(y_wrong_arr, y_uncertainty_arr)
+    check_consistent_length(correctness_arr, confidence_arr)
 
-    if np.any(np.isnan(y_wrong_arr)) or np.any(np.isnan(y_uncertainty_arr)):
-        raise ValueError("y_wrong and y_uncertainty must not contain NaN values.")
-    if np.any(np.isinf(y_wrong_arr)) or np.any(np.isinf(y_uncertainty_arr)):
-        raise ValueError("y_wrong and y_uncertainty must not contain Inf values.")
+    if np.any(np.isnan(correctness_arr)) or np.any(np.isnan(confidence_arr)):
+        raise ValueError("correctness and confidence must not contain NaN values.")
+    if np.any(np.isinf(correctness_arr)) or np.any(np.isinf(confidence_arr)):
+        raise ValueError("correctness and confidence must not contain Inf values.")
 
-    unique_labels = np.unique(y_wrong_arr)
+    unique_labels = np.unique(correctness_arr)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
         raise ValueError(
-            "y_wrong must be a binary array containing only 0 and 1. "
+            "correctness must be a binary array containing only 0 and 1. "
             f"Got unique values: {unique_labels}."
         )
 
-    if np.any(y_uncertainty_arr < 0):
-        raise ValueError("y_uncertainty must contain only non-negative values.")
-
-    # sklearn's roc_auc_score handles the AUC computation;
-    # we use uncertainty as the score that should rank positives (wrong=1)
-    # higher than negatives (wrong=0).
-    return float(roc_auc_score(y_wrong_arr, y_uncertainty_arr))
+    return float(roc_auc_score(correctness_arr, confidence_arr))
 
 
-def auarc_score(
-    y_wrong: ArrayLike,
-    y_uncertainty: ArrayLike,
+def auarc(
+    correctness: ArrayLike,
+    confidence: ArrayLike,
 ) -> float:
     """
     Area Under the Accuracy-Rejection Curve (AUARC).
 
-
     Measures how much accuracy improves when the model is allowed
-    to abstain on high-uncertainty predictions. Samples are rejected
-    in descending order of uncertainty; at each rejection threshold
+    to abstain on low-confidence predictions. Samples are retained
+    in descending order of confidence; at each retention threshold
     the accuracy on retained samples is recorded. The AUARC is the
     area under this curve, normalised to [0, 1].
 
-
-    A higher AUARC means that rejecting uncertain predictions leads
-    to a larger accuracy gain — i.e. the uncertainty is actionable
-    for selective prediction / human-in-the-loop workflows.
-
-
-    Defined as ``AUARC`` following Lin et al. (2023).
-
+    A higher AUARC means that rejecting low-confidence predictions
+    leads to a larger accuracy gain — i.e. the confidence is
+    actionable for selective prediction / human-in-the-loop
+    workflows.
 
     Parameters
     ----------
-    y_wrong : ArrayLike of shape (n_samples,)
+    correctness : ArrayLike of shape (n_samples,)
         Binary array. 1 if the prediction for that sample is
-        considered wrong, 0 if correct.
+        considered correct, 0 if incorrect.
 
-
-    y_uncertainty : ArrayLike of shape (n_samples,)
-        Non-negative scalar uncertainty estimate per sample.
-        Higher values must indicate higher uncertainty.
-
+    confidence : ArrayLike of shape (n_samples,)
+        Scalar confidence estimate per sample.
+        Higher values must indicate higher confidence
+        (lower uncertainty).
 
     Returns
     -------
     float
         AUARC score in [0, 1]. A higher score indicates a better
-        uncertainty estimator — the maximum achievable score depends
+        confidence estimator — the maximum achievable score depends
         on the fraction of correct predictions in the data. A score
         equal to the overall accuracy corresponds to a random estimator.
-
 
     Raises
     ------
     ValueError
-        If ``y_wrong`` and ``y_uncertainty`` have different lengths,
-        contain NaN or Inf values, if ``y_wrong`` is not binary,
-        or if ``y_uncertainty`` contains negative values.
-
+        If ``correctness`` and ``confidence`` have different
+        lengths, contain NaN or Inf values, or if ``correctness``
+        is not binary.
 
     Examples
     --------
     >>> import numpy as np
-    >>> from mapie.metrics.uncertainty import auarc_score
-    >>> y_wrong = np.array([1, 1, 0, 0])
-    >>> y_uncertainty = np.array([0.9, 0.8, 0.2, 0.1])
-    >>> auarc_score(y_wrong, y_uncertainty)
+    >>> from mapie.metrics.uncertainty import auarc
+    >>> correctness = np.array([0, 0, 1, 1])
+    >>> confidence = np.array([0.1, 0.2, 0.8, 0.9])
+    >>> auarc(correctness, confidence)
     0.7916666666666666
-
-
-    References
-    ----------
-    Lin et al. (2023). Generating with Confidence: Uncertainty
-    Quantification for Black-box Large Language Models. TMLR.
-    https://arxiv.org/abs/2305.19187
     """
-    y_wrong_arr = column_or_1d(np.asarray(y_wrong, dtype=float))
-    y_uncertainty_arr = column_or_1d(np.asarray(y_uncertainty, dtype=float))
+    correctness_arr = column_or_1d(np.asarray(correctness, dtype=float))
+    confidence_arr = column_or_1d(np.asarray(confidence, dtype=float))
 
-    check_consistent_length(y_wrong_arr, y_uncertainty_arr)
+    check_consistent_length(correctness_arr, confidence_arr)
 
-    if np.any(np.isnan(y_wrong_arr)) or np.any(np.isnan(y_uncertainty_arr)):
-        raise ValueError("y_wrong and y_uncertainty must not contain NaN values.")
-    if np.any(np.isinf(y_wrong_arr)) or np.any(np.isinf(y_uncertainty_arr)):
-        raise ValueError("y_wrong and y_uncertainty must not contain Inf values.")
+    if np.any(np.isnan(correctness_arr)) or np.any(np.isnan(confidence_arr)):
+        raise ValueError("correctness and confidence must not contain NaN values.")
+    if np.any(np.isinf(correctness_arr)) or np.any(np.isinf(confidence_arr)):
+        raise ValueError("correctness and confidence must not contain Inf values.")
 
-    unique_labels = np.unique(y_wrong_arr)
+    unique_labels = np.unique(correctness_arr)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
         raise ValueError(
-            "y_wrong must be a binary array containing only 0 and 1. "
+            "correctness must be a binary array containing only 0 and 1. "
             f"Got unique values: {unique_labels}."
         )
 
-    if np.any(y_uncertainty_arr < 0):
-        raise ValueError("y_uncertainty must contain only non-negative values.")
+    n = len(correctness_arr)
 
-    n = len(y_wrong_arr)
+    # Sort by descending confidence: retain highest confidence first.
+    order = np.argsort(-confidence_arr, kind="stable")
+    correctness_sorted = correctness_arr[order]
 
-    # Sort by descending uncertainty: highest uncertainty rejected first.
-    # Stable sort ensures deterministic behaviour for tied uncertainty values.
-    rejection_order = np.argsort(y_uncertainty_arr)[::-1]
-    y_wrong_sorted = y_wrong_arr[rejection_order]
+    # accuracy_at_k[k] = accuracy when we retain the top k most
+    # confident samples (k = n, n-1, ..., 1).
+    cumulative_correct = np.cumsum(correctness_sorted)
+    retained_counts = np.arange(1, n + 1, dtype=float)
+    accuracy_curve = cumulative_correct / retained_counts
 
-    # accuracy_at_k[k] = accuracy when the k most uncertain samples
-    # are rejected, i.e. we retain samples[k:] (n - k samples).
-    # We accumulate correct predictions from the *least* uncertain end.
-    y_correct_sorted = 1.0 - y_wrong_sorted
-    # cumulative correct from the retained tail as we reject from the front
-    cumulative_correct_from_tail = np.cumsum(y_correct_sorted[::-1])[::-1]
-
-    retained_counts = np.arange(n, 0, -1, dtype=float)  # n, n-1, ..., 1
-    accuracy_curve = cumulative_correct_from_tail / retained_counts
-
-    # AUARC = mean accuracy across all rejection thresholds (0 rejected,
-    # 1 rejected, ..., n-1 rejected), i.e. when retaining n, n-1, ..., 1
-    # samples respectively. We exclude the point where 0 samples remain.
-    auarc = float(np.mean(accuracy_curve))
-    return auarc
+    return float(np.mean(accuracy_curve))

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -1,10 +1,12 @@
 """
 Uncertainty evaluation metrics for MAPIE.
 
+
 Implements AUCROC and AUARC as introduced in:
     Lin et al. (2023), "Generating with Confidence: Uncertainty
     Quantification for Black-box Large Language Models",
     TMLR. https://arxiv.org/abs/2305.19187
+
 
 These metrics are model-agnostic and apply to both regression
 and classification tasks. The caller is responsible for computing
@@ -14,13 +16,17 @@ e.g. prediction interval width for regression, or 1 minus max
 softmax probability for classification).
 """
 
-from typing import cast
+
+from typing import Union
+
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from sklearn.metrics import roc_auc_score
 from sklearn.utils import column_or_1d
 from sklearn.utils.validation import check_consistent_length
+
+
 
 
 def aucroc_score(
@@ -31,12 +37,15 @@ def aucroc_score(
     Area Under the ROC Curve measuring how well uncertainty
     ranks incorrect predictions.
 
+
     A high score means that samples with larger uncertainty tend
     to be the ones where the model is wrong — i.e. the uncertainty
     is *predictive* of errors.
 
+
     Defined as ``AUCROC(y_wrong, y_uncertainty)`` following
     Lin et al. (2023).
+
 
     Parameters
     ----------
@@ -46,12 +55,14 @@ def aucroc_score(
         is left to the caller (e.g. outside prediction interval
         for regression, misclassified for classification).
 
+
     y_uncertainty : ArrayLike of shape (n_samples,)
         Non-negative scalar uncertainty estimate per sample.
         Higher values must indicate higher uncertainty.
         For regression, a common choice is prediction interval
         width. For classification, ``1 - max(softmax)`` or
         prediction-set size are typical choices.
+
 
     Returns
     -------
@@ -60,12 +71,14 @@ def aucroc_score(
         random uncertainty estimator. A score close to 1 means
         the uncertainty reliably identifies wrong predictions.
 
+
     Raises
     ------
     ValueError
         If ``y_wrong`` and ``y_uncertainty`` have different lengths,
         contain NaN or Inf values, if ``y_wrong`` is not binary,
         or if ``y_uncertainty`` contains negative values.
+
 
     Examples
     --------
@@ -76,18 +89,19 @@ def aucroc_score(
     >>> aucroc_score(y_wrong, y_uncertainty)
     1.0
 
+
     References
     ----------
     Lin et al. (2023). Generating with Confidence: Uncertainty
     Quantification for Black-box Large Language Models. TMLR.
     https://arxiv.org/abs/2305.19187
     """
-    y_wrong = cast(NDArray, column_or_1d(np.asarray(y_wrong, dtype=float)))
-    y_uncertainty = cast(
-        NDArray, column_or_1d(np.asarray(y_uncertainty, dtype=float))
-    )
+    y_wrong = column_or_1d(np.asarray(y_wrong, dtype=float))
+    y_uncertainty = column_or_1d(np.asarray(y_uncertainty, dtype=float))
+
 
     check_consistent_length(y_wrong, y_uncertainty)
+
 
     if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
         raise ValueError(
@@ -98,6 +112,7 @@ def aucroc_score(
             "y_wrong and y_uncertainty must not contain Inf values."
         )
 
+
     unique_labels = np.unique(y_wrong)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
         raise ValueError(
@@ -105,12 +120,19 @@ def aucroc_score(
             f"Got unique values: {unique_labels}."
         )
 
+
     if np.any(y_uncertainty < 0):
         raise ValueError(
             "y_uncertainty must contain only non-negative values."
         )
 
+
+    # sklearn's roc_auc_score handles the AUC computation;
+    # we use uncertainty as the score that should rank positives (wrong=1)
+    # higher than negatives (wrong=0).
     return float(roc_auc_score(y_wrong, y_uncertainty))
+
+
 
 
 def auarc_score(
@@ -120,17 +142,21 @@ def auarc_score(
     """
     Area Under the Accuracy-Rejection Curve (AUARC).
 
+
     Measures how much accuracy improves when the model is allowed
     to abstain on high-uncertainty predictions. Samples are rejected
     in descending order of uncertainty; at each rejection threshold
     the accuracy on retained samples is recorded. The AUARC is the
     area under this curve, normalised to [0, 1].
 
+
     A higher AUARC means that rejecting uncertain predictions leads
     to a larger accuracy gain — i.e. the uncertainty is actionable
     for selective prediction / human-in-the-loop workflows.
 
+
     Defined as ``AUARC`` following Lin et al. (2023).
+
 
     Parameters
     ----------
@@ -138,17 +164,20 @@ def auarc_score(
         Binary array. 1 if the prediction for that sample is
         considered wrong, 0 if correct.
 
+
     y_uncertainty : ArrayLike of shape (n_samples,)
         Non-negative scalar uncertainty estimate per sample.
         Higher values must indicate higher uncertainty.
 
+
     Returns
     -------
     float
-        AUARC score in [0, 1]. A score of 1 corresponds to a
-        perfect uncertainty estimator (all wrong predictions are
-        rejected first). A score equal to the overall accuracy
-        corresponds to a random estimator.
+        AUARC score in [0, 1]. A higher score indicates a better
+        uncertainty estimator — the maximum achievable score depends
+        on the fraction of correct predictions in the data. A score
+        equal to the overall accuracy corresponds to a random estimator.
+
 
     Raises
     ------
@@ -157,6 +186,7 @@ def auarc_score(
         contain NaN or Inf values, if ``y_wrong`` is not binary,
         or if ``y_uncertainty`` contains negative values.
 
+
     Examples
     --------
     >>> import numpy as np
@@ -164,7 +194,8 @@ def auarc_score(
     >>> y_wrong = np.array([1, 1, 0, 0])
     >>> y_uncertainty = np.array([0.9, 0.8, 0.2, 0.1])
     >>> auarc_score(y_wrong, y_uncertainty)
-    1.0
+    0.7916666666666666
+
 
     References
     ----------
@@ -172,12 +203,12 @@ def auarc_score(
     Quantification for Black-box Large Language Models. TMLR.
     https://arxiv.org/abs/2305.19187
     """
-    y_wrong = cast(NDArray, column_or_1d(np.asarray(y_wrong, dtype=float)))
-    y_uncertainty = cast(
-        NDArray, column_or_1d(np.asarray(y_uncertainty, dtype=float))
-    )
+    y_wrong = column_or_1d(np.asarray(y_wrong, dtype=float))
+    y_uncertainty = column_or_1d(np.asarray(y_uncertainty, dtype=float))
+
 
     check_consistent_length(y_wrong, y_uncertainty)
+
 
     if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
         raise ValueError(
@@ -188,6 +219,7 @@ def auarc_score(
             "y_wrong and y_uncertainty must not contain Inf values."
         )
 
+
     unique_labels = np.unique(y_wrong)
     if not np.all(np.isin(unique_labels, [0.0, 1.0])):
         raise ValueError(
@@ -195,21 +227,36 @@ def auarc_score(
             f"Got unique values: {unique_labels}."
         )
 
+
     if np.any(y_uncertainty < 0):
         raise ValueError(
             "y_uncertainty must contain only non-negative values."
         )
 
+
     n = len(y_wrong)
 
+
+    # Sort by descending uncertainty: highest uncertainty rejected first.
+    # Stable sort ensures deterministic behaviour for tied uncertainty values.
     rejection_order = np.argsort(y_uncertainty)[::-1]
     y_wrong_sorted = y_wrong[rejection_order]
 
+
+    # accuracy_at_k[k] = accuracy when the k most uncertain samples
+    # are rejected, i.e. we retain samples[k:] (n - k samples).
+    # We accumulate correct predictions from the *least* uncertain end.
     y_correct_sorted = 1.0 - y_wrong_sorted
+    # cumulative correct from the retained tail as we reject from the front
     cumulative_correct_from_tail = np.cumsum(y_correct_sorted[::-1])[::-1]
 
-    retained_counts = np.arange(n, 0, -1, dtype=float)
+
+    retained_counts = np.arange(n, 0, -1, dtype=float)  # n, n-1, ..., 1
     accuracy_curve = cumulative_correct_from_tail / retained_counts
 
+
+    # AUARC = mean accuracy across all rejection thresholds (0 rejected,
+    # 1 rejected, ..., n-1 rejected), i.e. when retaining n, n-1, ..., 1
+    # samples respectively. We exclude the point where 0 samples remain.
     auarc = float(np.mean(accuracy_curve))
     return auarc

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -145,6 +145,13 @@ def auarc(
     >>> confidence = np.array([0.1, 0.2, 0.8, 0.9])
     >>> auarc(correctness, confidence)
     0.7916666666666666
+
+    References
+    ----------
+    Nadeem, M. S. A., Zucker, J.-D., and Hanczar, B. (2009).
+    "Accuracy-rejection curves (ARCs) for comparing classification
+    methods with a reject option." Proceedings of Machine Learning
+    Research, 8, 65-81.
     """
     correctness_arr = column_or_1d(np.asarray(correctness, dtype=float))
     confidence_arr = column_or_1d(np.asarray(confidence, dtype=float))

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -17,11 +17,8 @@ softmax probability for classification).
 """
 
 
-from typing import Union
-
-
 import numpy as np
-from numpy.typing import ArrayLike, NDArray
+from numpy.typing import ArrayLike
 from sklearn.metrics import roc_auc_score
 from sklearn.utils import column_or_1d
 from sklearn.utils.validation import check_consistent_length

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -85,6 +85,11 @@ def auroc(
             f"Got unique values: {unique_labels}."
         )
 
+    if len(unique_labels) < 2:
+        raise ValueError(
+            "correctness must contain both 0 and 1 values to compute AUROC."
+        )
+
     return float(roc_auc_score(correctness_arr, confidence_arr))
 
 

--- a/mapie/metrics/uncertainty.py
+++ b/mapie/metrics/uncertainty.py
@@ -1,0 +1,215 @@
+"""
+Uncertainty evaluation metrics for MAPIE.
+
+Implements AUCROC and AUARC as introduced in:
+    Lin et al. (2023), "Generating with Confidence: Uncertainty
+    Quantification for Black-box Large Language Models",
+    TMLR. https://arxiv.org/abs/2305.19187
+
+These metrics are model-agnostic and apply to both regression
+and classification tasks. The caller is responsible for computing
+``y_wrong`` (binary: 1 if prediction is incorrect) and
+``y_uncertainty`` (a non-negative scalar uncertainty per sample,
+e.g. prediction interval width for regression, or 1 minus max
+softmax probability for classification).
+"""
+
+from typing import cast
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from sklearn.metrics import roc_auc_score
+from sklearn.utils import column_or_1d
+from sklearn.utils.validation import check_consistent_length
+
+
+def aucroc_score(
+    y_wrong: ArrayLike,
+    y_uncertainty: ArrayLike,
+) -> float:
+    """
+    Area Under the ROC Curve measuring how well uncertainty
+    ranks incorrect predictions.
+
+    A high score means that samples with larger uncertainty tend
+    to be the ones where the model is wrong — i.e. the uncertainty
+    is *predictive* of errors.
+
+    Defined as ``AUCROC(y_wrong, y_uncertainty)`` following
+    Lin et al. (2023).
+
+    Parameters
+    ----------
+    y_wrong : ArrayLike of shape (n_samples,)
+        Binary array. 1 if the prediction for that sample is
+        considered wrong, 0 if correct. The definition of "wrong"
+        is left to the caller (e.g. outside prediction interval
+        for regression, misclassified for classification).
+
+    y_uncertainty : ArrayLike of shape (n_samples,)
+        Non-negative scalar uncertainty estimate per sample.
+        Higher values must indicate higher uncertainty.
+        For regression, a common choice is prediction interval
+        width. For classification, ``1 - max(softmax)`` or
+        prediction-set size are typical choices.
+
+    Returns
+    -------
+    float
+        AUCROC score in [0, 1]. A score of 0.5 corresponds to a
+        random uncertainty estimator. A score close to 1 means
+        the uncertainty reliably identifies wrong predictions.
+
+    Raises
+    ------
+    ValueError
+        If ``y_wrong`` and ``y_uncertainty`` have different lengths,
+        contain NaN or Inf values, if ``y_wrong`` is not binary,
+        or if ``y_uncertainty`` contains negative values.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mapie.metrics.uncertainty import aucroc_score
+    >>> y_wrong = np.array([0, 0, 1, 1])
+    >>> y_uncertainty = np.array([0.1, 0.2, 0.8, 0.9])
+    >>> aucroc_score(y_wrong, y_uncertainty)
+    1.0
+
+    References
+    ----------
+    Lin et al. (2023). Generating with Confidence: Uncertainty
+    Quantification for Black-box Large Language Models. TMLR.
+    https://arxiv.org/abs/2305.19187
+    """
+    y_wrong = cast(NDArray, column_or_1d(np.asarray(y_wrong, dtype=float)))
+    y_uncertainty = cast(
+        NDArray, column_or_1d(np.asarray(y_uncertainty, dtype=float))
+    )
+
+    check_consistent_length(y_wrong, y_uncertainty)
+
+    if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
+        raise ValueError(
+            "y_wrong and y_uncertainty must not contain NaN values."
+        )
+    if np.any(np.isinf(y_wrong)) or np.any(np.isinf(y_uncertainty)):
+        raise ValueError(
+            "y_wrong and y_uncertainty must not contain Inf values."
+        )
+
+    unique_labels = np.unique(y_wrong)
+    if not np.all(np.isin(unique_labels, [0.0, 1.0])):
+        raise ValueError(
+            "y_wrong must be a binary array containing only 0 and 1. "
+            f"Got unique values: {unique_labels}."
+        )
+
+    if np.any(y_uncertainty < 0):
+        raise ValueError(
+            "y_uncertainty must contain only non-negative values."
+        )
+
+    return float(roc_auc_score(y_wrong, y_uncertainty))
+
+
+def auarc_score(
+    y_wrong: ArrayLike,
+    y_uncertainty: ArrayLike,
+) -> float:
+    """
+    Area Under the Accuracy-Rejection Curve (AUARC).
+
+    Measures how much accuracy improves when the model is allowed
+    to abstain on high-uncertainty predictions. Samples are rejected
+    in descending order of uncertainty; at each rejection threshold
+    the accuracy on retained samples is recorded. The AUARC is the
+    area under this curve, normalised to [0, 1].
+
+    A higher AUARC means that rejecting uncertain predictions leads
+    to a larger accuracy gain — i.e. the uncertainty is actionable
+    for selective prediction / human-in-the-loop workflows.
+
+    Defined as ``AUARC`` following Lin et al. (2023).
+
+    Parameters
+    ----------
+    y_wrong : ArrayLike of shape (n_samples,)
+        Binary array. 1 if the prediction for that sample is
+        considered wrong, 0 if correct.
+
+    y_uncertainty : ArrayLike of shape (n_samples,)
+        Non-negative scalar uncertainty estimate per sample.
+        Higher values must indicate higher uncertainty.
+
+    Returns
+    -------
+    float
+        AUARC score in [0, 1]. A score of 1 corresponds to a
+        perfect uncertainty estimator (all wrong predictions are
+        rejected first). A score equal to the overall accuracy
+        corresponds to a random estimator.
+
+    Raises
+    ------
+    ValueError
+        If ``y_wrong`` and ``y_uncertainty`` have different lengths,
+        contain NaN or Inf values, if ``y_wrong`` is not binary,
+        or if ``y_uncertainty`` contains negative values.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from mapie.metrics.uncertainty import auarc_score
+    >>> y_wrong = np.array([1, 1, 0, 0])
+    >>> y_uncertainty = np.array([0.9, 0.8, 0.2, 0.1])
+    >>> auarc_score(y_wrong, y_uncertainty)
+    1.0
+
+    References
+    ----------
+    Lin et al. (2023). Generating with Confidence: Uncertainty
+    Quantification for Black-box Large Language Models. TMLR.
+    https://arxiv.org/abs/2305.19187
+    """
+    y_wrong = cast(NDArray, column_or_1d(np.asarray(y_wrong, dtype=float)))
+    y_uncertainty = cast(
+        NDArray, column_or_1d(np.asarray(y_uncertainty, dtype=float))
+    )
+
+    check_consistent_length(y_wrong, y_uncertainty)
+
+    if np.any(np.isnan(y_wrong)) or np.any(np.isnan(y_uncertainty)):
+        raise ValueError(
+            "y_wrong and y_uncertainty must not contain NaN values."
+        )
+    if np.any(np.isinf(y_wrong)) or np.any(np.isinf(y_uncertainty)):
+        raise ValueError(
+            "y_wrong and y_uncertainty must not contain Inf values."
+        )
+
+    unique_labels = np.unique(y_wrong)
+    if not np.all(np.isin(unique_labels, [0.0, 1.0])):
+        raise ValueError(
+            "y_wrong must be a binary array containing only 0 and 1. "
+            f"Got unique values: {unique_labels}."
+        )
+
+    if np.any(y_uncertainty < 0):
+        raise ValueError(
+            "y_uncertainty must contain only non-negative values."
+        )
+
+    n = len(y_wrong)
+
+    rejection_order = np.argsort(y_uncertainty)[::-1]
+    y_wrong_sorted = y_wrong[rejection_order]
+
+    y_correct_sorted = 1.0 - y_wrong_sorted
+    cumulative_correct_from_tail = np.cumsum(y_correct_sorted[::-1])[::-1]
+
+    retained_counts = np.arange(n, 0, -1, dtype=float)
+    accuracy_curve = cumulative_correct_from_tail / retained_counts
+
+    auarc = float(np.mean(accuracy_curve))
+    return auarc

--- a/mapie/tests/test_metrics_uncertainty.py
+++ b/mapie/tests/test_metrics_uncertainty.py
@@ -9,182 +9,143 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from mapie.metrics.uncertainty import aucroc_score, auarc_score
+from mapie.metrics.uncertainty import auroc, auarc
 
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
 
-# Perfect case: uncertainty perfectly ranks wrong predictions above correct ones
-Y_WRONG_PERFECT = np.array([0, 0, 1, 1], dtype=float)
-Y_UNC_PERFECT = np.array([0.1, 0.2, 0.8, 0.9], dtype=float)
+# Perfect case: confidence perfectly ranks correct predictions above incorrect
+Y_CORRECT_PERFECT = np.array([1, 1, 0, 0], dtype=float)
+Y_CONF_PERFECT = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
 
-# Random case: uncertainty uncorrelated with errors
-Y_WRONG_RANDOM = np.array([0, 1, 0, 1], dtype=float)
-Y_UNC_RANDOM = np.array([0.1, 0.2, 0.3, 0.4], dtype=float)
+# Random case: confidence uncorrelated with correctness
+Y_CORRECT_RANDOM = np.array([1, 0, 1, 0], dtype=float)
+Y_CONF_RANDOM = np.array([0.1, 0.2, 0.3, 0.4], dtype=float)
 
 # All correct predictions
-Y_WRONG_ALL_CORRECT = np.zeros(4, dtype=float)
-Y_UNC_UNIFORM = np.array([0.1, 0.2, 0.3, 0.4], dtype=float)
+Y_CORRECT_ALL_CORRECT = np.ones(4, dtype=float)
+Y_CONF_UNIFORM = np.array([0.1, 0.2, 0.3, 0.4], dtype=float)
 
 
 # ---------------------------------------------------------------------------
-# aucroc_score — known-answer tests
+# auroc — known-answer tests
 # ---------------------------------------------------------------------------
 
 
-class TestAucrocScore:
+class TestAuroc:
     def test_perfect_discriminator(self):
-        """Uncertainty perfectly separates wrong from correct → AUCROC = 1."""
-        result = aucroc_score(Y_WRONG_PERFECT, Y_UNC_PERFECT)
+        """Confidence perfectly separates correct from incorrect → AUROC = 1."""
+        result = auroc(Y_CORRECT_PERFECT, Y_CONF_PERFECT)
         assert_allclose(result, 1.0)
 
     def test_returns_float(self):
-        result = aucroc_score(Y_WRONG_PERFECT, Y_UNC_PERFECT)
+        result = auroc(Y_CORRECT_PERFECT, Y_CONF_PERFECT)
         assert isinstance(result, float)
 
     def test_score_in_unit_interval(self):
-        result = aucroc_score(Y_WRONG_RANDOM, Y_UNC_RANDOM)
+        result = auroc(Y_CORRECT_RANDOM, Y_CONF_RANDOM)
         assert 0.0 <= result <= 1.0
 
     def test_accepts_list_input(self):
         """Should accept plain Python lists, not just numpy arrays."""
-        result = aucroc_score([0, 0, 1, 1], [0.1, 0.2, 0.8, 0.9])
+        result = auroc([1, 1, 0, 0], [0.9, 0.8, 0.2, 0.1])
         assert_allclose(result, 1.0)
 
     def test_known_value_random_case(self):
         """
-        y_wrong = [0, 1, 0, 1], y_unc = [0.1, 0.2, 0.3, 0.4]
+        correctness = [1, 0, 1, 0], confidence = [0.1, 0.2, 0.3, 0.4]
         sklearn roc_auc_score ground truth.
-        Wrong indices: 1, 3 (uncertainty 0.2, 0.4)
-        Correct indices: 0, 2 (uncertainty 0.1, 0.3)
-        By hand: TPR/FPR pairs give AUC = 0.75
         """
-        result = aucroc_score(Y_WRONG_RANDOM, Y_UNC_RANDOM)
-        assert_allclose(result, 0.75)
+        result = auroc(Y_CORRECT_RANDOM, Y_CONF_RANDOM)
+        expected = np.float64(0.25)
+        assert_allclose(result, expected)
 
-    # --- input validation ---
+    def test_all_correct_predictions(self):
+        """
+        When all predictions are correct, sklearn warns about
+        undefined AUC (single class). We still get a float result.
+        """
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = auroc(Y_CORRECT_ALL_CORRECT, Y_CONF_UNIFORM)
+        assert isinstance(result, float)
+
+    def test_raises_on_non_binary_labels(self):
+        with pytest.raises(ValueError, match="binary"):
+            auroc([0, 1, 2], [0.1, 0.2, 0.3])
+
+    def test_raises_on_nan(self):
+        with pytest.raises(ValueError, match="NaN"):
+            auroc([0, np.nan, 1], [0.1, 0.2, 0.3])
+
+    def test_raises_on_inf(self):
+        with pytest.raises(ValueError, match="Inf"):
+            auroc([0, 1, 1], [0.1, np.inf, 0.3])
 
     def test_raises_on_length_mismatch(self):
         with pytest.raises(ValueError):
-            aucroc_score([0, 1], [0.1, 0.2, 0.3])
-
-    def test_raises_on_nan_in_y_wrong(self):
-        with pytest.raises(ValueError, match="NaN"):
-            aucroc_score([0, np.nan, 1, 1], Y_UNC_PERFECT)
-
-    def test_raises_on_nan_in_y_uncertainty(self):
-        with pytest.raises(ValueError, match="NaN"):
-            aucroc_score(Y_WRONG_PERFECT, [0.1, np.nan, 0.8, 0.9])
-
-    def test_raises_on_inf_in_y_wrong(self):
-        with pytest.raises(ValueError, match="Inf"):
-            aucroc_score([0, np.inf, 1, 1], Y_UNC_PERFECT)
-
-    def test_raises_on_inf_in_y_uncertainty(self):
-        with pytest.raises(ValueError, match="Inf"):
-            aucroc_score(Y_WRONG_PERFECT, [0.1, np.inf, 0.8, 0.9])
-
-    def test_raises_on_non_binary_y_wrong(self):
-        with pytest.raises(ValueError, match="binary"):
-            aucroc_score([0, 0.5, 1, 1], Y_UNC_PERFECT)
-
-    def test_raises_on_negative_uncertainty(self):
-        with pytest.raises(ValueError, match="non-negative"):
-            aucroc_score(Y_WRONG_PERFECT, [-0.1, 0.2, 0.8, 0.9])
+            auroc([0, 1], [0.1, 0.2, 0.3])
 
 
 # ---------------------------------------------------------------------------
-# auarc_score — known-answer tests
+# auarc — known-answer tests
 # ---------------------------------------------------------------------------
 
 
-class TestAuarcScore:
-    def test_perfect_rejection(self):
+class TestAuarc:
+    def test_perfect_confidence(self):
         """
-        Wrong samples have highest uncertainty, so rejecting by uncertainty
-        removes all errors first → accuracy reaches 1.0 quickly → AUARC = 1.0.
-
-        y_wrong      = [1, 1, 0, 0]
-        y_uncertainty= [0.9, 0.8, 0.2, 0.1]
-        rejection order (desc unc): indices [0,1,2,3]
-        y_wrong_sorted = [1,1,0,0]
-
-        accuracy_curve (retaining n, n-1, ..., 1 samples):
-          retain 4: (0+0+0+0... wait — correct = 1-wrong = [0,0,1,1])
-          cumsum from tail of [0,0,1,1] = [2,2,2,1]  NO let me redo:
-          y_correct_sorted = [0,0,1,1]
-          cumsum from tail: cumsum([1,1,0,0]) reversed → [2,2,1,1] reversed
-          Actually cumsum([0,0,1,1] reversed=[1,1,0,0]) = [1,2,2,2], reversed=[2,2,2,1]
-          retained_counts = [4,3,2,1]
-          accuracy_curve = [2/4, 2/3, 2/2, 1/1] = [0.5, 0.667, 1.0, 1.0]
-          mean = (0.5 + 0.667 + 1.0 + 1.0) / 4 = 0.792
+        confidence perfectly ranks correct above incorrect →
+        AUARC > overall accuracy.
         """
-        y_wrong = np.array([1, 1, 0, 0], dtype=float)
-        y_unc = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
-        result = auarc_score(y_wrong, y_unc)
-        expected = np.mean([0.5, 2 / 3, 1.0, 1.0])
+        result = auarc(Y_CORRECT_PERFECT, Y_CONF_PERFECT)
+        # correctness=[1,1,0,0], confidence=[0.9,0.8,0.2,0.1]
+        # sorted descending: k=1→1.0, k=2→1.0, k=3→0.667, k=4→0.5
+        expected = np.mean([1.0, 1.0, 2 / 3, 0.5])
         assert_allclose(result, expected, rtol=1e-6)
 
     def test_all_correct_predictions(self):
         """
-        If no predictions are wrong, accuracy is always 1.0 regardless
-        of rejection order → AUARC = 1.0.
+        If all predictions are correct, accuracy is always 1.0
+        regardless of rejection order → AUARC = 1.0.
         """
-        y_wrong = np.zeros(5, dtype=float)
-        y_unc = np.array([0.1, 0.5, 0.3, 0.9, 0.2], dtype=float)
-        result = auarc_score(y_wrong, y_unc)
+        result = auarc(
+            np.ones(5, dtype=float),
+            np.array([0.1, 0.5, 0.3, 0.9, 0.2], dtype=float),
+        )
         assert_allclose(result, 1.0)
 
     def test_returns_float(self):
-        result = auarc_score(Y_WRONG_PERFECT, Y_UNC_PERFECT)
+        result = auarc(Y_CORRECT_PERFECT, Y_CONF_PERFECT)
         assert isinstance(result, float)
 
     def test_score_in_unit_interval(self):
-        result = auarc_score(Y_WRONG_RANDOM, Y_UNC_RANDOM)
+        result = auarc(Y_CORRECT_RANDOM, Y_CONF_RANDOM)
         assert 0.0 <= result <= 1.0
 
     def test_accepts_list_input(self):
-        result = auarc_score([0, 0, 1, 1], [0.1, 0.2, 0.8, 0.9])
+        result = auarc([1, 1, 0, 0], [0.9, 0.8, 0.2, 0.1])
         assert isinstance(result, float)
 
-    def test_worst_rejection(self):
+    def test_worst_confidence(self):
         """
-        Correct samples have highest uncertainty → we reject correct ones first
-        → accuracy degrades. AUARC should be lower than the perfect case.
+        Correct samples have lowest confidence → we retain least
+        confident first → accuracy degrades. AUARC should be lower
+        than the perfect case.
         """
-        y_wrong = np.array([0, 0, 1, 1], dtype=float)
-        y_unc_bad = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
-        y_unc_good = np.array([0.1, 0.2, 0.8, 0.9], dtype=float)
-        assert auarc_score(y_wrong, y_unc_bad) < auarc_score(y_wrong, y_unc_good)
+        correctness = np.array([0, 0, 1, 1], dtype=float)
+        conf_bad = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
+        conf_good = np.array([0.1, 0.2, 0.8, 0.9], dtype=float)
+        assert auarc(correctness, conf_bad) < auarc(correctness, conf_good)
 
-    # --- input validation ---
+    def test_raises_on_nan(self):
+        with pytest.raises(ValueError, match="NaN"):
+            auarc([0, np.nan, 1], [0.1, 0.2, 0.3])
 
     def test_raises_on_length_mismatch(self):
         with pytest.raises(ValueError):
-            auarc_score([0, 1], [0.1, 0.2, 0.3])
-
-    def test_raises_on_nan_in_y_wrong(self):
-        with pytest.raises(ValueError, match="NaN"):
-            auarc_score([0, np.nan, 1, 1], Y_UNC_PERFECT)
-
-    def test_raises_on_nan_in_y_uncertainty(self):
-        with pytest.raises(ValueError, match="NaN"):
-            auarc_score(Y_WRONG_PERFECT, [0.1, np.nan, 0.8, 0.9])
-
-    def test_raises_on_inf_in_y_wrong(self):
-        with pytest.raises(ValueError, match="Inf"):
-            auarc_score([0, np.inf, 1, 1], Y_UNC_PERFECT)
-
-    def test_raises_on_inf_in_y_uncertainty(self):
-        with pytest.raises(ValueError, match="Inf"):
-            auarc_score(Y_WRONG_PERFECT, [0.1, np.inf, 0.8, 0.9])
-
-    def test_raises_on_non_binary_y_wrong(self):
-        with pytest.raises(ValueError, match="binary"):
-            auarc_score([0, 0.5, 1, 1], Y_UNC_PERFECT)
-
-    def test_raises_on_negative_uncertainty(self):
-        with pytest.raises(ValueError, match="non-negative"):
-            auarc_score(Y_WRONG_PERFECT, [-0.1, 0.2, 0.8, 0.9])
+            auarc([0, 1], [0.1, 0.2, 0.3])

--- a/mapie/tests/test_metrics_uncertainty.py
+++ b/mapie/tests/test_metrics_uncertainty.py
@@ -187,4 +187,4 @@ class TestAuarcScore:
 
     def test_raises_on_negative_uncertainty(self):
         with pytest.raises(ValueError, match="non-negative"):
-            aucroc_score(Y_WRONG_PERFECT, [-0.1, 0.2, 0.8, 0.9])
+            auarc_score(Y_WRONG_PERFECT, [-0.1, 0.2, 0.8, 0.9])

--- a/mapie/tests/test_metrics_uncertainty.py
+++ b/mapie/tests/test_metrics_uncertainty.py
@@ -64,15 +64,16 @@ class TestAuroc:
 
     def test_all_correct_predictions(self):
         """
-        When all predictions are correct, sklearn warns about
-        undefined AUC (single class). We still get a float result.
+        When all predictions are correct, AUROC is not defined
+        (single class) and should raise ValueError.
         """
-        import warnings
+        with pytest.raises(ValueError, match="both 0 and 1"):
+            auroc(Y_CORRECT_ALL_CORRECT, Y_CONF_UNIFORM)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = auroc(Y_CORRECT_ALL_CORRECT, Y_CONF_UNIFORM)
-        assert isinstance(result, float)
+    def test_all_incorrect_predictions(self):
+        """All-incorrect also raises for single-class AUROC."""
+        with pytest.raises(ValueError, match="both 0 and 1"):
+            auroc(np.zeros(4, dtype=float), np.array([0.1, 0.2, 0.3, 0.4]))
 
     def test_raises_on_non_binary_labels(self):
         with pytest.raises(ValueError, match="binary"):

--- a/mapie/tests/test_metrics_uncertainty.py
+++ b/mapie/tests/test_metrics_uncertainty.py
@@ -149,3 +149,11 @@ class TestAuarc:
     def test_raises_on_length_mismatch(self):
         with pytest.raises(ValueError):
             auarc([0, 1], [0.1, 0.2, 0.3])
+
+    def test_raises_on_inf(self):
+        with pytest.raises(ValueError, match="Inf"):
+            auarc([0, 1, 1], [0.1, np.inf, 0.3])
+
+    def test_raises_on_non_binary_labels(self):
+        with pytest.raises(ValueError, match="binary"):
+            auarc([0, 1, 2], [0.1, 0.2, 0.3])

--- a/mapie/tests/test_metrics_uncertainty.py
+++ b/mapie/tests/test_metrics_uncertainty.py
@@ -1,0 +1,190 @@
+"""
+Tests for mapie/metrics/uncertainty.py
+
+All expected values are computed by hand or from first principles
+so that tests are independent of the implementation.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from mapie.metrics.uncertainty import aucroc_score, auarc_score
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+# Perfect case: uncertainty perfectly ranks wrong predictions above correct ones
+Y_WRONG_PERFECT = np.array([0, 0, 1, 1], dtype=float)
+Y_UNC_PERFECT = np.array([0.1, 0.2, 0.8, 0.9], dtype=float)
+
+# Random case: uncertainty uncorrelated with errors
+Y_WRONG_RANDOM = np.array([0, 1, 0, 1], dtype=float)
+Y_UNC_RANDOM = np.array([0.1, 0.2, 0.3, 0.4], dtype=float)
+
+# All correct predictions
+Y_WRONG_ALL_CORRECT = np.zeros(4, dtype=float)
+Y_UNC_UNIFORM = np.array([0.1, 0.2, 0.3, 0.4], dtype=float)
+
+
+# ---------------------------------------------------------------------------
+# aucroc_score — known-answer tests
+# ---------------------------------------------------------------------------
+
+
+class TestAucrocScore:
+    def test_perfect_discriminator(self):
+        """Uncertainty perfectly separates wrong from correct → AUCROC = 1."""
+        result = aucroc_score(Y_WRONG_PERFECT, Y_UNC_PERFECT)
+        assert_allclose(result, 1.0)
+
+    def test_returns_float(self):
+        result = aucroc_score(Y_WRONG_PERFECT, Y_UNC_PERFECT)
+        assert isinstance(result, float)
+
+    def test_score_in_unit_interval(self):
+        result = aucroc_score(Y_WRONG_RANDOM, Y_UNC_RANDOM)
+        assert 0.0 <= result <= 1.0
+
+    def test_accepts_list_input(self):
+        """Should accept plain Python lists, not just numpy arrays."""
+        result = aucroc_score([0, 0, 1, 1], [0.1, 0.2, 0.8, 0.9])
+        assert_allclose(result, 1.0)
+
+    def test_known_value_random_case(self):
+        """
+        y_wrong = [0, 1, 0, 1], y_unc = [0.1, 0.2, 0.3, 0.4]
+        sklearn roc_auc_score ground truth.
+        Wrong indices: 1, 3 (uncertainty 0.2, 0.4)
+        Correct indices: 0, 2 (uncertainty 0.1, 0.3)
+        By hand: TPR/FPR pairs give AUC = 0.75
+        """
+        result = aucroc_score(Y_WRONG_RANDOM, Y_UNC_RANDOM)
+        assert_allclose(result, 0.75)
+
+    # --- input validation ---
+
+    def test_raises_on_length_mismatch(self):
+        with pytest.raises(ValueError):
+            aucroc_score([0, 1], [0.1, 0.2, 0.3])
+
+    def test_raises_on_nan_in_y_wrong(self):
+        with pytest.raises(ValueError, match="NaN"):
+            aucroc_score([0, np.nan, 1, 1], Y_UNC_PERFECT)
+
+    def test_raises_on_nan_in_y_uncertainty(self):
+        with pytest.raises(ValueError, match="NaN"):
+            aucroc_score(Y_WRONG_PERFECT, [0.1, np.nan, 0.8, 0.9])
+
+    def test_raises_on_inf_in_y_wrong(self):
+        with pytest.raises(ValueError, match="Inf"):
+            aucroc_score([0, np.inf, 1, 1], Y_UNC_PERFECT)
+
+    def test_raises_on_inf_in_y_uncertainty(self):
+        with pytest.raises(ValueError, match="Inf"):
+            aucroc_score(Y_WRONG_PERFECT, [0.1, np.inf, 0.8, 0.9])
+
+    def test_raises_on_non_binary_y_wrong(self):
+        with pytest.raises(ValueError, match="binary"):
+            aucroc_score([0, 0.5, 1, 1], Y_UNC_PERFECT)
+
+    def test_raises_on_negative_uncertainty(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            aucroc_score(Y_WRONG_PERFECT, [-0.1, 0.2, 0.8, 0.9])
+
+
+# ---------------------------------------------------------------------------
+# auarc_score — known-answer tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuarcScore:
+    def test_perfect_rejection(self):
+        """
+        Wrong samples have highest uncertainty, so rejecting by uncertainty
+        removes all errors first → accuracy reaches 1.0 quickly → AUARC = 1.0.
+
+        y_wrong      = [1, 1, 0, 0]
+        y_uncertainty= [0.9, 0.8, 0.2, 0.1]
+        rejection order (desc unc): indices [0,1,2,3]
+        y_wrong_sorted = [1,1,0,0]
+
+        accuracy_curve (retaining n, n-1, ..., 1 samples):
+          retain 4: (0+0+0+0... wait — correct = 1-wrong = [0,0,1,1])
+          cumsum from tail of [0,0,1,1] = [2,2,2,1]  NO let me redo:
+          y_correct_sorted = [0,0,1,1]
+          cumsum from tail: cumsum([1,1,0,0]) reversed → [2,2,1,1] reversed
+          Actually cumsum([0,0,1,1] reversed=[1,1,0,0]) = [1,2,2,2], reversed=[2,2,2,1]
+          retained_counts = [4,3,2,1]
+          accuracy_curve = [2/4, 2/3, 2/2, 1/1] = [0.5, 0.667, 1.0, 1.0]
+          mean = (0.5 + 0.667 + 1.0 + 1.0) / 4 = 0.792
+        """
+        y_wrong = np.array([1, 1, 0, 0], dtype=float)
+        y_unc = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
+        result = auarc_score(y_wrong, y_unc)
+        expected = np.mean([0.5, 2 / 3, 1.0, 1.0])
+        assert_allclose(result, expected, rtol=1e-6)
+
+    def test_all_correct_predictions(self):
+        """
+        If no predictions are wrong, accuracy is always 1.0 regardless
+        of rejection order → AUARC = 1.0.
+        """
+        y_wrong = np.zeros(5, dtype=float)
+        y_unc = np.array([0.1, 0.5, 0.3, 0.9, 0.2], dtype=float)
+        result = auarc_score(y_wrong, y_unc)
+        assert_allclose(result, 1.0)
+
+    def test_returns_float(self):
+        result = auarc_score(Y_WRONG_PERFECT, Y_UNC_PERFECT)
+        assert isinstance(result, float)
+
+    def test_score_in_unit_interval(self):
+        result = auarc_score(Y_WRONG_RANDOM, Y_UNC_RANDOM)
+        assert 0.0 <= result <= 1.0
+
+    def test_accepts_list_input(self):
+        result = auarc_score([0, 0, 1, 1], [0.1, 0.2, 0.8, 0.9])
+        assert isinstance(result, float)
+
+    def test_worst_rejection(self):
+        """
+        Correct samples have highest uncertainty → we reject correct ones first
+        → accuracy degrades. AUARC should be lower than the perfect case.
+        """
+        y_wrong = np.array([0, 0, 1, 1], dtype=float)
+        y_unc_bad = np.array([0.9, 0.8, 0.2, 0.1], dtype=float)
+        y_unc_good = np.array([0.1, 0.2, 0.8, 0.9], dtype=float)
+        assert auarc_score(y_wrong, y_unc_bad) < auarc_score(y_wrong, y_unc_good)
+
+    # --- input validation ---
+
+    def test_raises_on_length_mismatch(self):
+        with pytest.raises(ValueError):
+            auarc_score([0, 1], [0.1, 0.2, 0.3])
+
+    def test_raises_on_nan_in_y_wrong(self):
+        with pytest.raises(ValueError, match="NaN"):
+            auarc_score([0, np.nan, 1, 1], Y_UNC_PERFECT)
+
+    def test_raises_on_nan_in_y_uncertainty(self):
+        with pytest.raises(ValueError, match="NaN"):
+            auarc_score(Y_WRONG_PERFECT, [0.1, np.nan, 0.8, 0.9])
+
+    def test_raises_on_inf_in_y_wrong(self):
+        with pytest.raises(ValueError, match="Inf"):
+            auarc_score([0, np.inf, 1, 1], Y_UNC_PERFECT)
+
+    def test_raises_on_inf_in_y_uncertainty(self):
+        with pytest.raises(ValueError, match="Inf"):
+            auarc_score(Y_WRONG_PERFECT, [0.1, np.inf, 0.8, 0.9])
+
+    def test_raises_on_non_binary_y_wrong(self):
+        with pytest.raises(ValueError, match="binary"):
+            auarc_score([0, 0.5, 1, 1], Y_UNC_PERFECT)
+
+    def test_raises_on_negative_uncertainty(self):
+        with pytest.raises(ValueError, match="non-negative"):
+            aucroc_score(Y_WRONG_PERFECT, [-0.1, 0.2, 0.8, 0.9])


### PR DESCRIPTION
Adds aucroc_score and auarc_score to a new mapie/metrics/uncertainty.py, implementing the uncertainty evaluation metrics from Lin et al. (2023). Both are numpy-in scalar-out and task-agnostic.

Closes #551