### PR TITLE
chore: fix Dependabot vulnerabilities

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@
 
 ## 1.x.x (2026-xx-xx)
 
+- Upgrade JupyterLab and PyTorch development dependencies to fix security vulnerabilities.
 - Add `ConditionalSplitConformalRegressor` and `ConditionalSplitConformalClassifier`, implementing conformal prediction with conditional guarantees (Gibbs et al., 2023), adapted from https://github.com/jjcherian/conditional-conformal.
 - Raise `NotImplementedError` from the conditional conformal estimators when the infinite-dimensional (RKHS) component is requested via `infinite_params`; the supporting code is retained for future work.
 - Add experimental multivariate standardized residuals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ docs = [
     "sphinx_rtd_theme==3.0.2",
     "pandas==2.3.3",
     "typing_extensions==4.15.0",
-    "torch==2.12.0",
+    "torch==2.13.0",
     "pytorch-lightning==2.6.5",
     "albumentations==2.0.8",
     "opencv-python==4.13.0.92",
@@ -102,7 +102,7 @@ docs = [
 notebooks = [
     "ipykernel==6.31.0",
     "jupyter==1.1.1",
-    "jupyterlab==4.5.7",
+    "jupyterlab==4.5.10",
     "jupytext==1.18.1",
     "nbconvert==7.17.1",
     "matplotlib==3.9.4",


### PR DESCRIPTION
## Summary

- upgrade JupyterLab from 4.5.7 to 4.5.10
- upgrade PyTorch from 2.12.0 to 2.13.0
- document the security dependency updates in `HISTORY.md`

## Why

The versions pinned in the notebook and documentation extras are affected by
seven open Dependabot alerts:

- JupyterLab alerts 12 and 14–18, including two high-severity XSS advisories
- PyTorch alert 13 for memory corruption in `torch.jit.script`

These are development-only dependencies, so the change does not alter MAPIE's
runtime dependency requirements for library users. The new pins are the minimum
versions identified by the advisories as containing the security patches.

## Validation

- `uv lock --check`
- `make lint`
- `make format`
- full pytest suite with doctests and branch coverage: 2,743 passed, 100% coverage

The standalone mypy check is currently blocked before checking MAPIE by the
existing environment's NumPy stubs using Python 3.12 syntax while the project
configures mypy for Python 3.10.
