### PR TITLE
fix: Read the Docs gallery memory usage

### DIFF
--- a/doc/hooks/gallery_memory.py
+++ b/doc/hooks/gallery_memory.py
@@ -1,0 +1,37 @@
+"""Keep gallery builds within the memory available on Read the Docs."""
+
+import gc
+import os
+from functools import wraps
+
+from mkdocs_gallery import gen_single
+
+
+# Several examples use ``n_jobs=-1``.  Limit the worker pool before joblib is
+# first used so that a documentation build cannot scale its memory use with the
+# number of CPUs exposed by the build host.
+os.environ.setdefault("LOKY_MAX_CPU_COUNT", "4")
+
+
+def _release_example_globals(result):
+    """Release objects retained by mkdocs-gallery after an example finishes."""
+    run_vars = result.script.run_vars
+    if run_vars is not None:
+        if run_vars.example_globals is not None:
+            run_vars.example_globals.clear()
+            run_vars.example_globals = None
+        run_vars.fake_main = None
+    gc.collect()
+    return result
+
+
+if not getattr(gen_single.generate_file_md, "_mapie_releases_globals", False):
+    _original_generate_file_md = gen_single.generate_file_md
+
+    @wraps(_original_generate_file_md)
+    def _generate_file_md_without_retained_globals(*args, **kwargs):
+        result = _original_generate_file_md(*args, **kwargs)
+        return _release_example_globals(result)
+
+    _generate_file_md_without_retained_globals._mapie_releases_globals = True
+    gen_single.generate_file_md = _generate_file_md_without_retained_globals

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,12 +87,13 @@ plugins:
         - doc/generated/exchangeability_testing
       within_subsection_order: FileNameSortKey
       plot_gallery: true
-      run_stale_examples: true
+      run_stale_examples: false
       download_all_examples: false
       abort_on_example_error: true
       only_warn_on_example_error: false
 
 hooks:
+  - doc/hooks/gallery_memory.py
   - doc/hooks/api_reference.py
   - doc/hooks/gallery_nav_fix.py
 


### PR DESCRIPTION
## Summary

- release each gallery example's global namespace once its generated page and backreferences are complete
- cap joblib worker pools at four processes during documentation builds
- restore mkdocs-gallery's normal stale-example caching

## Root cause

`mkdocs-gallery` keeps each executed script's globals reachable until the full gallery build finishes. MAPIE's examples retain large arrays, datasets, and fitted estimators, while examples using `n_jobs=-1` also scale their worker pools with every CPU exposed by the Read the Docs host. The resulting cumulative memory use intermittently exceeds the Read the Docs limit and terminates the build with exit code 137.

## Impact

Documentation output is unchanged. Builds now release completed examples promptly, use bounded parallelism, and skip unchanged examples when cache metadata is available.

## Validation

- `mkdocs build --strict` completed successfully, including the gallery location where Read the Docs was previously killed
- measured peak RSS: 4.86 GB (below the 7 GB Read the Docs limit)
- `pytest mapie/tests/test_doc_api_reference.py -q` — 4 passed
- Ruff check and format check passed for the new hook
- `git diff --check` passed
