### PR TITLE
docs: remove 27 duplicated HISTORY.md entries

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -36,13 +36,6 @@
 - Raise `NotImplementedError` from the conditional conformal estimators when the infinite-dimensional (RKHS) component is requested via `infinite_params`; the supporting code is retained for future work.
 - Add experimental multivariate standardized residuals
 - Add `aucroc_score` and `auarc_score` to `mapie/metrics/uncertainty.py` for uncertainty evaluation following Lin et al. (2023); resolves #551.
-- Add `StdConformityScore` for regression models that expose prediction standard deviations through `predict(..., return_std=True)`, enabling standard-deviation-normalized conformal prediction intervals such as J+GP.
-- Add a scientific article example reproducing the Jaber et al. (2025) Gaussian-process surrogate experiment and comparing GP credibility intervals, J+GP, and standard Jackknife+ intervals.
-- Consolidate quantile computation: extract `_compute_regression_quantile` and `_compute_classification_quantile` functions in `utils.py`, replacing the former `get_quantile` method and `_compute_quantiles` wrapper. No public API changes. (issue #479)
-- Add optional `covmetrics` integration for conditional coverage diagnostics.
-- Add CovGap and WCovGap documentation for conditional coverage diagnostics.
-- Add WSC (`worst_slab_coverage`) for slab-based conditional coverage diagnostics.
-- Add ERT (`excess_risk_target_coverage`) for model-based conditional coverage diagnostics.
 - Add a benchmark notebook for exchangeability tests using the current API.
 
 ## 1.4.1 (2026-06-08)
@@ -65,21 +58,9 @@
 * Simplify internal `sample_weight` handling in classification module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
 * Simplify internal `sample_weight` handling in quantile regression module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
 * Remove `_prepare_fit_params_and_sample_weight` utility (no longer needed after regression, classification, and quantile regression refactors). (issue #753)
-* Relax the monotonicity check in the `fixed_sequence` FWER procedure: a non-monotonic risk now emits a `UserWarning` (suggesting `split_fixed_sequence`) and infers a direction, instead of raising a `ValueError`. (issue #942)
-* Add validation that a custom `BinaryRisk` returns per-sample occurrence values that are binary indicators (booleans, or values equal to 0 or 1); a `ValueError` is now raised otherwise, as the binary Hoeffding-Bentkus guarantees require it.
-* Add validation to reject `Subsample` as `cv` in `CrossConformalRegressor`, directing users to `JackknifeAfterBootstrapRegressor` instead. (issue #924)
-* Add defensive validation: `_MapieRegressor` and `_MapieClassifier` now raise `TypeError` when `sample_weight` is passed as a top-level keyword argument instead of inside `fit_params`. Previously, top-level `sample_weight` was silently ignored. Also fix `TimeSeriesRegressor` tests that were affected by the same silent-ignore bug.
-* Add notebook kernel restart warning for Kaggle/Jupyter/Colab users after installation or version changes. (issue #916)
-* Simplify internal `sample_weight` handling in classification module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
-* Simplify internal `sample_weight` handling in quantile regression module: `sample_weight` now flows through `fit_params` instead of being passed as a separate argument through the call chain. No public API changes. (issue #753)
-* Remove `_prepare_fit_params_and_sample_weight` utility (no longer needed after regression, classification, and quantile regression refactors). (issue #753)
 
 ### Bug fixes
 
-* Fix `BinaryClassificationController` so the selected best threshold is optimal: when several parameters reach the minimum secondary risk, ties are now broken in favor of the least conservative threshold. (issue #942)
-* Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
-* Propagate `random_state` to the internal `Subsample` in `JackknifeAfterBootstrapRegressor` so bootstrap resampling is reproducible and no longer depends on the global NumPy RNG state. (issue #940)
-* Restore backward compatibility for the predict-argument renames introduced in #919: `CrossConformalRegressor`'s `aggregate_predictions` and `JackknifeAfterBootstrapRegressor`'s `ensemble` (in `predict` and `predict_interval`) keep working as deprecated aliases for `aggregate_point_predictions`, now emitting a `FutureWarning` instead of raising a `TypeError`. (issue #906)
 * Fix `BinaryClassificationController` so the selected best threshold is optimal: when several parameters reach the minimum secondary risk, ties are now broken in favor of the least conservative threshold. (issue #942)
 * Fix `optimize_beta` in regression conformity scores so prediction interval width minimization actually optimizes β (was previously a no-op due to a shape-collapsing reshape); also resolves incorrect prediction interval shape when used with multiple confidence levels. (issues #588, #484)
 * Propagate `random_state` to the internal `Subsample` in `JackknifeAfterBootstrapRegressor` so bootstrap resampling is reproducible and no longer depends on the global NumPy RNG state. (issue #940)
@@ -91,23 +72,15 @@
 * Add a repository backup of the BlogFeedback dataset (`examples/data/blogData_train.csv.gz`) used by the Kim et al. (2020) example, now loaded by default so the example no longer depends on the UCI download server.
 * Add repository backups of the Zaffran et al. (2022) data used by the ACI comparison example — the prices dataset (`examples/data/zaffran2022_prices.csv.gz`) and the reference results (`examples/data/zaffran2022_aci_reference.csv`) — now loaded by default so the example no longer depends on external downloads (also fixes an `UnboundLocalError` that surfaced when the reference download failed).
 * Fix the documentation site navigation dropdown and even out the vertical spacing between sidebar nav entries.
-* Add a risk control advanced-analysis example showing how to define and control a custom risk (specificity) with `BinaryRisk` and the `BinaryClassificationController`.
-* Add a repository backup of the BlogFeedback dataset (`examples/data/blogData_train.csv.gz`) used by the Kim et al. (2020) example, now loaded by default so the example no longer depends on the UCI download server.
-* Add repository backups of the Zaffran et al. (2022) data used by the ACI comparison example — the prices dataset (`examples/data/zaffran2022_prices.csv.gz`) and the reference results (`examples/data/zaffran2022_aci_reference.csv`) — now loaded by default so the example no longer depends on external downloads (also fixes an `UnboundLocalError` that surfaced when the reference download failed).
-* Fix the documentation site navigation dropdown and even out the vertical spacing between sidebar nav entries.
 
 ### CI, release, and developer experience
 
 * Fix the release process (release-candidate/final-release workflows, docs deployment, and release checklist).
 * Make tests compatible with scikit-learn 1.9 (calibration tests).
 * Silence intentional `UserWarning`s emitted during test runs to keep the test output clean.
-* Fix the release process (release-candidate/final-release workflows, docs deployment, and release checklist).
-* Make tests compatible with scikit-learn 1.9 (calibration tests).
-* Silence intentional `UserWarning`s emitted during test runs to keep the test output clean.
 
 ### Breaking changes
 
-* Drop support for Python 3.9 (EOL since October 2025). Minimum supported version is now Python 3.10. This was required to upgrade `pytest` to 9.0.3, which fixes a security advisory (CVE on `/tmp/pytest-of-{user}` directory handling).
 * Drop support for Python 3.9 (EOL since October 2025). Minimum supported version is now Python 3.10. This was required to upgrade `pytest` to 9.0.3, which fixes a security advisory (CVE on `/tmp/pytest-of-{user}` directory handling).
 
 ## 1.4.0 (2026-04-30)


### PR DESCRIPTION
# Description

Hello — small housekeeping one, no code touched.

`HISTORY.md` currently lists 27 entries twice. They came in with #958: the file has **0** duplicated bullets at that PR's merge-base (`1ace2d3e`) and **27** at its merge commit (`44405c80`), spread across the `1.x.x` section and five of the `1.4.1` subsections. I noticed it while reviewing that PR and it merged before the comment was picked up, so here it is as its own change.

This removes the 27 duplicates and nothing else. To check nothing was lost, I compared the multiset of bullet lines before and after: no entry disappears, and the only lines the deduplicated file has that `1ace2d3e` did not are the three added since by #975, #976 and `6478f16c`.

Not touched, in case either is intentional rather than a second artifact of the same merge:

- The two `## 1.x.x (2026-xx-xx)` sections. Those predate #958 (both present at `1ace2d3e`), so I left them alone — happy to merge them in this PR if you'd like them merged.
- `CrossConformalizedQuantileRegressor` has no entry at all. That belongs with the follow-up in #978 rather than here.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

- [x] Bullet-multiset comparison against `1ace2d3e` (pre-#958) — no entry lost, three expected additions.
- [x] Duplicate count after the change: 0.
- [x] `make lint`, `make format`, `make coverage` — unaffected, but green. `HISTORY.md` is not part of the MkDocs nav, so no doc build change.

# Checklist

## Guidelines
- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.md)
- [x] I have read and followed the [testing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/mapie/tests/README.md)

## Quality Checks
- [x] Linting passes successfully: `make lint`
- [x] Typing passes successfully: `make type-check`
- [x] Unit tests pass successfully: `make tests`
- [x] Coverage is 100%: `make coverage`
- [ ] When updating documentation: doc builds successfully and without warnings: `make doc` — n/a, `HISTORY.md` is not in the MkDocs nav
- [ ] When updating documentation: code examples in doc run successfully: `make doctest` — n/a, no code examples changed

## Contribution Documentation
- [x] I have updated the [HISTORY.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.md) and [AUTHORS.md](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.md) files — this PR *is* the HISTORY.md change; no AUTHORS.md line, since removing duplicated text is not a contribution worth a credit line.

## LLM Usage
- [x] I used a Large Language Model (LLM) for this contribution.
- [x] I carefully reviewed and verified all LLM-generated content.

- **LLM used**: Claude (Claude Code)
- **Purpose**: running the before/after multiset comparison and drafting this description. The duplication was found by hand while reviewing #958; the change itself is 27 deleted lines.
